### PR TITLE
docs: refactor README into landing page + separate guide docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,58 @@
+<div align="center">
+
 # OpenACP
 
-Self-hosted bridge that lets you interact with AI coding agents (Claude Code, Codex, etc.) from messaging platforms (Telegram, Discord, etc.) via the [Agent Client Protocol (ACP)](https://agentclientprotocol.org/).
+**Self-hosted bridge between messaging platforms and AI coding agents**
 
-**One message, any channel, any agent.**
+One message, any channel, any agent.
 
-## How It Works
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![Node.js >= 20](https://img.shields.io/badge/Node.js-%3E%3D%2020-green.svg)](https://nodejs.org/)
+[![ACP Protocol](https://img.shields.io/badge/Protocol-ACP-purple.svg)](https://agentclientprotocol.org/)
+
+[Getting Started](docs/guide/getting-started.md) | [Usage](docs/guide/usage.md) | [Configuration](docs/guide/configuration.md) | [Tunnel](docs/guide/tunnel.md) | [Plugins](docs/guide/plugins.md) | [Development](docs/guide/development.md)
+
+</div>
+
+---
+
+Send a message in Telegram. An AI coding agent picks it up, writes code, runs commands, and streams everything back — in real time.
+
+OpenACP connects messaging platforms (Telegram, Discord, ...) to AI coding agents (Claude Code, Codex, ...) via the [Agent Client Protocol (ACP)](https://agentclientprotocol.org/). You host it, you own the data.
+
+## Architecture
 
 ```
 You (Telegram / Discord / ...)
-  │
-  ▼
-OpenACP (ChannelAdapter)
-  │
-  ▼
-ACP Protocol (JSON-RPC over stdio)
-  │
-  ▼
-AI Agent subprocess (Claude Code, Codex, ...)
+  ↓
+OpenACP ─── ChannelAdapter ─── Session Manager ─── Session Store
+  ↓                                                     ↓
+ACP Protocol (JSON-RPC / stdio)                  Tunnel Service
+  ↓                                                     ↓
+AI Agent (Claude Code, Codex, ...)            File/Diff Viewer (Monaco)
 ```
 
-You send a message in Telegram → OpenACP forwards it to an AI coding agent via ACP → agent responds with text, code, tool calls → OpenACP streams the response back to your chat.
+## Highlights
 
-## Features
-
-- **Multi-agent** — Switch between Claude Code, Codex, or any ACP-compatible agent
-- **Telegram integration** — Forum topics per session, real-time streaming, inline permission buttons
-- **Session management** — Multiple parallel sessions, prompt queue, auto-naming
-- **Assistant topic** — AI-powered help bot that guides you through creating sessions
-- **Notification topic** — Aggregated notifications with deep links
-- **Workspace management** — Named workspaces or custom paths
+- [**Multi-agent**](docs/guide/configuration.md#agents) — Claude Code, Codex, or any ACP-compatible agent
+- [**Telegram**](docs/guide/telegram-setup.md) — Forum topics, real-time streaming, permission buttons, skill commands
+- [**Tunnel & Viewer**](docs/guide/tunnel.md) — Public file/diff viewer via Cloudflare, ngrok, bore, Tailscale
+- [**Session persistence**](docs/guide/usage.md#session-persistence--resume) — Lazy resume across restarts
+- [**Setup wizard**](docs/guide/getting-started.md) — Interactive first-run setup with bot validation and auto-detect
+- [**Plugin system**](docs/guide/plugins.md) — Install channel adapters as npm packages
+- [**Structured logging**](docs/guide/configuration.md#logging) — Pino with rotation, per-session log files
 - **Self-hosted** — Your keys, your data, your machine
 
 ## Quick Start
-
-### Prerequisites
-
-- Node.js >= 20
-- pnpm
-- A Telegram bot token (from [@BotFather](https://t.me/BotFather))
-- A Telegram Supergroup with **Forum/Topics enabled**
-- At least one ACP agent installed (e.g., `claude-agent-acp`)
-
-### Install
 
 ```bash
 npm install -g @openacp/cli
 openacp
 ```
 
-### Setup Telegram
+First run launches an [interactive setup wizard](docs/guide/getting-started.md) that validates your bot token, auto-detects your Telegram group, and finds installed agents.
 
-1. Create a Supergroup in Telegram
-2. Enable **Topics** in group settings
-3. Add your bot as **admin** with **Manage Topics** permission
-4. Get the chat ID (use [@raw_data_bot](https://t.me/raw_data_bot) or similar)
-
-### Run
-
-```bash
-openacp
-```
-
-On first run (no config file), an **interactive setup wizard** walks you through:
-
-1. **Telegram** — bot token + chat ID (validated against Telegram API)
-2. **Agents** — auto-detects installed agents, select which to enable
-3. **Workspace** — base directory for project workspaces
-4. **Security** — allowed users, session limits, timeout
-
-Config is saved to `~/.openacp/config.json`. See [docs/setup-guide.md](docs/setup-guide.md) for details.
-
-OpenACP will auto-create two topics in your group:
-- Notifications — aggregated alerts with deep links
-- Assistant — AI helper for managing sessions
-
-## Usage
-
-### Commands
+## Commands
 
 | Command | Description |
 |---------|-------------|
@@ -85,169 +61,29 @@ OpenACP will auto-create two topics in your group:
 | `/cancel` | Cancel current session |
 | `/status` | Show session or system status |
 | `/agents` | List available agents |
-| `/help` | Show help |
-
-### Examples
-
-```
-/new claude my-app          → New session with Claude in ~/openacp-workspace/my-app/
-/new codex api-server       → New session with Codex in ~/openacp-workspace/api-server/
-/new claude ~/code/project  → New session with absolute path
-/new                        → New session with default agent and workspace
-```
-
-### Session Flow
-
-1. Type `/new claude my-project` — bot creates a new topic
-2. Send your coding request in the topic
-3. Agent responds with streaming text, tool calls, and code
-4. When agent needs permission (run command, edit file) → inline buttons appear
-5. Click Allow/Deny → agent continues
-6. `/cancel` to stop, or start a new topic with `/new`
-
-## Configuration
-
-Config file: `~/.openacp/config.json`
-
-```json
-{
-  "channels": {
-    "telegram": {
-      "enabled": true,
-      "botToken": "...",
-      "chatId": -1001234567890,
-      "notificationTopicId": null,
-      "assistantTopicId": null
-    }
-  },
-  "agents": {
-    "claude": {
-      "command": "claude-agent-acp",
-      "args": [],
-      "env": {}
-    },
-    "codex": {
-      "command": "codex",
-      "args": ["--acp"],
-      "env": {}
-    }
-  },
-  "defaultAgent": "claude",
-  "workspace": {
-    "baseDir": "~/openacp-workspace"
-  },
-  "security": {
-    "allowedUserIds": [],
-    "maxConcurrentSessions": 5,
-    "sessionTimeoutMinutes": 60
-  }
-}
-```
-
-### Environment Variables
-
-| Variable | Overrides |
-|----------|-----------|
-| `OPENACP_CONFIG_PATH` | Config file location |
-| `OPENACP_TELEGRAM_BOT_TOKEN` | `channels.telegram.botToken` |
-| `OPENACP_TELEGRAM_CHAT_ID` | `channels.telegram.chatId` |
-| `OPENACP_DEFAULT_AGENT` | `defaultAgent` |
-| `OPENACP_DEBUG` | Enable debug logging (set to `1`) |
-
-## Plugins
-
-Install additional adapters:
-
-```bash
-openacp install @openacp/adapter-discord
-openacp plugins                              # list installed
-openacp uninstall @openacp/adapter-discord   # remove
-```
-
-Configure in `~/.openacp/config.json`:
-
-```json
-{
-  "channels": {
-    "discord": {
-      "enabled": true,
-      "adapter": "@openacp/adapter-discord",
-      "botToken": "..."
-    }
-  }
-}
-```
-
-## Project Structure
-
-```
-src/
-  cli.ts                         → CLI entry point
-  main.ts                        → Server startup
-  index.ts                       → Public API exports
-  core/
-    core.ts                      → OpenACPCore orchestrator
-    config.ts                    → ConfigManager + Zod validation
-    setup.ts                     → Interactive setup wizard
-    session.ts                   → Session (prompt queue, auto-name)
-    agent-instance.ts            → ACP SDK integration
-    channel.ts                   → ChannelAdapter abstract class
-    plugin-manager.ts            → Plugin install/uninstall/load
-    types.ts                     → Shared types
-  adapters/
-    telegram/
-      adapter.ts                 → TelegramAdapter
-      streaming.ts               → Real-time message streaming
-      commands.ts                → Bot commands
-      permissions.ts             → Permission inline buttons
-      assistant.ts               → AI assistant topic
-      formatting.ts              → Markdown → Telegram HTML
-      topics.ts                  → Forum topic management
-```
 
 ## Roadmap
 
-- **Phase 1** ✅ Core + Telegram + ACP agents
-- **Phase 2** — Web UI, CLI, Discord adapter, tunnel/file viewer
-- **Phase 3** — Agent skills as commands, session persistence
-- **Phase 4** — Voice control, file sharing
+- **Phase 1** — Core + Telegram + ACP agents
+- **Phase 2** — Tunnel/file viewer, session persistence, logging, plugin system
+- **Phase 3** — Agent skills as commands, Discord adapter, Web UI
+- **Phase 4** — Voice control, file/image sharing
 - **Phase 5** — WhatsApp, agent chaining, plugin marketplace
 
-See [docs/specs/01-roadmap.md](docs/specs/01-roadmap.md) for details.
+## Star History
 
-## Adding a Channel Adapter
+<a href="https://star-history.com/#Open-ACP/OpenACP&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Open-ACP/OpenACP&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Open-ACP/OpenACP&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Open-ACP/OpenACP&type=Date" />
+ </picture>
+</a>
 
-Extend `ChannelAdapter` from `@openacp/cli`:
+## Contributing
 
-```typescript
-import { ChannelAdapter } from '@openacp/cli'
-
-class MyAdapter extends ChannelAdapter {
-  async start() { /* connect to platform */ }
-  async stop() { /* disconnect */ }
-  async sendMessage(sessionId, content) { /* send to user */ }
-  async sendPermissionRequest(sessionId, request) { /* show buttons */ }
-  async sendNotification(notification) { /* notify user */ }
-  async createSessionThread(sessionId, name) { /* create thread */ }
-  async renameSessionThread(sessionId, name) { /* rename thread */ }
-}
-```
-
-## Development
-
-```bash
-git clone https://github.com/nicepkg/OpenACP.git
-cd OpenACP
-pnpm install
-pnpm build
-```
-
-Run locally:
-
-```bash
-pnpm start
-```
+See [development guide](docs/guide/development.md).
 
 ## License
 
-AGPL-3.0
+[AGPL-3.0](LICENSE)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,155 @@
+# Configuration
+
+Config file: `~/.openacp/config.json`
+
+Created by the setup wizard on first run. Edit manually anytime.
+
+## Full Example
+
+```json
+{
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "botToken": "YOUR_BOT_TOKEN",
+      "chatId": -1001234567890
+    }
+  },
+  "agents": {
+    "claude": {
+      "command": "claude-agent-acp",
+      "args": [],
+      "env": {}
+    },
+    "codex": {
+      "command": "codex",
+      "args": ["--acp"],
+      "env": {}
+    }
+  },
+  "defaultAgent": "claude",
+  "workspace": {
+    "baseDir": "~/openacp-workspace"
+  },
+  "security": {
+    "allowedUserIds": [],
+    "maxConcurrentSessions": 5,
+    "sessionTimeoutMinutes": 60
+  },
+  "tunnel": {
+    "enabled": true,
+    "port": 3100,
+    "provider": "cloudflare",
+    "options": {},
+    "storeTtlMinutes": 60,
+    "auth": { "enabled": false }
+  },
+  "logging": {
+    "level": "info",
+    "logDir": "~/.openacp/logs",
+    "maxFileSize": "10m",
+    "maxFiles": 7,
+    "sessionLogRetentionDays": 30
+  },
+  "sessionStore": {
+    "ttlDays": 30
+  }
+}
+```
+
+## Channels
+
+Each key is a channel name. Built-in: `telegram`. Plugins: any name with `adapter` field.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Enable this channel |
+| `botToken` | string | Platform bot token |
+| `chatId` | number | Telegram group chat ID |
+| `adapter` | string | Package name for plugin adapters |
+
+## Agents
+
+Each key is the agent name used in `/new` command.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `command` | string | — | CLI command to spawn the agent |
+| `args` | string[] | `[]` | Additional arguments |
+| `workingDirectory` | string | — | Default working directory |
+| `env` | object | `{}` | Additional environment variables |
+
+## Workspace
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `baseDir` | `~/openacp-workspace` | Base directory for named workspaces |
+
+## Security
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `allowedUserIds` | `[]` (all) | Telegram user IDs allowed to use the bot |
+| `maxConcurrentSessions` | `5` | Max parallel sessions |
+| `sessionTimeoutMinutes` | `60` | Session timeout |
+
+## Tunnel
+
+See [Tunnel & File Viewer](tunnel.md) for full details.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Enable tunnel service |
+| `port` | `3100` | Local HTTP server port |
+| `provider` | `"cloudflare"` | Provider: `cloudflare`, `ngrok`, `bore`, `tailscale` |
+| `options` | `{}` | Provider-specific options |
+| `storeTtlMinutes` | `60` | Viewer entry expiration (minutes) |
+| `auth.enabled` | `false` | Require Bearer token for viewer |
+| `auth.token` | — | Token value |
+
+## Logging
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `level` | `"info"` | `debug`, `info`, `warn`, `error`, `fatal`, `silent` |
+| `logDir` | `~/.openacp/logs` | Log directory |
+| `maxFileSize` | `"10m"` | Log file rotation threshold |
+| `maxFiles` | `7` | Rotated files to keep |
+| `sessionLogRetentionDays` | `30` | Days to keep per-session logs |
+
+Logs are written to:
+- **Console**: pretty-printed with colors (Pino Pretty)
+- **Combined file**: `~/.openacp/logs/openacp.log` (JSONL, rotated)
+- **Per-session files**: `~/.openacp/logs/sessions/{sessionId}.log`
+
+Old session logs are cleaned up automatically on startup.
+
+## Session Store
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `ttlDays` | `30` | Days to keep session records |
+
+Sessions are stored in `~/.openacp/sessions.json` with debounced writes (2s). Enables [lazy resume](usage.md#session-persistence--resume) across restarts.
+
+## Environment Variables
+
+| Variable | Overrides |
+|----------|-----------|
+| `OPENACP_CONFIG_PATH` | Config file location |
+| `OPENACP_TELEGRAM_BOT_TOKEN` | `channels.telegram.botToken` |
+| `OPENACP_TELEGRAM_CHAT_ID` | `channels.telegram.chatId` |
+| `OPENACP_DEFAULT_AGENT` | `defaultAgent` |
+| `OPENACP_TUNNEL_ENABLED` | `tunnel.enabled` |
+| `OPENACP_TUNNEL_PORT` | `tunnel.port` |
+| `OPENACP_TUNNEL_PROVIDER` | `tunnel.provider` |
+| `OPENACP_LOG_LEVEL` | `logging.level` |
+| `OPENACP_LOG_DIR` | `logging.logDir` |
+| `OPENACP_DEBUG` | Set logging to debug level |
+
+## Backward Compatibility
+
+New config sections are auto-added on upgrade:
+- If `tunnel` section is missing → written to file with `enabled: true`, `provider: "cloudflare"`
+- Existing fields are never modified
+- Zod defaults handle any missing optional fields

--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -1,0 +1,107 @@
+# Development
+
+## Setup
+
+```bash
+git clone https://github.com/Open-ACP/OpenACP.git
+cd OpenACP
+pnpm install
+pnpm build
+```
+
+## Run
+
+```bash
+pnpm start                    # Start server
+OPENACP_DEBUG=1 pnpm start    # Debug mode
+```
+
+## Tests
+
+```bash
+pnpm test
+```
+
+## Pre-commit Hook
+
+Husky runs `pnpm build` before every commit to catch type errors.
+
+## Project Structure
+
+```
+src/
+  cli.ts                           CLI entry point (openacp command)
+  main.ts                          Server startup & shutdown
+  core/
+    core.ts                        OpenACPCore orchestrator
+    config.ts                      ConfigManager + Zod schema
+    setup.ts                       Interactive setup wizard
+    session.ts                     Session (prompt queue, auto-name, resume)
+    session-manager.ts             Session lifecycle
+    session-store.ts               JSON file persistence
+    agent-instance.ts              ACP SDK integration + resume
+    agent-manager.ts               Agent spawning
+    channel.ts                     ChannelAdapter abstract class
+    plugin-manager.ts              Plugin install/uninstall/load
+    log.ts                         Pino logging (console + file rotation)
+    types.ts                       Shared types
+  adapters/
+    telegram/
+      adapter.ts                   TelegramAdapter
+      streaming.ts                 MessageDraft (throttled streaming)
+      commands.ts                  Bot commands (/new, /cancel, etc.)
+      permissions.ts               Permission inline buttons
+      assistant.ts                 AI assistant topic
+      formatting.ts                Markdown → Telegram HTML
+      topics.ts                    Forum topic management
+  tunnel/
+    tunnel-service.ts              Orchestrator: server + provider + store
+    server.ts                      Hono HTTP routes
+    provider.ts                    TunnelProvider interface
+    viewer-store.ts                In-memory store with TTL
+    extract-file-info.ts           ACP content → file info parser
+    providers/
+      cloudflare.ts                Cloudflare Tunnel
+      ngrok.ts                     ngrok
+      bore.ts                      bore
+      tailscale.ts                 Tailscale Funnel
+    templates/
+      file-viewer.ts               Monaco Editor HTML
+      diff-viewer.ts               Monaco Diff Editor HTML
+```
+
+## Architecture
+
+```
+ChannelAdapter (Telegram, plugin adapters)
+  ↕ messages
+OpenACPCore
+  ├── SessionManager → Session → AgentInstance (ACP SDK)
+  ├── ConfigManager (Zod validation, env overrides)
+  ├── SessionStore (JSON file, debounced writes, lazy resume)
+  ├── NotificationManager
+  └── TunnelService (optional)
+        ├── HTTP Server (Hono)
+        ├── TunnelProvider (cloudflare/ngrok/bore/tailscale)
+        └── ViewerStore (in-memory, TTL)
+```
+
+## Key Design Decisions
+
+- **Fire-and-forget message handling** — Telegram handler doesn't await the agent prompt, preventing a deadlock between polling and permission callbacks
+- **Lazy resume** — Sessions only reconnect when a user sends a message, not on startup (avoids subprocess explosion)
+- **Debounced session store** — Writes batched every 2s with force flush on shutdown
+- **Pluggable adapters** — `ChannelAdapter` abstract class, loaded dynamically for plugins
+- **Pluggable tunnel providers** — `TunnelProvider` interface, add providers with `start()`/`stop()`/`getPublicUrl()`
+- **Config auto-migration** — New sections auto-added to existing config files on upgrade
+
+## Standard Paths
+
+| Path | Purpose |
+|------|---------|
+| `~/.openacp/config.json` | Configuration |
+| `~/.openacp/sessions.json` | Session persistence |
+| `~/.openacp/plugins/` | Installed plugin adapters |
+| `~/.openacp/logs/openacp.log` | Combined log (JSONL, rotated) |
+| `~/.openacp/logs/sessions/` | Per-session log files |
+| `~/openacp-workspace/` | Default workspace base |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,73 @@
+# Getting Started
+
+## Prerequisites
+
+- Node.js >= 20
+- At least one ACP agent installed (e.g., `@zed-industries/claude-agent-acp`)
+- A Telegram bot token (from [@BotFather](https://t.me/BotFather))
+- A Telegram Supergroup with **Topics** enabled
+
+## Install
+
+```bash
+npm install -g @openacp/cli
+```
+
+## First Run
+
+```bash
+openacp
+```
+
+On first run (no config file), an **interactive setup wizard** guides you through:
+
+### Step 1: Telegram Bot
+
+- Enter your bot token from @BotFather
+- Token is **validated** against the Telegram API — you'll see the bot name on success
+- Option to retry if validation fails
+
+### Step 2: Group Chat
+
+- OpenACP **auto-detects** your supergroup by listening for messages (120s timeout)
+- Send any message in your group while it's listening
+- If multiple groups are found, you pick from a list
+- Alternatively, press `m` to enter the chat ID manually
+- Validates that it's a supergroup (required for forum topics)
+
+### Step 3: Workspace
+
+- Choose a base directory for project workspaces
+- Default: `~/openacp-workspace`
+- Named workspaces resolve to `{baseDir}/{name}`
+
+### Agent Detection
+
+The wizard automatically scans your system for known ACP agents:
+- `claude-agent-acp` (preferred)
+- `claude-code`
+- `claude`
+- `codex`
+
+The first detected agent becomes the default. If none found, falls back to `claude-agent-acp`.
+
+### Done
+
+Config is saved to `~/.openacp/config.json`. Edit it anytime — see [Configuration](configuration.md).
+
+## What Happens on Startup
+
+1. Config loaded and validated (Zod schema)
+2. Logger initialized (Pino with file rotation)
+3. Session store loaded (`~/.openacp/sessions.json`)
+4. Tunnel service started (if enabled — default: Cloudflare)
+5. Channel adapters registered and started
+6. System topics created in Telegram (Notifications + Assistant)
+7. Ready for messages
+
+## Next Steps
+
+- [Telegram Setup](telegram-setup.md) — detailed bot & group configuration
+- [Usage Guide](usage.md) — commands, sessions, workspaces
+- [Configuration Reference](configuration.md) — all config options
+- [Tunnel & File Viewer](tunnel.md) — shareable code viewer

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,0 +1,64 @@
+# Plugins
+
+OpenACP supports installing additional channel adapters as npm packages.
+
+## CLI Commands
+
+```bash
+openacp install <package>     # Install a plugin adapter
+openacp uninstall <package>   # Remove a plugin
+openacp plugins               # List installed plugins with versions
+```
+
+## Example
+
+```bash
+openacp install @openacp/adapter-discord
+```
+
+Then configure in `~/.openacp/config.json`:
+
+```json
+{
+  "channels": {
+    "discord": {
+      "enabled": true,
+      "adapter": "@openacp/adapter-discord",
+      "botToken": "YOUR_DISCORD_BOT_TOKEN"
+    }
+  }
+}
+```
+
+Plugins are installed to `~/.openacp/plugins/`.
+
+## Creating a Channel Adapter
+
+Implement the `ChannelAdapter` abstract class:
+
+```typescript
+import { ChannelAdapter } from '@openacp/cli'
+
+class MyAdapter extends ChannelAdapter {
+  async start() { /* connect to platform */ }
+  async stop() { /* disconnect */ }
+  async sendMessage(sessionId, content) { /* send to user */ }
+  async sendPermissionRequest(sessionId, request) { /* show permission UI */ }
+  async sendNotification(notification) { /* notify user */ }
+  async createSessionThread(sessionId, name) { /* create thread */ }
+  async renameSessionThread(sessionId, name) { /* rename thread */ }
+}
+```
+
+Export an `AdapterFactory`:
+
+```typescript
+export const adapterFactory = {
+  name: 'my-adapter',
+  createAdapter(core, config) {
+    return new MyAdapter(core, config)
+  }
+}
+```
+
+OpenACP loads plugins dynamically via `createRequire()` from the plugins directory. It looks for `module.adapterFactory` or `module.default`.

--- a/docs/guide/telegram-setup.md
+++ b/docs/guide/telegram-setup.md
@@ -1,0 +1,67 @@
+# Telegram Setup
+
+## Create a Bot
+
+1. Open [@BotFather](https://t.me/BotFather) in Telegram
+2. Send `/newbot`, follow the prompts
+3. Copy the bot token
+
+## Create a Supergroup
+
+1. Create a new Group in Telegram
+2. Go to **Group Settings** → enable **Topics**
+3. This converts it to a Supergroup with forum topics
+
+## Add Bot as Admin
+
+Add your bot to the group and promote to **Admin** with:
+- **Manage Topics** (required)
+- **Send Messages**
+- **Delete Messages** (optional)
+
+## Get Chat ID
+
+Forward any message from the group to [@RawDataBot](https://t.me/raw_data_bot). It replies with the chat ID (negative number starting with `-100`).
+
+Or use the API directly:
+```
+https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates
+```
+
+## System Topics
+
+On first start, OpenACP creates two topics automatically:
+
+| Topic | Purpose |
+|-------|---------|
+| **Notifications** | Session completed, errors, permission requests — with deep links |
+| **Assistant** | AI-powered helper that guides you through creating and managing sessions |
+
+Topic IDs are saved to config (`notificationTopicId`, `assistantTopicId`).
+
+## Session Topics
+
+Each `/new` command creates a **separate forum topic** for that session. Features:
+
+- **Real-time streaming** — agent responses stream as they're generated, with throttled message updates (1s interval)
+- **Auto-naming** — after the first prompt, the topic is renamed to a 5-word summary
+- **Prompt queue** — send multiple messages while agent is busy, they queue up
+- **Skill commands** — agent publishes available skills as inline buttons, pinned in the topic
+- **Permission buttons** — when agent needs approval, inline buttons appear (Allow / Always Allow / Reject)
+- **Viewer links** — if tunnel is enabled, tool calls include clickable file/diff viewer links
+
+## Message Streaming
+
+Agent output is streamed in real-time using a `MessageDraft` system:
+- Text buffers and flushes at 1-second intervals
+- First chunk creates a new message, subsequent chunks edit it
+- Markdown → Telegram HTML conversion with syntax highlighting
+- Messages split at 4096 chars (Telegram limit)
+- Graceful fallback to plain text if HTML parsing fails
+
+## Environment Variables
+
+```bash
+OPENACP_TELEGRAM_BOT_TOKEN=your_token openacp
+OPENACP_TELEGRAM_CHAT_ID=-1001234567890 openacp
+```

--- a/docs/guide/tunnel.md
+++ b/docs/guide/tunnel.md
@@ -1,0 +1,91 @@
+# Tunnel & File Viewer
+
+The tunnel service exposes a local HTTP server to the public internet, generating shareable links for file/diff viewing directly from Telegram.
+
+## How It Works
+
+```
+Agent reads/writes file → content stored in ViewerStore → link in Telegram
+                                                              ↓
+User clicks → Browser opens Monaco Editor (VS Code engine) with syntax highlighting
+```
+
+## File Viewer
+
+- Monaco Editor loaded from CDN
+- Syntax highlighting for all languages
+- Line range highlighting via URL hash: `#L42` or `#L42-L55`
+- Dark/light theme, word wrap, minimap toggle
+- Copy button, file path breadcrumb
+
+## Diff Viewer
+
+- Monaco diff editor — side-by-side or inline toggle
+- +/- change stats
+- Syntax highlighting, dark/light theme
+
+## Configuration
+
+```json
+{
+  "tunnel": {
+    "enabled": true,
+    "port": 3100,
+    "provider": "cloudflare",
+    "options": {},
+    "storeTtlMinutes": 60,
+    "auth": {
+      "enabled": false,
+      "token": ""
+    }
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `true` | Enable tunnel service |
+| `port` | `3100` | Local HTTP server port |
+| `provider` | `"cloudflare"` | Tunnel provider |
+| `options` | `{}` | Provider-specific options |
+| `storeTtlMinutes` | `60` | Viewer entry expiration (minutes) |
+| `auth.enabled` | `false` | Require Bearer token |
+| `auth.token` | — | Token value |
+
+## Providers
+
+| Provider | Config | Free | Stable URL | CLI |
+|----------|--------|------|------------|-----|
+| **Cloudflare** (default) | `"cloudflare"` | Yes | No | [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/) |
+| **ngrok** | `"ngrok"` | Freemium | With paid plan | [ngrok](https://ngrok.com/download) |
+| **bore** | `"bore"` | Yes | No | [bore](https://github.com/ekzhang/bore) |
+| **Tailscale Funnel** | `"tailscale"` | With account | Yes | [tailscale](https://tailscale.com/download) |
+
+### Provider Options
+
+**Cloudflare**: `{ "domain": "my-app.trycloudflare.com" }`
+
+**ngrok**: `{ "authtoken": "xxx", "domain": "my-app.ngrok-free.app", "region": "ap" }`
+
+**bore**: `{ "server": "bore.pub", "port": 12345, "secret": "xxx" }`
+
+**Tailscale**: `{ "bg": true }`
+
+## HTTP Endpoints
+
+| Route | Description |
+|-------|-------------|
+| `GET /health` | Health check (always public) |
+| `GET /view/:id` | File viewer (Monaco Editor) |
+| `GET /diff/:id` | Diff viewer (Monaco Diff Editor) |
+| `GET /api/file/:id` | JSON file content |
+| `GET /api/diff/:id` | JSON diff content |
+
+## Security
+
+- **Auth**: `auth.enabled: true` requires Bearer token (header or `?token=` query param)
+- **Path validation**: only files within session working directory
+- **Content size**: max 1MB per entry
+- **TTL**: entries auto-expire after `storeTtlMinutes`
+- **Ephemeral URLs**: Cloudflare free tier URL changes on every restart
+- **Resilience**: if port in use, warns and continues without tunnel (no crash)

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -1,0 +1,76 @@
+# Usage
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/new [agent] [workspace]` | Create a new session (new topic) |
+| `/new_chat` | New session, same agent & workspace |
+| `/cancel` | Cancel current session |
+| `/status` | Show session or system status |
+| `/agents` | List available agents |
+| `/help` | Show help |
+| `/menu` | Show menu keyboard |
+
+## Examples
+
+```
+/new claude my-app          → Claude in ~/openacp-workspace/my-app/
+/new codex api-server       → Codex in ~/openacp-workspace/api-server/
+/new claude ~/code/project  → Absolute path
+/new                        → Default agent and workspace
+```
+
+## Session Flow
+
+1. `/new claude my-project` — creates a new forum topic + spawns agent
+2. Send your coding request
+3. Agent responds with streaming text, tool calls, code
+4. Permission needed → inline buttons (Allow / Always Allow / Reject)
+5. File written → "View file" link opens Monaco Editor in browser
+6. `/cancel` to stop, `/new` for another session
+
+## Workspaces
+
+| Input | Resolves to |
+|-------|-------------|
+| (none) | `~/openacp-workspace/` |
+| `my-app` | `~/openacp-workspace/my-app/` |
+| `~/code/project` | `~/code/project/` |
+| `/absolute/path` | `/absolute/path/` |
+
+Base directory is configurable via `workspace.baseDir` in config.
+
+## Session Persistence & Resume
+
+Sessions survive OpenACP restarts:
+
+1. Session data is persisted to `~/.openacp/sessions.json`
+2. After a restart, existing Telegram topics remain
+3. Send a message in an old topic → **lazy resume** kicks in:
+   - Agent subprocess respawns with the same session ID
+   - Agent reconnects to its internal state
+   - Your message is forwarded to the resumed agent
+4. Sessions older than `sessionStore.ttlDays` (default: 30) are cleaned up
+
+Resume works for sessions with status `active` or `finished`. Cancelled/error sessions are not resumable.
+
+## Skill Commands
+
+AI agents can publish available skills (like `/compact`, `/review`, `/debug`). When they do:
+
+- An inline keyboard with skill buttons is pinned in the session topic
+- Click a skill button to invoke it
+- Skills update dynamically as the agent's capabilities change
+
+## Multiple Sessions
+
+Run sessions in parallel — each `/new` creates a separate topic with its own agent subprocess. Limited by `security.maxConcurrentSessions` (default: 5).
+
+## Assistant
+
+The **Assistant topic** is an always-on AI helper:
+- Knows your available agents and commands
+- Helps create sessions interactively
+- Provides guidance on OpenACP usage
+- Shows a menu keyboard on startup


### PR DESCRIPTION
## Summary

- Refactor README.md into a concise landing page: badges, architecture diagram, feature highlights with linked titles, quick start, commands table, roadmap, star history chart
- Move detailed documentation into `docs/guide/` (separate from `docs/specs/` and `docs/superpowers/`)

## New docs

| File | Content |
|------|---------|
| `docs/guide/getting-started.md` | Install, setup wizard flow, agent detection, startup sequence |
| `docs/guide/telegram-setup.md` | Bot setup, group config, streaming, skill commands, system topics |
| `docs/guide/usage.md` | Commands, session flow, workspaces, session persistence & lazy resume |
| `docs/guide/configuration.md` | Full config reference, all sections, env vars, backward compat |
| `docs/guide/tunnel.md` | Tunnel providers, file/diff viewer, security, HTTP endpoints |
| `docs/guide/plugins.md` | Install/create channel adapters, AdapterFactory interface |
| `docs/guide/development.md` | Build, project structure, architecture, design decisions, paths |

## Test plan

- [ ] All internal links in README resolve correctly
- [ ] All cross-references between guide docs resolve correctly
- [ ] No content lost from previous README (moved to appropriate guide doc)