### PR TITLE
feat(tunnel): viewer link extraction, md preview, port auto-retry

### DIFF
--- a/src/adapters/telegram/adapter.ts
+++ b/src/adapters/telegram/adapter.ts
@@ -87,6 +87,7 @@ export class TelegramAdapter extends ChannelAdapter {
         name: string;
         kind?: string;
         viewerLinks?: { file?: string; diff?: string };
+        viewerFilePath?: string;
       }
     >
   > = new Map(); // sessionId → (toolCallId → state)
@@ -384,6 +385,7 @@ export class TelegramAdapter extends ChannelAdapter {
           name: meta.name,
           kind: meta.kind,
           viewerLinks: meta.viewerLinks,
+          viewerFilePath: (content.metadata as any)?.viewerFilePath,
         });
         break;
       }
@@ -399,15 +401,18 @@ export class TelegramAdapter extends ChannelAdapter {
         };
         const toolState = this.toolCallMessages.get(sessionId)?.get(meta.id);
         if (toolState) {
-          // Carry forward viewerLinks from previous updates if not present in current
+          // Carry forward viewerLinks and filePath from previous updates
           const viewerLinks = meta.viewerLinks || toolState.viewerLinks;
+          const viewerFilePath = (content.metadata as any)?.viewerFilePath || toolState.viewerFilePath;
           if (meta.viewerLinks) toolState.viewerLinks = meta.viewerLinks;
+          if (viewerFilePath) toolState.viewerFilePath = viewerFilePath;
           // Merge name/kind from original tool_call
           const merged = {
             ...meta,
             name: meta.name || toolState.name,
             kind: meta.kind || toolState.kind,
             viewerLinks,
+            viewerFilePath,
           };
           try {
             await this.sendQueue.enqueue(() =>

--- a/src/adapters/telegram/formatting.ts
+++ b/src/adapters/telegram/formatting.ts
@@ -98,7 +98,7 @@ function truncateContent(text: string, maxLen = 3800): string {
   return text.slice(0, maxLen) + '\n… (truncated)'
 }
 
-export function formatToolCall(tool: { id: string; name?: string; kind?: string; status?: string; content?: unknown; viewerLinks?: { file?: string; diff?: string } }): string {
+export function formatToolCall(tool: { id: string; name?: string; kind?: string; status?: string; content?: unknown; viewerLinks?: { file?: string; diff?: string }; viewerFilePath?: string }): string {
   const si = STATUS_ICON[tool.status || ''] || '🔧'
   const ki = KIND_ICON[tool.kind || ''] || '🛠️'
   let text = `${si} ${ki} <b>${escapeHtml(tool.name || 'Tool')}</b>`
@@ -106,11 +106,11 @@ export function formatToolCall(tool: { id: string; name?: string; kind?: string;
   if (details) {
     text += `\n<pre>${escapeHtml(truncateContent(details))}</pre>`
   }
-  text += formatViewerLinks(tool.viewerLinks)
+  text += formatViewerLinks(tool.viewerLinks, tool.viewerFilePath)
   return text
 }
 
-export function formatToolUpdate(update: { id: string; name?: string; kind?: string; status: string; content?: unknown; viewerLinks?: { file?: string; diff?: string } }): string {
+export function formatToolUpdate(update: { id: string; name?: string; kind?: string; status: string; content?: unknown; viewerLinks?: { file?: string; diff?: string }; viewerFilePath?: string }): string {
   const si = STATUS_ICON[update.status] || '🔧'
   const ki = KIND_ICON[update.kind || ''] || '🛠️'
   const name = update.name || 'Tool'
@@ -119,15 +119,16 @@ export function formatToolUpdate(update: { id: string; name?: string; kind?: str
   if (details) {
     text += `\n<pre>${escapeHtml(truncateContent(details))}</pre>`
   }
-  text += formatViewerLinks(update.viewerLinks)
+  text += formatViewerLinks(update.viewerLinks, update.viewerFilePath)
   return text
 }
 
-function formatViewerLinks(links?: { file?: string; diff?: string }): string {
+function formatViewerLinks(links?: { file?: string; diff?: string }, filePath?: string): string {
   if (!links) return ''
-  let text = ''
-  if (links.file) text += `\n📄 <a href="${escapeHtml(links.file)}">View file</a>`
-  if (links.diff) text += `\n📝 <a href="${escapeHtml(links.diff)}">View diff</a>`
+  const fileName = filePath ? filePath.split('/').pop() || filePath : ''
+  let text = '\n'
+  if (links.file) text += `\n📄 <a href="${escapeHtml(links.file)}">View ${escapeHtml(fileName || 'file')}</a>`
+  if (links.diff) text += `\n📝 <a href="${escapeHtml(links.diff)}">View diff${fileName ? ` — ${escapeHtml(fileName)}` : ''}</a>`
   return text
 }
 

--- a/src/core/agent-instance.ts
+++ b/src/core/agent-instance.ts
@@ -322,6 +322,8 @@ export class AgentInstance {
               kind: update.kind ?? undefined,
               status: update.status ?? "pending",
               content: update.content ?? undefined,
+              rawInput: (update as any).rawInput ?? undefined,
+              meta: (update as any)._meta ?? undefined,
             };
             break;
           case "tool_call_update":
@@ -330,6 +332,8 @@ export class AgentInstance {
               id: update.toolCallId,
               status: update.status ?? "pending",
               content: update.content ?? undefined,
+              rawInput: (update as any).rawInput ?? undefined,
+              meta: (update as any)._meta ?? undefined,
             };
             break;
           case "plan":

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -320,7 +320,7 @@ export class OpenACPCore {
       "enrichWithViewerLinks: inspecting event",
     );
 
-    const fileInfo = extractFileInfo(name, kind, event.content);
+    const fileInfo = extractFileInfo(name, kind, event.content, event.rawInput, event.meta);
     if (!fileInfo) return;
 
     log.info(
@@ -359,6 +359,7 @@ export class OpenACPCore {
 
     if (Object.keys(viewerLinks).length > 0) {
       metadata.viewerLinks = viewerLinks;
+      metadata.viewerFilePath = fileInfo.filePath;
     }
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -56,6 +56,8 @@ export type AgentEvent =
       status: string;
       content?: unknown;
       locations?: unknown;
+      rawInput?: unknown;
+      meta?: unknown;
     }
   | {
       type: "tool_update";
@@ -63,6 +65,8 @@ export type AgentEvent =
       status: string;
       content?: unknown;
       locations?: unknown;
+      rawInput?: unknown;
+      meta?: unknown;
     }
   | { type: "plan"; entries: PlanEntry[] }
   | {

--- a/src/tunnel/extract-file-info.ts
+++ b/src/tunnel/extract-file-info.ts
@@ -13,19 +13,47 @@ export interface FileInfo {
  * - Text block: { type: "text", text: "..." }
  * - rawInput: { file_path: "...", content: "..." }
  */
-export function extractFileInfo(name: string, kind: string | undefined, content: unknown): FileInfo | null {
-  if (!content) return null
-
+export function extractFileInfo(
+  name: string,
+  kind: string | undefined,
+  content: unknown,
+  rawInput?: unknown,
+  meta?: unknown,
+): FileInfo | null {
   // Only process file-related tool kinds
   if (kind && !['read', 'edit', 'write'].includes(kind)) return null
 
-  // Try to extract from known ACP content patterns
-  const info = parseContent(content)
+  let info: Partial<FileInfo> | null = null
+
+  // 1. Try _meta.claudeCode.toolResponse.file (Claude Code puts raw file data here)
+  if (meta) {
+    const m = meta as any
+    const file = m?.claudeCode?.toolResponse?.file
+    if (file?.filePath && file?.content) {
+      info = { filePath: file.filePath, content: file.content }
+    }
+  }
+
+  // 2. Try rawInput for file path + content from regular content
+  if (!info && rawInput) {
+    const ri = rawInput as any
+    const filePath = ri?.file_path || ri?.filePath || ri?.path
+    if (typeof filePath === 'string') {
+      // Try to get content from the content field
+      const parsed = content ? parseContent(content) : null
+      info = { filePath, content: parsed?.content || ri?.content }
+    }
+  }
+
+  // 3. Try to extract from known ACP content patterns
+  if (!info && content) {
+    info = parseContent(content)
+  }
+
   if (!info) return null
 
   // Infer file path from tool name if not in content
   if (!info.filePath) {
-    // Some agents put the path in the tool name (e.g., "Read src/main.ts" or "Write index.html")
     const pathMatch = name.match(/(?:Read|Edit|Write|View)\s+(.+)/i)
     if (pathMatch) info.filePath = pathMatch[1].trim()
   }

--- a/src/tunnel/templates/file-viewer.ts
+++ b/src/tunnel/templates/file-viewer.ts
@@ -58,6 +58,7 @@ export function renderFileViewer(entry: ViewerEntry): string {
       ${formatBreadcrumb(fileName)}
     </div>
     <div class="actions">
+      ${lang === 'markdown' ? '<button class="btn" onclick="togglePreview()" id="btn-preview">Preview</button>' : ''}
       <button class="btn" onclick="toggleWordWrap()" id="btn-wrap">Wrap</button>
       <button class="btn" onclick="toggleMinimap()" id="btn-minimap">Minimap</button>
       <button class="btn" onclick="toggleTheme()" id="btn-theme">Light</button>
@@ -65,11 +66,15 @@ export function renderFileViewer(entry: ViewerEntry): string {
     </div>
   </div>
   <div id="editor-container"></div>
+  <div id="preview-wrapper" style="display:none; flex:1; overflow-y:auto;">
+    <div id="preview-container" style="padding:24px 48px; max-width:900px; margin:0 auto; width:100%;"></div>
+  </div>
   <div class="status-bar">
     <span>${escapeHtml(entry.language || 'plaintext')} | ${entry.content.split('\n').length} lines</span>
     <span>OpenACP Viewer (read-only)</span>
   </div>
 
+  ${lang === 'markdown' ? '<script src="https://cdn.jsdelivr.net/npm/marked@15.0.0/marked.min.js"></script>' : ''}
   <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/loader.js"></script>
   <script>
     const content = ${safeContent};
@@ -139,7 +144,47 @@ export function renderFileViewer(entry: ViewerEntry): string {
         setTimeout(() => btn.textContent = 'Copy', 2000);
       });
     }
+
+    let previewMode = false;
+    function togglePreview() {
+      previewMode = !previewMode;
+      const editorEl = document.getElementById('editor-container');
+      const wrapperEl = document.getElementById('preview-wrapper');
+      const previewEl = document.getElementById('preview-container');
+      const btn = document.getElementById('btn-preview');
+      if (previewMode) {
+        editorEl.style.display = 'none';
+        wrapperEl.style.display = 'block';
+        previewEl.innerHTML = typeof marked !== 'undefined' ? marked.parse(content) : content.replace(/\\n/g, '<br>');
+        previewEl.style.color = isDark ? '#d4d4d4' : '#1e1e1e';
+        wrapperEl.style.background = isDark ? '#1e1e1e' : '#ffffff';
+        btn.classList.add('active');
+        btn.textContent = 'Editor';
+      } else {
+        editorEl.style.display = 'block';
+        wrapperEl.style.display = 'none';
+        btn.classList.remove('active');
+        btn.textContent = 'Preview';
+      }
+    }
   </script>
+  <style>
+    #preview-container { font-size: 15px; line-height: 1.7; }
+    #preview-container h1 { font-size: 2em; margin: 0.5em 0 0.3em; border-bottom: 1px solid #3c3c3c; padding-bottom: 0.3em; }
+    #preview-container h2 { font-size: 1.5em; margin: 0.5em 0 0.3em; border-bottom: 1px solid #3c3c3c; padding-bottom: 0.2em; }
+    #preview-container h3 { font-size: 1.25em; margin: 0.4em 0 0.2em; }
+    #preview-container p { margin: 0.5em 0; }
+    #preview-container code { background: rgba(128,128,128,0.2); padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+    #preview-container pre { background: rgba(0,0,0,0.3); padding: 16px; border-radius: 6px; overflow-x: auto; margin: 0.5em 0; }
+    #preview-container pre code { background: none; padding: 0; }
+    #preview-container blockquote { border-left: 3px solid #505050; padding-left: 16px; margin: 0.5em 0; color: #969696; }
+    #preview-container ul, #preview-container ol { padding-left: 24px; margin: 0.5em 0; }
+    #preview-container table { border-collapse: collapse; margin: 0.5em 0; width: 100%; }
+    #preview-container th, #preview-container td { border: 1px solid #3c3c3c; padding: 6px 12px; text-align: left; }
+    #preview-container th { background: rgba(128,128,128,0.15); }
+    #preview-container a { color: #3794ff; }
+    #preview-container img { max-width: 100%; }
+  </style>
 </body>
 </html>`
 }

--- a/src/tunnel/tunnel-service.ts
+++ b/src/tunnel/tunnel-service.ts
@@ -25,31 +25,48 @@ export class TunnelService {
   }
 
   async start(): Promise<string> {
-    // 1. Start HTTP server
+    // 1. Start HTTP server — try configured port, then auto-increment up to 10 times
     const authToken = this.config.auth.enabled ? this.config.auth.token : undefined
     const app = createTunnelServer(this.store, authToken)
 
-    this.server = serve({ fetch: app.fetch, port: this.config.port })
-    // Wait for server to be listening or fail
-    await new Promise<void>((resolve, reject) => {
-      this.server!.on('listening', () => resolve())
-      this.server!.on('error', (err: NodeJS.ErrnoException) => reject(err))
-    }).catch((err) => {
-      log.warn({ err: err.message, port: this.config.port }, 'Tunnel HTTP server failed to start')
-      this.server = null
+    let actualPort = this.config.port
+    const maxRetries = 10
+
+    for (let i = 0; i < maxRetries; i++) {
+      const port = this.config.port + i
+      const server = serve({ fetch: app.fetch, port })
+
+      const ok = await new Promise<boolean>((resolve) => {
+        server.on('listening', () => resolve(true))
+        server.on('error', () => resolve(false))
+      })
+
+      if (ok) {
+        this.server = server
+        actualPort = port
+        if (i > 0) {
+          log.info({ configuredPort: this.config.port, actualPort }, 'Configured port in use, using next available')
+        }
+        log.info({ port: actualPort }, 'Tunnel HTTP server started')
+        break
+      }
+
+      server.close()
+    }
+
+    if (!this.server) {
+      log.warn({ port: this.config.port }, 'Could not find available port for tunnel HTTP server')
       this.publicUrl = `http://localhost:${this.config.port}`
-      return
-    })
-    if (!this.server) return this.publicUrl
-    log.info({ port: this.config.port }, 'Tunnel HTTP server started')
+      return this.publicUrl
+    }
 
     // 2. Start tunnel provider
     try {
-      this.publicUrl = await this.provider.start(this.config.port)
+      this.publicUrl = await this.provider.start(actualPort)
       log.info({ url: this.publicUrl }, 'Tunnel public URL ready')
     } catch (err) {
       log.warn({ err }, 'Tunnel provider failed to start, running without public URL')
-      this.publicUrl = `http://localhost:${this.config.port}`
+      this.publicUrl = `http://localhost:${actualPort}`
     }
 
     return this.publicUrl


### PR DESCRIPTION
## Summary

- **Viewer link extraction**: Pass `_meta` and `rawInput` from ACP events so `extractFileInfo` can get file content from `_meta.claudeCode.toolResponse.file` (where Claude Code stores raw data). Previously viewer links were missing because content was only in `_meta`, not in `event.content`.
- **Markdown preview**: File viewer now shows a "Preview" button for `.md` files — toggles between Monaco editor and rendered markdown (via marked.js CDN). Fixed vertical scrollbar in preview.
- **Viewer link display**: Shows file name in link text (e.g. "View index.html") instead of generic "View file". Extra spacing before links.
- **Port auto-retry**: When configured tunnel port is in use, automatically tries next port (up to 10 attempts) instead of failing silently.

## Files changed

| File | Change |
|------|--------|
| `src/core/types.ts` | Add `rawInput`, `meta` to tool event types |
| `src/core/agent-instance.ts` | Pass `_meta`, `rawInput` through events |
| `src/core/core.ts` | Pass new fields to extractFileInfo, add viewerFilePath to metadata |
| `src/tunnel/extract-file-info.ts` | Extract from `_meta.claudeCode.toolResponse.file` + `rawInput` |
| `src/tunnel/templates/file-viewer.ts` | Markdown preview toggle, scrollbar fix |
| `src/tunnel/tunnel-service.ts` | Port auto-retry loop |
| `src/adapters/telegram/adapter.ts` | Carry forward viewerFilePath in tool state |
| `src/adapters/telegram/formatting.ts` | Show file name in viewer links, spacing |

## Test plan

- [ ] Agent reads file → "View {filename}" link appears in Telegram
- [ ] Click link → Monaco viewer opens
- [ ] Read `.md` file → Preview button visible → renders markdown
- [ ] Port 3100 in use → tunnel starts on 3101 with log message
- [ ] `pnpm build` passes