### PR TITLE
feat: add tunnel service with file/code viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,21 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.16.0",
+    "@hono/node-server": "^1.19.11",
     "@inquirer/prompts": "^8.3.2",
     "@zed-industries/claude-agent-acp": "^0.22.2",
+    "diff": "^8.0.3",
     "grammy": "^1.30.0",
+    "hono": "^4.12.8",
     "nanoid": "^5.0.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "pino-roll": "^4.0.0",
+    "shiki": "^4.0.2",
     "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@types/diff": "^8.0.0",
     "@types/node": "^25.5.0",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,24 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^0.16.0
         version: 0.16.1(zod@3.25.76)
+      '@hono/node-server':
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.8)
       '@inquirer/prompts':
         specifier: ^8.3.2
         version: 8.3.2(@types/node@25.5.0)
       '@zed-industries/claude-agent-acp':
         specifier: ^0.22.2
         version: 0.22.2
+      diff:
+        specifier: ^8.0.3
+        version: 8.0.3
       grammy:
         specifier: ^1.30.0
         version: 1.41.1
+      hono:
+        specifier: ^4.12.8
+        version: 4.12.8
       nanoid:
         specifier: ^5.0.0
         version: 5.1.7
@@ -32,10 +41,16 @@ importers:
       pino-roll:
         specifier: ^4.0.0
         version: 4.0.0
+      shiki:
+        specifier: ^4.0.2
+        version: 4.0.2
       zod:
         specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
