### PR TITLE
fix: address PR #2 review feedback

### DIFF
--- a/src/adapters/telegram/adapter.ts
+++ b/src/adapters/telegram/adapter.ts
@@ -55,7 +55,7 @@ export class TelegramAdapter extends ChannelAdapter {
   private skillMessages: Map<string, number> = new Map(); // sessionId → pinned messageId
 
   constructor(core: OpenACPCore, config: TelegramChannelConfig) {
-    super(core, config as any);
+    super(core, config as never);
     this.telegramConfig = config;
   }
 
@@ -64,13 +64,19 @@ export class TelegramAdapter extends ChannelAdapter {
 
     // Global error handler — prevent unhandled errors from crashing the bot
     this.bot.catch((err) => {
-      log.error({ err: err }, "Telegram bot error");
+      const rootCause = err.error instanceof Error ? err.error : err;
+      log.error({ err: rootCause }, "Telegram bot error");
     });
 
-    // Ensure allowed_updates includes callback_query on every poll
+    // Ensure allowed_updates includes callback_query on every poll.
+    // bot.start() passes allowed_updates, but grammY only sends it on the first
+    // getUpdates call. Subsequent polls may omit the parameter, causing Telegram
+    // to fall back to its default (which excludes callback_query). This transformer
+    // guarantees callback_query is always requested.
     this.bot.api.config.use((prev, method, payload, signal) => {
       if (method === "getUpdates") {
-        (payload as any).allowed_updates = (payload as any).allowed_updates ?? [
+        const p = payload as never as Record<string, unknown>;
+        p.allowed_updates = (p.allowed_updates as string[] | undefined) ?? [
           "message",
           "callback_query",
         ];
@@ -266,7 +272,7 @@ export class TelegramAdapter extends ChannelAdapter {
 
       case "tool_call": {
         await this.finalizeDraft(sessionId);
-        const meta = content.metadata as any;
+        const meta = content.metadata as never as { id: string; name: string; kind?: string; status?: string; content?: unknown };
         const msg = await this.bot.api.sendMessage(
           this.telegramConfig.chatId,
           formatToolCall(meta),
@@ -288,7 +294,7 @@ export class TelegramAdapter extends ChannelAdapter {
       }
 
       case "tool_update": {
-        const meta = content.metadata as any;
+        const meta = content.metadata as never as { id: string; name: string; kind?: string; status: string; content?: unknown };
         const toolState = this.toolCallMessages.get(sessionId)?.get(meta.id);
         if (toolState) {
           // Merge name/kind from original tool_call
@@ -315,7 +321,7 @@ export class TelegramAdapter extends ChannelAdapter {
         await this.finalizeDraft(sessionId);
         await this.bot.api.sendMessage(
           this.telegramConfig.chatId,
-          formatPlan(content.metadata as any),
+          formatPlan(content.metadata as never as { entries: Array<{ content: string; status: string }> }),
           {
             message_thread_id: threadId,
             parse_mode: "HTML",
@@ -329,7 +335,7 @@ export class TelegramAdapter extends ChannelAdapter {
         // Show usage stats
         await this.bot.api.sendMessage(
           this.telegramConfig.chatId,
-          formatUsage(content.metadata as any),
+          formatUsage(content.metadata as never as { tokensUsed?: number; contextSize?: number; cost?: { amount: number; currency: string } }),
           {
             message_thread_id: threadId,
             parse_mode: "HTML",

--- a/src/adapters/telegram/formatting.ts
+++ b/src/adapters/telegram/formatting.ts
@@ -67,24 +67,24 @@ const KIND_ICON: Record<string, string> = {
   search: '🔍', fetch: '🌐', think: '🧠', move: '📦', other: '🛠️',
 }
 
-function extractContentText(content: unknown): string {
-  if (!content) return ''
+function extractContentText(content: unknown, depth = 0): string {
+  if (!content || depth > 5) return ''
   if (typeof content === 'string') return content
   if (Array.isArray(content)) {
     return content
-      .map((c: any) => extractContentText(c))
+      .map((c: unknown) => extractContentText(c, depth + 1))
       .filter(Boolean)
       .join('\n')
   }
   if (typeof content === 'object' && content !== null) {
-    const c = content as any
+    const c = content as Record<string, unknown>
     // ACP content blocks: {type: ..., text: ...} or {type: ..., content: ...}
     if (c.type === 'text' && typeof c.text === 'string') return c.text
     if (typeof c.text === 'string') return c.text
     if (typeof c.content === 'string') return c.content
     // Tool input/output objects
-    if (c.input) return extractContentText(c.input)
-    if (c.output) return extractContentText(c.output)
+    if (c.input) return extractContentText(c.input, depth + 1)
+    if (c.output) return extractContentText(c.output, depth + 1)
     // Fallback: pretty-print JSON (but skip type-only objects)
     const keys = Object.keys(c).filter(k => k !== 'type')
     if (keys.length === 0) return ''


### PR DESCRIPTION
## Summary

Addresses all review feedback from @0xmrpeter on PR #2:

- **`as any` → `as never`**: Replace all `as any` casts with `as never` + proper type annotations in `adapter.ts` and `formatting.ts`, following project convention
- **`allowed_updates` comment**: Add explanation for why the API transformer is needed alongside `bot.start()` (grammY may omit the param on subsequent polls)
- **`bot.catch` root cause**: Extract original error from grammY `BotError` via `err.error` instead of logging the wrapper
- **`extractContentText` depth limit**: Add `maxDepth=5` parameter to prevent stack overflow on deeply nested ACP content
- **`tool_update` status type**: Use required `status: string` for tool_update metadata to match `formatToolUpdate` signature

## Test plan

- [ ] `pnpm build` passes cleanly
- [ ] Verify no `as any` remains in changed files
- [ ] Test permission button flow (callback_query still works)
- [ ] Test tool call/update display in Telegram