### PR TITLE
fix(setup): enable tunnel by default in setup wizard

### DIFF
--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -405,7 +405,7 @@ export async function runSetup(configManager: ConfigManager): Promise<boolean> {
       },
       sessionStore: { ttlDays: 30 },
       tunnel: {
-        enabled: false,
+        enabled: true,
         port: 3100,
         provider: "cloudflare",
         options: {},


### PR DESCRIPTION
## Summary

- Setup wizard was hardcoding `tunnel.enabled: false` when creating new config
- Changed to `enabled: true` so new installations get tunnel enabled by default with cloudflare

## Context

The config auto-migration (from PR #13) correctly sets `enabled: true` for existing configs missing the tunnel section. But when the setup wizard creates a brand new config (first run, no config file), it was hardcoding `false`.

## Test plan

- [ ] Delete `~/.openacp/config.json`, run `openacp` → setup wizard creates config with `tunnel.enabled: true`