### PR TITLE
feat(telegram): improve new chat session handling and error management

### DIFF
--- a/src/adapters/telegram/commands.ts
+++ b/src/adapters/telegram/commands.ts
@@ -192,17 +192,34 @@ async function handleNewChat(
     return;
   }
 
-  try {
-    const session = await core.handleNewChat("telegram", String(threadId));
-    if (!session) {
+  // Resolve agent config from existing session/record BEFORE spawning
+  const currentSession = core.sessionManager.getSessionByThread(
+    "telegram",
+    String(threadId),
+  );
+  let agentName: string | undefined;
+  let workspace: string | undefined;
+
+  if (currentSession) {
+    agentName = currentSession.agentName;
+    workspace = currentSession.workingDirectory;
+  } else {
+    const record = core.sessionManager.getRecordByThread("telegram", String(threadId));
+    if (!record || record.status === "cancelled" || record.status === "error") {
       await ctx.reply("No active session in this topic.", {
         parse_mode: "HTML",
       });
       return;
     }
+    agentName = record.agentName;
+    workspace = record.workingDir;
+  }
 
-    const topicName = `🔄 ${session.agentName} — New Chat`;
-    const newThreadId = await createSessionTopic(
+  let newThreadId: number | undefined;
+  try {
+    // Create topic FIRST so threadId is ready before session events fire
+    const topicName = `🔄 ${agentName} — New Chat`;
+    newThreadId = await createSessionTopic(
       botFromCtx(ctx),
       chatId,
       topicName,
@@ -213,6 +230,11 @@ async function handleNewChat(
       parse_mode: "HTML",
     });
 
+    const session = await core.handleNewSession(
+      "telegram",
+      agentName,
+      workspace,
+    );
     session.threadId = String(newThreadId);
 
     // Persist platform mapping for new chat
@@ -235,6 +257,14 @@ async function handleNewChat(
     // Warm up model cache in background while user types
     session.warmup().catch((err) => log.error({ err }, "Warm-up error"));
   } catch (err) {
+    // Clean up orphaned topic if session creation failed
+    if (newThreadId) {
+      try {
+        await ctx.api.deleteForumTopic(chatId, newThreadId);
+      } catch {
+        /* ignore cleanup failures */
+      }
+    }
     const message = err instanceof Error ? err.message : String(err);
     await ctx.reply(`❌ ${escapeHtml(message)}`, { parse_mode: "HTML" });
   }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -140,9 +140,10 @@ export class Session {
 
   async cancel(): Promise<void> {
     this.promptQueue = [];
-    this.status = "cancelled";
     this.log.info("Session cancelled");
     await this.agentInstance.cancel();
+    this.promptRunning = false;
+    this.status = "active";
   }
 
   async destroy(): Promise<void> {


### PR DESCRIPTION
- Enhanced `handleNewChat` to resolve agent configuration from existing sessions or records before creating a new session.
- Implemented cleanup of orphaned topics if session creation fails, ensuring better resource management.
- Updated session cancellation logic to maintain active status during cancellation, improving session state integrity.