+      '@types/diff':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -273,6 +288,12 @@ packages:
 
   '@grammyjs/types@3.25.0':
     resolution: {integrity: sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg==}
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
@@ -736,6 +757,37 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/core@4.0.2':
+    resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.0.2':
+    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.0.2':
+    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.0.2':
+    resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.0.2':
+    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -748,11 +800,27 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/diff@8.0.0':
+    resolution: {integrity: sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==}
+    deprecated: This is a stub types definition. diff provides its own type definitions, so you do not need this installed.
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
@@ -817,9 +885,18 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -834,6 +911,9 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -864,9 +944,20 @@ packages:
       supports-color:
         optional: true
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -929,8 +1020,21 @@ packages:
     resolution: {integrity: sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1024,6 +1128,24 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -1072,6 +1194,12 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
+  oniguruma-to-es@4.3.5:
+    resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1132,6 +1260,9 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -1145,6 +1276,15 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1173,6 +1313,10 @@ packages:
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
+  shiki@4.0.2:
+    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+    engines: {node: '>=20'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1191,6 +1335,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -1200,6 +1347,9 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -1246,6 +1396,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -1286,6 +1439,27 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.1:
     resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
@@ -1381,6 +1555,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1497,6 +1674,10 @@ snapshots:
     optional: true
 
   '@grammyjs/types@3.25.0': {}
+
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -1828,6 +2009,46 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@shikijs/core@4.0.2':
+    dependencies:
+      '@shikijs/primitive': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.5
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/primitive@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/types@4.0.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1842,11 +2063,27 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/diff@8.0.0':
+    dependencies:
+      diff: 8.0.3
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -1914,7 +2151,13 @@ snapshots:
 
   cac@6.7.14: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   chardet@2.1.1: {}
 
@@ -1925,6 +2168,8 @@ snapshots:
   cli-width@4.1.0: {}
 
   colorette@2.0.20: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
 
@@ -1942,7 +2187,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  diff@8.0.3: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -2028,7 +2281,29 @@ snapshots:
       - encoding
       - supports-color
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   help-me@5.0.0: {}
+
+  hono@4.12.8: {}
+
+  html-void-elements@3.0.0: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -2095,6 +2370,35 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
   minimist@1.2.8: {}
 
   mlly@1.8.1:
@@ -2131,6 +2435,14 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  oniguruma-parser@0.12.1: {}
+
+  oniguruma-to-es@4.3.5:
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   pathe@2.0.3: {}
 
@@ -2202,6 +2514,8 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  property-information@7.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -2212,6 +2526,16 @@ snapshots:
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   resolve-from@5.0.0: {}
 
@@ -2275,6 +2599,17 @@ snapshots:
 
   secure-json-parse@4.1.0: {}
 
+  shiki@4.0.2:
+    dependencies:
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/engine-oniguruma': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -2287,11 +2622,18 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-json-comments@5.0.3: {}
 
@@ -2333,6 +2675,8 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
+
+  trim-lines@3.0.1: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -2379,6 +2723,39 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@7.18.2: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:
@@ -2435,3 +2812,5 @@ snapshots:
   wrappy@1.0.2: {}
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}

--- a/src/adapters/telegram/adapter.ts
+++ b/src/adapters/telegram/adapter.ts
@@ -46,7 +46,7 @@ export class TelegramAdapter extends ChannelAdapter {
   private sessionDrafts: Map<string, MessageDraft> = new Map();
   private toolCallMessages: Map<
     string,
-    Map<string, { msgId: number; name: string; kind?: string }>
+    Map<string, { msgId: number; name: string; kind?: string; viewerLinks?: { file?: string; diff?: string } }>
   > = new Map(); // sessionId → (toolCallId → state)
   private permissionHandler!: PermissionHandler;
   private assistantSession: Session | null = null;
@@ -272,7 +272,7 @@ export class TelegramAdapter extends ChannelAdapter {
 
       case "tool_call": {
         await this.finalizeDraft(sessionId);
-        const meta = content.metadata as never as { id: string; name: string; kind?: string; status?: string; content?: unknown };
+        const meta = content.metadata as never as { id: string; name: string; kind?: string; status?: string; content?: unknown; viewerLinks?: { file?: string; diff?: string } };
         const msg = await this.bot.api.sendMessage(
           this.telegramConfig.chatId,
           formatToolCall(meta),
@@ -289,19 +289,24 @@ export class TelegramAdapter extends ChannelAdapter {
           msgId: msg.message_id,
           name: meta.name,
           kind: meta.kind,
+          viewerLinks: meta.viewerLinks,
         });
         break;
       }
 
       case "tool_update": {
-        const meta = content.metadata as never as { id: string; name: string; kind?: string; status: string; content?: unknown };
+        const meta = content.metadata as never as { id: string; name: string; kind?: string; status: string; content?: unknown; viewerLinks?: { file?: string; diff?: string } };
         const toolState = this.toolCallMessages.get(sessionId)?.get(meta.id);
         if (toolState) {
+          // Carry forward viewerLinks from previous updates if not present in current
+          const viewerLinks = meta.viewerLinks || toolState.viewerLinks;
+          if (meta.viewerLinks) toolState.viewerLinks = meta.viewerLinks;
           // Merge name/kind from original tool_call
           const merged = {
             ...meta,
             name: meta.name || toolState.name,
             kind: meta.kind || toolState.kind,
+            viewerLinks,
           };
           try {
             await this.bot.api.editMessageText(

--- a/src/adapters/telegram/formatting.ts
+++ b/src/adapters/telegram/formatting.ts
@@ -98,7 +98,7 @@ function truncateContent(text: string, maxLen = 3800): string {
   return text.slice(0, maxLen) + '\n… (truncated)'
 }
 
-export function formatToolCall(tool: { id: string; name?: string; kind?: string; status?: string; content?: unknown }): string {
+export function formatToolCall(tool: { id: string; name?: string; kind?: string; status?: string; content?: unknown; viewerLinks?: { file?: string; diff?: string } }): string {
   const si = STATUS_ICON[tool.status || ''] || '🔧'
   const ki = KIND_ICON[tool.kind || ''] || '🛠️'
   let text = `${si} ${ki} <b>${escapeHtml(tool.name || 'Tool')}</b>`
@@ -106,10 +106,11 @@ export function formatToolCall(tool: { id: string; name?: string; kind?: string;
   if (details) {
     text += `\n<pre>${escapeHtml(truncateContent(details))}</pre>`
   }
+  text += formatViewerLinks(tool.viewerLinks)
   return text
 }
 
-export function formatToolUpdate(update: { id: string; name?: string; kind?: string; status: string; content?: unknown }): string {
+export function formatToolUpdate(update: { id: string; name?: string; kind?: string; status: string; content?: unknown; viewerLinks?: { file?: string; diff?: string } }): string {
   const si = STATUS_ICON[update.status] || '🔧'
   const ki = KIND_ICON[update.kind || ''] || '🛠️'
   const name = update.name || 'Tool'
@@ -118,6 +119,15 @@ export function formatToolUpdate(update: { id: string; name?: string; kind?: str
   if (details) {
     text += `\n<pre>${escapeHtml(truncateContent(details))}</pre>`
   }
+  text += formatViewerLinks(update.viewerLinks)
+  return text
+}
+
+function formatViewerLinks(links?: { file?: string; diff?: string }): string {
+  if (!links) return ''
+  let text = ''
+  if (links.file) text += `\n📄 <a href="${escapeHtml(links.file)}">View file</a>`
+  if (links.diff) text += `\n📝 <a href="${escapeHtml(links.diff)}">View diff</a>`
   return text
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -29,6 +29,22 @@ const LoggingSchema = z.object({
 
 export type LoggingConfig = z.infer<typeof LoggingSchema>
 
+const TunnelAuthSchema = z.object({
+  enabled: z.boolean().default(false),
+  token: z.string().optional(),
+}).default({})
+
+const TunnelSchema = z.object({
+  enabled: z.boolean().default(false),
+  port: z.number().default(3100),
+  provider: z.enum(['cloudflare', 'ngrok', 'bore']).default('cloudflare'),
+  options: z.record(z.string(), z.unknown()).default({}),
+  storeTtlMinutes: z.number().default(60),
+  auth: TunnelAuthSchema,
+}).default({})
+
+export type TunnelConfig = z.infer<typeof TunnelSchema>
+
 export const ConfigSchema = z.object({
   channels: z.record(z.string(), BaseChannelSchema),
   agents: z.record(z.string(), AgentSchema),
@@ -42,6 +58,7 @@ export const ConfigSchema = z.object({
     sessionTimeoutMinutes: z.number().default(60),
   }).default({}),
   logging: LoggingSchema,
+  tunnel: TunnelSchema,
 })
 
 export type Config = z.infer<typeof ConfigSchema>
@@ -191,6 +208,20 @@ export class ConfigManager {
     if (process.env.OPENACP_DEBUG && !process.env.OPENACP_LOG_LEVEL) {
       raw.logging = raw.logging || {}
       ;(raw.logging as Record<string, unknown>).level = 'debug'
+    }
+
+    // Tunnel env var overrides
+    if (process.env.OPENACP_TUNNEL_ENABLED) {
+      raw.tunnel = raw.tunnel || {}
+      ;(raw.tunnel as Record<string, unknown>).enabled = process.env.OPENACP_TUNNEL_ENABLED === 'true'
+    }
+    if (process.env.OPENACP_TUNNEL_PORT) {
+      raw.tunnel = raw.tunnel || {}
+      ;(raw.tunnel as Record<string, unknown>).port = Number(process.env.OPENACP_TUNNEL_PORT)
+    }
+    if (process.env.OPENACP_TUNNEL_PROVIDER) {
+      raw.tunnel = raw.tunnel || {}
+      ;(raw.tunnel as Record<string, unknown>).provider = process.env.OPENACP_TUNNEL_PROVIDER
     }
   }
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -5,6 +5,8 @@ import { NotificationManager } from './notification.js'
 import { ChannelAdapter } from './channel.js'
 import { Session } from './session.js'
 import type { IncomingMessage, AgentEvent, OutgoingMessage, PermissionRequest } from './types.js'
+import type { TunnelService } from '../tunnel/tunnel-service.js'
+import { extractFileInfo } from '../tunnel/extract-file-info.js'
 import { createChildLogger } from './log.js'
 const log = createChildLogger({ module: 'core' })
 
@@ -14,6 +16,7 @@ export class OpenACPCore {
   sessionManager: SessionManager
   notificationManager: NotificationManager
   adapters: Map<string, ChannelAdapter> = new Map()
+  tunnelService?: TunnelService
 
   constructor(configManager: ConfigManager) {
     this.configManager = configManager
@@ -130,22 +133,63 @@ export class OpenACPCore {
 
   // --- Event Wiring ---
 
-  private toOutgoingMessage(event: AgentEvent): OutgoingMessage {
+  private toOutgoingMessage(event: AgentEvent, session?: Session): OutgoingMessage {
     switch (event.type) {
       case 'text':
         return { type: 'text', text: event.content }
       case 'thought':
         return { type: 'thought', text: event.content }
-      case 'tool_call':
-        return { type: 'tool_call', text: event.name, metadata: { id: event.id, kind: event.kind, status: event.status, content: event.content, locations: event.locations } }
-      case 'tool_update':
-        return { type: 'tool_update', text: '', metadata: { id: event.id, status: event.status, content: event.content } }
+      case 'tool_call': {
+        const metadata: Record<string, unknown> = { id: event.id, kind: event.kind, status: event.status, content: event.content, locations: event.locations }
+        this.enrichWithViewerLinks(event, metadata, session)
+        return { type: 'tool_call', text: event.name, metadata }
+      }
+      case 'tool_update': {
+        const metadata: Record<string, unknown> = { id: event.id, status: event.status, content: event.content }
+        this.enrichWithViewerLinks(event, metadata, session)
+        return { type: 'tool_update', text: '', metadata }
+      }
       case 'plan':
         return { type: 'plan', text: '', metadata: { entries: event.entries } }
       case 'usage':
         return { type: 'usage', text: '', metadata: { tokensUsed: event.tokensUsed, contextSize: event.contextSize, cost: event.cost } }
       default:
         return { type: 'text', text: '' }
+    }
+  }
+
+  private enrichWithViewerLinks(
+    event: AgentEvent & { type: 'tool_call' | 'tool_update' },
+    metadata: Record<string, unknown>,
+    session?: Session,
+  ): void {
+    if (!this.tunnelService || !session) return
+
+    const name = 'name' in event ? (event.name || '') : ''
+    const kind = 'kind' in event ? event.kind : undefined
+
+    log.debug({ name, kind, status: event.status, hasContent: !!event.content }, 'enrichWithViewerLinks: inspecting event')
+
+    const fileInfo = extractFileInfo(name, kind, event.content)
+    if (!fileInfo) return
+
+    log.info({ name, kind, filePath: fileInfo.filePath, hasOldContent: !!fileInfo.oldContent }, 'enrichWithViewerLinks: extracted file info')
+
+    const store = this.tunnelService.getStore()
+    const viewerLinks: Record<string, string> = {}
+
+    // For edits/writes with diff data (oldText + newText)
+    if (fileInfo.oldContent) {
+      const id = store.storeDiff(session.id, fileInfo.filePath, fileInfo.oldContent, fileInfo.content, session.workingDirectory)
+      if (id) viewerLinks.diff = this.tunnelService.diffUrl(id)
+    }
+
+    // Always store as file view (new file creation or read)
+    const id = store.storeFile(session.id, fileInfo.filePath, fileInfo.content, session.workingDirectory)
+    if (id) viewerLinks.file = this.tunnelService.fileUrl(id)
+
+    if (Object.keys(viewerLinks).length > 0) {
+      metadata.viewerLinks = viewerLinks
     }
   }
 
@@ -162,7 +206,7 @@ export class OpenACPCore {
         case 'tool_update':
         case 'plan':
         case 'usage':
-          adapter.sendMessage(session.id, this.toOutgoingMessage(event))
+          adapter.sendMessage(session.id, this.toOutgoingMessage(event, session))
           break
 
         case 'session_end':

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -399,6 +399,7 @@ export async function runSetup(configManager: ConfigManager): Promise<boolean> {
         maxFiles: 7,
         sessionLogRetentionDays: 30,
       },
+      tunnel: { enabled: false, port: 3100, provider: 'cloudflare', options: {}, storeTtlMinutes: 60, auth: { enabled: false } },
     };
 
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,16 @@ export async function startServer() {
   // 3. Create core
   const core = new OpenACPCore(configManager)
 
+  // 3.5 Start tunnel if configured
+  let tunnelService: import('./tunnel/tunnel-service.js').TunnelService | undefined
+  if (config.tunnel.enabled) {
+    const { TunnelService } = await import('./tunnel/tunnel-service.js')
+    tunnelService = new TunnelService(config.tunnel)
+    const publicUrl = await tunnelService.start()
+    core.tunnelService = tunnelService
+    log.info({ publicUrl }, 'Tunnel started')
+  }
+
   // 4. Register adapters from config
   for (const [channelName, channelConfig] of Object.entries(config.channels)) {
     if (!channelConfig.enabled) continue
@@ -78,6 +88,7 @@ export async function startServer() {
 
     try {
       await core.stop()
+      if (tunnelService) await tunnelService.stop()
     } catch (err) {
       log.error({ err }, 'Error during shutdown')
     }

--- a/src/tunnel/extract-file-info.ts
+++ b/src/tunnel/extract-file-info.ts
@@ -1,0 +1,107 @@
+export interface FileInfo {
+  filePath: string
+  content: string
+  oldContent?: string
+}
+
+/**
+ * Extract file path and content from ACP tool_call/tool_update content.
+ *
+ * ACP content formats observed:
+ * - Diff block: [{ type: "diff", path: "...", oldText: "...", newText: "..." }]
+ * - Content wrapper: [{ type: "content", content: { type: "text", text: "..." } }]
+ * - Text block: { type: "text", text: "..." }
+ * - rawInput: { file_path: "...", content: "..." }
+ */
+export function extractFileInfo(name: string, kind: string | undefined, content: unknown): FileInfo | null {
+  if (!content) return null
+
+  // Only process file-related tool kinds
+  if (kind && !['read', 'edit', 'write'].includes(kind)) return null
+
+  // Try to extract from known ACP content patterns
+  const info = parseContent(content)
+  if (!info) return null
+
+  // Infer file path from tool name if not in content
+  if (!info.filePath) {
+    // Some agents put the path in the tool name (e.g., "Read src/main.ts" or "Write index.html")
+    const pathMatch = name.match(/(?:Read|Edit|Write|View)\s+(.+)/i)
+    if (pathMatch) info.filePath = pathMatch[1].trim()
+  }
+
+  if (!info.filePath || !info.content) return null
+  return info as FileInfo
+}
+
+function parseContent(content: unknown): Partial<FileInfo> | null {
+  if (typeof content === 'string') {
+    return { content }
+  }
+
+  if (Array.isArray(content)) {
+    // Array of content blocks — try each
+    for (const block of content) {
+      const result = parseContent(block)
+      if (result?.content || result?.filePath) return result
+    }
+    return null
+  }
+
+  if (typeof content === 'object' && content !== null) {
+    const c = content as Record<string, unknown>
+
+    // ACP diff block: { type: 'diff', path: '...', oldText: '...', newText: '...' }
+    if (c.type === 'diff' && typeof c.path === 'string') {
+      const newText = c.newText as string | null | undefined
+      const oldText = c.oldText as string | null | undefined
+      if (newText) {
+        return {
+          filePath: c.path as string,
+          content: newText,
+          oldContent: oldText ?? undefined,
+        }
+      }
+    }
+
+    // ACP content wrapper: { type: 'content', content: { type: 'text', text: '...' } }
+    if (c.type === 'content' && c.content) {
+      return parseContent(c.content)
+    }
+
+    // ACP text block: { type: 'text', text: '...' }
+    if (c.type === 'text' && typeof c.text === 'string') {
+      return { content: c.text, filePath: c.filePath as string | undefined }
+    }
+
+    // Direct fields
+    if (typeof c.text === 'string') {
+      return { content: c.text, filePath: c.filePath as string | undefined }
+    }
+
+    // Tool input with file path: { file_path: '...', content: '...' }
+    if (typeof c.file_path === 'string' || typeof c.filePath === 'string' || typeof c.path === 'string') {
+      const filePath = (c.file_path || c.filePath || c.path) as string
+      const fileContent = (c.content || c.text || c.output || c.newText) as string | undefined
+      if (typeof fileContent === 'string') {
+        return {
+          filePath,
+          content: fileContent,
+          oldContent: (c.old_content || c.oldText) as string | undefined,
+        }
+      }
+    }
+
+    // Nested input/output
+    if (c.input) {
+      const result = parseContent(c.input)
+      if (result) return result
+    }
+    if (c.output) {
+      const result = parseContent(c.output)
+      if (result) return result
+    }
+  }
+
+  return null
+}

--- a/src/tunnel/index.ts
+++ b/src/tunnel/index.ts
@@ -1,0 +1,3 @@
+export { TunnelService } from './tunnel-service.js'
+export type { TunnelProvider } from './provider.js'
+export { ViewerStore } from './viewer-store.js'

--- a/src/tunnel/provider.ts
+++ b/src/tunnel/provider.ts
@@ -1,0 +1,5 @@
+export interface TunnelProvider {
+  start(localPort: number): Promise<string>  // returns public URL
+  stop(): Promise<void>
+  getPublicUrl(): string
+}

--- a/src/tunnel/providers/cloudflare.ts
+++ b/src/tunnel/providers/cloudflare.ts
@@ -1,0 +1,82 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { createChildLogger } from '../../core/log.js'
+import type { TunnelProvider } from '../provider.js'
+
+const log = createChildLogger({ module: 'cloudflare-tunnel' })
+
+export class CloudflareTunnelProvider implements TunnelProvider {
+  private child: ChildProcess | null = null
+  private publicUrl = ''
+  private options: Record<string, unknown>
+
+  constructor(options: Record<string, unknown> = {}) {
+    this.options = options
+  }
+
+  async start(localPort: number): Promise<string> {
+    const args = ['tunnel', '--url', `http://localhost:${localPort}`]
+    if (this.options.domain) {
+      args.push('--hostname', String(this.options.domain))
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.stop()
+        reject(new Error('Cloudflare tunnel timed out after 30s. Is cloudflared installed?'))
+      }, 30_000)
+
+      try {
+        this.child = spawn('cloudflared', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+      } catch {
+        clearTimeout(timeout)
+        reject(new Error(
+          'Failed to start cloudflared. Install it from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/'
+        ))
+        return
+      }
+
+      const urlPattern = /https:\/\/[a-zA-Z0-9-]+\.trycloudflare\.com/
+
+      const onData = (data: Buffer) => {
+        const line = data.toString()
+        log.debug(line.trim())
+        const match = line.match(urlPattern)
+        if (match) {
+          clearTimeout(timeout)
+          this.publicUrl = match[0]
+          log.info({ url: this.publicUrl }, 'Cloudflare tunnel ready')
+          resolve(this.publicUrl)
+        }
+      }
+
+      this.child.stdout?.on('data', onData)
+      this.child.stderr?.on('data', onData)
+
+      this.child.on('error', (err) => {
+        clearTimeout(timeout)
+        reject(new Error(
+          `cloudflared failed to start: ${err.message}. Install it from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/`
+        ))
+      })
+
+      this.child.on('exit', (code) => {
+        if (!this.publicUrl) {
+          clearTimeout(timeout)
+          reject(new Error(`cloudflared exited with code ${code} before establishing tunnel`))
+        }
+      })
+    })
+  }
+
+  async stop(): Promise<void> {
+    if (this.child) {
+      this.child.kill('SIGTERM')
+      this.child = null
+      log.info('Cloudflare tunnel stopped')
+    }
+  }
+
+  getPublicUrl(): string {
+    return this.publicUrl
+  }
+}

--- a/src/tunnel/server.ts
+++ b/src/tunnel/server.ts
@@ -1,0 +1,65 @@
+import { Hono } from 'hono'
+import type { ViewerStore } from './viewer-store.js'
+import { renderFileViewer } from './templates/file-viewer.js'
+import { renderDiffViewer } from './templates/diff-viewer.js'
+
+function notFoundPage(): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Not Found - OpenACP</title>
+<style>body{background:#0d1117;color:#c9d1d9;font-family:sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+.box{text-align:center;padding:40px}.code{font-size:72px;font-weight:bold;color:#484f58}p{margin-top:16px;color:#8b949e}</style>
+</head><body><div class="box"><div class="code">404</div><p>This viewer link has expired or does not exist.</p></div></body></html>`
+}
+
+export function createTunnelServer(store: ViewerStore, authToken?: string): Hono {
+  const app = new Hono()
+
+  // Auth middleware
+  if (authToken) {
+    app.use('*', async (c, next) => {
+      if (c.req.path === '/health') return next()
+      const bearer = c.req.header('Authorization')?.replace('Bearer ', '')
+      const query = c.req.query('token')
+      if (bearer !== authToken && query !== authToken) {
+        return c.text('Unauthorized', 401)
+      }
+      return next()
+    })
+  }
+
+  app.get('/health', (c) => c.json({ status: 'ok' }))
+
+  app.get('/view/:id', (c) => {
+    const entry = store.get(c.req.param('id'))
+    if (!entry || entry.type !== 'file') {
+      return c.html(notFoundPage(), 404)
+    }
+    return c.html(renderFileViewer(entry))
+  })
+
+  app.get('/diff/:id', (c) => {
+    const entry = store.get(c.req.param('id'))
+    if (!entry || entry.type !== 'diff') {
+      return c.html(notFoundPage(), 404)
+    }
+    return c.html(renderDiffViewer(entry))
+  })
+
+  app.get('/api/file/:id', (c) => {
+    const entry = store.get(c.req.param('id'))
+    if (!entry || entry.type !== 'file') {
+      return c.json({ error: 'not found' }, 404)
+    }
+    return c.json({ filePath: entry.filePath, content: entry.content, language: entry.language })
+  })
+
+  app.get('/api/diff/:id', (c) => {
+    const entry = store.get(c.req.param('id'))
+    if (!entry || entry.type !== 'diff') {
+      return c.json({ error: 'not found' }, 404)
+    }
+    return c.json({ filePath: entry.filePath, oldContent: entry.oldContent, newContent: entry.content, language: entry.language })
+  })
+
+  return app
+}

--- a/src/tunnel/templates/diff-viewer.ts
+++ b/src/tunnel/templates/diff-viewer.ts
@@ -1,0 +1,132 @@
+import { createPatch } from 'diff'
+import type { ViewerEntry } from '../viewer-store.js'
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+const MONACO_LANGUAGE: Record<string, string> = {
+  typescript: 'typescript', javascript: 'javascript', python: 'python',
+  rust: 'rust', go: 'go', java: 'java', kotlin: 'kotlin', ruby: 'ruby',
+  php: 'php', c: 'c', cpp: 'cpp', csharp: 'csharp', swift: 'swift',
+  bash: 'shell', json: 'json', yaml: 'yaml', toml: 'ini', xml: 'xml',
+  html: 'html', css: 'css', scss: 'scss', sql: 'sql', markdown: 'markdown',
+  dockerfile: 'dockerfile', hcl: 'hcl', plaintext: 'plaintext',
+}
+
+function getMonacoLang(lang?: string): string {
+  if (!lang) return 'plaintext'
+  return MONACO_LANGUAGE[lang] || 'plaintext'
+}
+
+export function renderDiffViewer(entry: ViewerEntry): string {
+  const fileName = entry.filePath || 'untitled'
+  const lang = getMonacoLang(entry.language)
+  const oldContent = entry.oldContent || ''
+  const newContent = entry.content
+
+  // Count changes for stats
+  const patch = createPatch(fileName, oldContent, newContent, 'before', 'after')
+  const adds = (patch.match(/^\+[^+]/gm) || []).length
+  const dels = (patch.match(/^-[^-]/gm) || []).length
+
+  // Escape </script> in content
+  const safeOld = JSON.stringify(oldContent).replace(/<\//g, '<\\/')
+  const safeNew = JSON.stringify(newContent).replace(/<\//g, '<\\/')
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(fileName)} (diff) - OpenACP</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: #1e1e1e; color: #d4d4d4; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; display: flex; flex-direction: column; height: 100vh; }
+    .header { background: #252526; border-bottom: 1px solid #3c3c3c; padding: 8px 16px; display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; z-index: 10; }
+    .file-info { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+    .file-icon { font-size: 14px; }
+    .file-name { color: #e0e0e0; font-weight: 500; }
+    .stats { font-size: 12px; margin-left: 12px; }
+    .stats .add { color: #4ec9b0; }
+    .stats .del { color: #f14c4c; }
+    .actions { display: flex; gap: 6px; }
+    .btn { background: #3c3c3c; color: #d4d4d4; border: 1px solid #505050; padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; transition: background 0.15s; }
+    .btn:hover { background: #505050; }
+    .btn.active { background: #0e639c; border-color: #1177bb; }
+    #editor-container { flex: 1; overflow: hidden; }
+    .status-bar { background: #007acc; color: #fff; padding: 2px 16px; font-size: 12px; display: flex; justify-content: space-between; flex-shrink: 0; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="file-info">
+      <span class="file-icon">📝</span>
+      <span class="file-name">${escapeHtml(fileName)}</span>
+      <span class="stats"><span class="add">+${adds}</span> / <span class="del">-${dels}</span></span>
+    </div>
+    <div class="actions">
+      <button class="btn active" id="btn-side" onclick="setView('side')">Side by Side</button>
+      <button class="btn" id="btn-inline" onclick="setView('inline')">Inline</button>
+      <button class="btn" onclick="toggleTheme()" id="btn-theme">Light</button>
+    </div>
+  </div>
+  <div id="editor-container"></div>
+  <div class="status-bar">
+    <span>${escapeHtml(entry.language || 'plaintext')} | <span class="add">+${adds}</span> <span class="del">-${dels}</span></span>
+    <span>OpenACP Diff Viewer</span>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js"></script>
+  <script>
+    const oldContent = ${safeOld};
+    const newContent = ${safeNew};
+    const lang = ${JSON.stringify(lang)};
+    let diffEditor;
+    let isDark = true;
+    let renderSideBySide = true;
+
+    require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs' } });
+    require(['vs/editor/editor.main'], function () {
+      const originalModel = monaco.editor.createModel(oldContent, lang);
+      const modifiedModel = monaco.editor.createModel(newContent, lang);
+
+      diffEditor = monaco.editor.createDiffEditor(document.getElementById('editor-container'), {
+        theme: 'vs-dark',
+        readOnly: true,
+        automaticLayout: true,
+        renderSideBySide: true,
+        scrollBeyondLastLine: false,
+        fontSize: 13,
+        fontFamily: "'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
+        padding: { top: 8 },
+        enableSplitViewResizing: true,
+        renderOverviewRuler: true,
+      });
+
+      diffEditor.setModel({ original: originalModel, modified: modifiedModel });
+    });
+
+    function setView(mode) {
+      renderSideBySide = mode === 'side';
+      diffEditor.updateOptions({ renderSideBySide });
+      document.getElementById('btn-side').classList.toggle('active', renderSideBySide);
+      document.getElementById('btn-inline').classList.toggle('active', !renderSideBySide);
+    }
+
+    function toggleTheme() {
+      isDark = !isDark;
+      monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs');
+      document.body.style.background = isDark ? '#1e1e1e' : '#ffffff';
+      document.querySelector('.header').style.background = isDark ? '#252526' : '#f3f3f3';
+      document.querySelector('.header').style.borderColor = isDark ? '#3c3c3c' : '#e0e0e0';
+      document.getElementById('btn-theme').textContent = isDark ? 'Light' : 'Dark';
+    }
+  </script>
+</body>
+</html>`
+}

--- a/src/tunnel/templates/file-viewer.ts
+++ b/src/tunnel/templates/file-viewer.ts
@@ -1,0 +1,153 @@
+import type { ViewerEntry } from '../viewer-store.js'
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+// Map our language IDs to Monaco language IDs
+const MONACO_LANGUAGE: Record<string, string> = {
+  typescript: 'typescript', javascript: 'javascript', python: 'python',
+  rust: 'rust', go: 'go', java: 'java', kotlin: 'kotlin', ruby: 'ruby',
+  php: 'php', c: 'c', cpp: 'cpp', csharp: 'csharp', swift: 'swift',
+  bash: 'shell', json: 'json', yaml: 'yaml', toml: 'ini', xml: 'xml',
+  html: 'html', css: 'css', scss: 'scss', sql: 'sql', markdown: 'markdown',
+  dockerfile: 'dockerfile', hcl: 'hcl', plaintext: 'plaintext',
+}
+
+function getMonacoLang(lang?: string): string {
+  if (!lang) return 'plaintext'
+  return MONACO_LANGUAGE[lang] || 'plaintext'
+}
+
+export function renderFileViewer(entry: ViewerEntry): string {
+  const fileName = entry.filePath || 'untitled'
+  const lang = getMonacoLang(entry.language)
+  // Escape </script> inside content to prevent premature tag closure
+  const safeContent = JSON.stringify(entry.content).replace(/<\//g, '<\\/')
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(fileName)} - OpenACP</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: #1e1e1e; color: #d4d4d4; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; display: flex; flex-direction: column; height: 100vh; }
+    .header { background: #252526; border-bottom: 1px solid #3c3c3c; padding: 8px 16px; display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; z-index: 10; }
+    .file-info { display: flex; align-items: center; gap: 8px; font-size: 13px; min-width: 0; }
+    .file-icon { font-size: 14px; flex-shrink: 0; }
+    .file-path { color: #969696; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .file-name { color: #e0e0e0; font-weight: 500; flex-shrink: 0; }
+    .actions { display: flex; gap: 6px; flex-shrink: 0; }
+    .btn { background: #3c3c3c; color: #d4d4d4; border: 1px solid #505050; padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; transition: background 0.15s; }
+    .btn:hover { background: #505050; }
+    .btn.active { background: #0e639c; border-color: #1177bb; }
+    #editor-container { flex: 1; overflow: hidden; }
+    .status-bar { background: #007acc; color: #fff; padding: 2px 16px; font-size: 12px; display: flex; justify-content: space-between; flex-shrink: 0; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="file-info">
+      <span class="file-icon">📄</span>
+      ${formatBreadcrumb(fileName)}
+    </div>
+    <div class="actions">
+      <button class="btn" onclick="toggleWordWrap()" id="btn-wrap">Wrap</button>
+      <button class="btn" onclick="toggleMinimap()" id="btn-minimap">Minimap</button>
+      <button class="btn" onclick="toggleTheme()" id="btn-theme">Light</button>
+      <button class="btn" onclick="copyCode()">Copy</button>
+    </div>
+  </div>
+  <div id="editor-container"></div>
+  <div class="status-bar">
+    <span>${escapeHtml(entry.language || 'plaintext')} | ${entry.content.split('\n').length} lines</span>
+    <span>OpenACP Viewer (read-only)</span>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js"></script>
+  <script>
+    const content = ${safeContent};
+    const lang = ${JSON.stringify(lang)};
+    let editor;
+    let isDark = true;
+    let wordWrap = false;
+    let minimap = true;
+
+    require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs' } });
+    require(['vs/editor/editor.main'], function () {
+      editor = monaco.editor.create(document.getElementById('editor-container'), {
+        value: content,
+        language: lang,
+        theme: 'vs-dark',
+        readOnly: true,
+        automaticLayout: true,
+        minimap: { enabled: true },
+        scrollBeyondLastLine: false,
+        fontSize: 13,
+        fontFamily: "'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
+        lineNumbers: 'on',
+        renderLineHighlight: 'all',
+        wordWrap: 'off',
+        padding: { top: 8 },
+      });
+
+      // Handle line range from URL hash: #L42 or #L42-L55
+      function highlightFromHash() {
+        const hash = location.hash.slice(1);
+        const match = hash.match(/^L(\\d+)(?:-L?(\\d+))?$/);
+        if (!match) return;
+        const startLine = parseInt(match[1], 10);
+        const endLine = match[2] ? parseInt(match[2], 10) : startLine;
+        editor.revealLineInCenter(startLine);
+        editor.setSelection(new monaco.Selection(startLine, 1, endLine + 1, 1));
+      }
+      highlightFromHash();
+      window.addEventListener('hashchange', highlightFromHash);
+    });
+
+    function toggleTheme() {
+      isDark = !isDark;
+      monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs');
+      document.body.style.background = isDark ? '#1e1e1e' : '#ffffff';
+      document.querySelector('.header').style.background = isDark ? '#252526' : '#f3f3f3';
+      document.querySelector('.header').style.borderColor = isDark ? '#3c3c3c' : '#e0e0e0';
+      document.getElementById('btn-theme').textContent = isDark ? 'Light' : 'Dark';
+    }
+
+    function toggleWordWrap() {
+      wordWrap = !wordWrap;
+      editor.updateOptions({ wordWrap: wordWrap ? 'on' : 'off' });
+      document.getElementById('btn-wrap').classList.toggle('active', wordWrap);
+    }
+
+    function toggleMinimap() {
+      minimap = !minimap;
+      editor.updateOptions({ minimap: { enabled: minimap } });
+      document.getElementById('btn-minimap').classList.toggle('active', !minimap);
+    }
+
+    function copyCode() {
+      navigator.clipboard.writeText(content).then(() => {
+        const btn = event.target;
+        btn.textContent = 'Copied!';
+        setTimeout(() => btn.textContent = 'Copy', 2000);
+      });
+    }
+  </script>
+</body>
+</html>`
+}
+
+function formatBreadcrumb(filePath: string): string {
+  const parts = filePath.split('/')
+  if (parts.length <= 1) return `<span class="file-name">${escapeHtml(filePath)}</span>`
+  const dir = parts.slice(0, -1).join(' / ')
+  const name = parts[parts.length - 1]
+  return `<span class="file-path">${escapeHtml(dir)} /</span> <span class="file-name">${escapeHtml(name)}</span>`
+}

--- a/src/tunnel/tunnel-service.ts
+++ b/src/tunnel/tunnel-service.ts
@@ -1,0 +1,79 @@
+import { serve } from '@hono/node-server'
+import type { TunnelConfig } from '../core/config.js'
+import { createChildLogger } from '../core/log.js'
+import type { TunnelProvider } from './provider.js'
+import { CloudflareTunnelProvider } from './providers/cloudflare.js'
+import { ViewerStore } from './viewer-store.js'
+import { createTunnelServer } from './server.js'
+
+const log = createChildLogger({ module: 'tunnel' })
+
+export class TunnelService {
+  private provider: TunnelProvider
+  private store: ViewerStore
+  private server: ReturnType<typeof serve> | null = null
+  private publicUrl = ''
+  private config: TunnelConfig
+
+  constructor(config: TunnelConfig) {
+    this.config = config
+    this.store = new ViewerStore(config.storeTtlMinutes)
+    this.provider = this.createProvider(config.provider, config.options)
+  }
+
+  async start(): Promise<string> {
+    // 1. Start HTTP server
+    const authToken = this.config.auth.enabled ? this.config.auth.token : undefined
+    const app = createTunnelServer(this.store, authToken)
+
+    this.server = serve({ fetch: app.fetch, port: this.config.port })
+    log.info({ port: this.config.port }, 'Tunnel HTTP server started')
+
+    // 2. Start tunnel provider
+    try {
+      this.publicUrl = await this.provider.start(this.config.port)
+      log.info({ url: this.publicUrl }, 'Tunnel public URL ready')
+    } catch (err) {
+      log.warn({ err }, 'Tunnel provider failed to start, running without public URL')
+      this.publicUrl = `http://localhost:${this.config.port}`
+    }
+
+    return this.publicUrl
+  }
+
+  async stop(): Promise<void> {
+    await this.provider.stop()
+    if (this.server) {
+      this.server.close()
+      this.server = null
+    }
+    this.store.destroy()
+    log.info('Tunnel service stopped')
+  }
+
+  getPublicUrl(): string {
+    return this.publicUrl
+  }
+
+  getStore(): ViewerStore {
+    return this.store
+  }
+
+  fileUrl(entryId: string): string {
+    return `${this.publicUrl}/view/${entryId}`
+  }
+
+  diffUrl(entryId: string): string {
+    return `${this.publicUrl}/diff/${entryId}`
+  }
+
+  private createProvider(name: string, options: Record<string, unknown>): TunnelProvider {
+    switch (name) {
+      case 'cloudflare':
+        return new CloudflareTunnelProvider(options)
+      default:
+        log.warn({ provider: name }, 'Unknown tunnel provider, falling back to cloudflare')
+        return new CloudflareTunnelProvider(options)
+    }
+  }
+}

--- a/src/tunnel/viewer-store.ts
+++ b/src/tunnel/viewer-store.ts
@@ -1,0 +1,137 @@
+import * as path from 'node:path'
+import { nanoid } from 'nanoid'
+import { createChildLogger } from '../core/log.js'
+
+const log = createChildLogger({ module: 'viewer-store' })
+
+const MAX_CONTENT_SIZE = 1_000_000  // 1MB
+
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  '.ts': 'typescript', '.tsx': 'typescript', '.js': 'javascript', '.jsx': 'javascript',
+  '.py': 'python', '.rs': 'rust', '.go': 'go', '.java': 'java', '.kt': 'kotlin',
+  '.rb': 'ruby', '.php': 'php', '.c': 'c', '.cpp': 'cpp', '.h': 'c', '.hpp': 'cpp',
+  '.cs': 'csharp', '.swift': 'swift', '.sh': 'bash', '.zsh': 'bash', '.bash': 'bash',
+  '.json': 'json', '.yaml': 'yaml', '.yml': 'yaml', '.toml': 'toml',
+  '.xml': 'xml', '.html': 'html', '.css': 'css', '.scss': 'scss',
+  '.sql': 'sql', '.md': 'markdown', '.dockerfile': 'dockerfile',
+  '.tf': 'hcl', '.vue': 'xml', '.svelte': 'xml',
+}
+
+export interface ViewerEntry {
+  id: string
+  type: 'file' | 'diff'
+  filePath?: string
+  content: string
+  oldContent?: string
+  language?: string
+  sessionId: string
+  workingDirectory: string
+  createdAt: number
+  expiresAt: number
+}
+
+export class ViewerStore {
+  private entries = new Map<string, ViewerEntry>()
+  private cleanupTimer: ReturnType<typeof setInterval>
+  private ttlMs: number
+
+  constructor(ttlMinutes: number = 60) {
+    this.ttlMs = ttlMinutes * 60 * 1000
+    this.cleanupTimer = setInterval(() => this.cleanup(), 5 * 60 * 1000)
+  }
+
+  storeFile(sessionId: string, filePath: string, content: string, workingDirectory: string): string | null {
+    if (!this.isPathAllowed(filePath, workingDirectory)) {
+      log.warn({ filePath, workingDirectory }, 'Path outside workspace, rejecting')
+      return null
+    }
+    if (content.length > MAX_CONTENT_SIZE) {
+      log.debug({ filePath, size: content.length }, 'File too large for viewer')
+      return null
+    }
+
+    const id = nanoid(12)
+    const now = Date.now()
+    this.entries.set(id, {
+      id,
+      type: 'file',
+      filePath,
+      content,
+      language: this.detectLanguage(filePath),
+      sessionId,
+      workingDirectory,
+      createdAt: now,
+      expiresAt: now + this.ttlMs,
+    })
+    log.debug({ id, filePath }, 'Stored file for viewing')
+    return id
+  }
+
+  storeDiff(sessionId: string, filePath: string, oldContent: string, newContent: string, workingDirectory: string): string | null {
+    if (!this.isPathAllowed(filePath, workingDirectory)) {
+      log.warn({ filePath, workingDirectory }, 'Path outside workspace, rejecting')
+      return null
+    }
+    const combined = oldContent.length + newContent.length
+    if (combined > MAX_CONTENT_SIZE) {
+      log.debug({ filePath, size: combined }, 'Diff content too large for viewer')
+      return null
+    }
+
+    const id = nanoid(12)
+    const now = Date.now()
+    this.entries.set(id, {
+      id,
+      type: 'diff',
+      filePath,
+      content: newContent,
+      oldContent,
+      language: this.detectLanguage(filePath),
+      sessionId,
+      workingDirectory,
+      createdAt: now,
+      expiresAt: now + this.ttlMs,
+    })
+    log.debug({ id, filePath }, 'Stored diff for viewing')
+    return id
+  }
+
+  get(id: string): ViewerEntry | undefined {
+    const entry = this.entries.get(id)
+    if (!entry) return undefined
+    if (Date.now() > entry.expiresAt) {
+      this.entries.delete(id)
+      return undefined
+    }
+    return entry
+  }
+
+  private cleanup(): void {
+    const now = Date.now()
+    let removed = 0
+    for (const [id, entry] of this.entries) {
+      if (now > entry.expiresAt) {
+        this.entries.delete(id)
+        removed++
+      }
+    }
+    if (removed > 0) {
+      log.debug({ removed, remaining: this.entries.size }, 'Cleaned up expired viewer entries')
+    }
+  }
+
+  private isPathAllowed(filePath: string, workingDirectory: string): boolean {
+    const resolved = path.resolve(workingDirectory, filePath)
+    return resolved.startsWith(path.resolve(workingDirectory))
+  }
+
+  private detectLanguage(filePath: string): string | undefined {
+    const ext = path.extname(filePath).toLowerCase()
+    return EXTENSION_LANGUAGE[ext]
+  }
+
+  destroy(): void {
+    clearInterval(this.cleanupTimer)
+    this.entries.clear()
+  }
+}


### PR DESCRIPTION
## Summary

- **Tunnel Service**: pluggable provider interface (Cloudflare built-in), local Hono HTTP server, in-memory ViewerStore with TTL/path validation
- **File Viewer**: Monaco Editor (VS Code engine) from CDN — syntax highlight, minimap, line range via URL hash, dark/light theme, copy
- **Diff Viewer**: Monaco diff editor with side-by-side + inline toggle, +/- stats
- **Integration**: core enriches tool events with viewer links, Telegram renders clickable links that persist across updates
- **Opt-in**: `tunnel.enabled: true` in config or `OPENACP_TUNNEL_ENABLED=true` env var

## Test plan

- [ ] `pnpm build` passes
- [ ] Set `tunnel.enabled: true`, start server — tunnel URL logged
- [ ] `curl http://localhost:3100/health` → 200
- [ ] Agent reads/writes file → "View file" link in Telegram → Monaco viewer in browser
- [ ] Agent edits file with old content → "View diff" link → Monaco diff viewer
- [ ] Viewer links persist after tool completes (not lost on message update)
- [ ] Files outside workspace rejected (path validation)
- [ ] Entries expire after TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)