### PR TITLE
fix(tunnel): scope /tunnels to current session + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ One message, any channel, any agent.
 [![npm](https://img.shields.io/npm/v/@openacp/cli.svg)](https://www.npmjs.com/package/@openacp/cli)
 [![Twitter Follow](https://img.shields.io/twitter/follow/Open_ACP?style=social)](https://x.com/Open_ACP)
 
-[Getting Started](docs/guide/getting-started.md) | [Agents](docs/guide/agents.md) | [Usage](docs/guide/usage.md) | [Configuration](docs/guide/configuration.md) | [Tunnel](docs/guide/tunnel.md) | [Plugins](docs/guide/plugins.md) | [Development](docs/guide/development.md)
+[Getting Started](docs/guide/getting-started.md) | [Agents](docs/guide/agents.md) | [Usage](docs/guide/usage.md) | [Configuration](docs/guide/configuration.md) | [Plugins](docs/guide/plugins.md) | [Development](docs/guide/development.md)
 
 </div>
 
@@ -77,7 +77,6 @@ OpenACP follows the [Agent Client Protocol (ACP)](https://agentclientprotocol.co
 - **Multi-agent** — Claude Code, Codex, Gemini, Cursor, and [28+ ACP-compatible agents](#supported-agents)
 - **Telegram** — Forum topics, real-time streaming, permission buttons, skill commands
 - **Discord** — Forum/thread-based sessions, slash commands, button interactions
-- **Tunnel & file viewer** — Public file/diff viewer via Cloudflare, ngrok, bore, or Tailscale
 - **Session persistence** — Resume sessions across restarts
 - **Daemon mode** — Background service with auto-start on boot
 - **CLI API** — Create and manage sessions from the terminal
@@ -86,6 +85,16 @@ OpenACP follows the [Agent Client Protocol (ACP)](https://agentclientprotocol.co
 - **Plugin system** — Install channel adapters as npm packages
 - **Structured logging** — Pino with rotation, per-session log files
 - **Self-hosted** — Your keys, your data, your machine
+
+### [Tunnel & Port Forwarding](docs/guide/tunnel.md)
+
+Expose any local port to the internet — dev servers, APIs, static sites. Tunnel is enabled by default with Cloudflare (free, no account needed).
+
+- `/tunnel 3000 my-app` in Telegram or `openacp tunnel add 3000 --label my-app` from CLI
+- `/tunnels` to list active tunnels with public URLs and stop buttons
+- Agents can create tunnels too — say "expose port 5173" and the agent handles it
+- Built-in file/diff viewer — Monaco Editor (VS Code engine) with syntax highlighting, line range links, markdown preview
+- Providers: Cloudflare (default), ngrok, bore, Tailscale Funnel
 
 ## Setup
 

--- a/src/adapters/telegram/commands/tunnel.ts
+++ b/src/adapters/telegram/commands/tunnel.ts
@@ -85,13 +85,24 @@ export async function handleTunnels(
     return;
   }
 
-  const entries = core.tunnelService.listTunnels();
+  // In session topic: show only that session's tunnels. In assistant/other: show all.
+  const threadId = ctx.message?.message_thread_id;
+  let entries = core.tunnelService.listTunnels();
+  let sessionScoped = false;
+
+  if (threadId) {
+    const session = core.sessionManager.getSessionByThread("telegram", String(threadId));
+    if (session) {
+      entries = entries.filter(e => e.sessionId === session.id);
+      sessionScoped = true;
+    }
+  }
 
   if (entries.length === 0) {
-    await ctx.reply(
-      "No active tunnels.\n\nUse <code>/tunnel &lt;port&gt;</code> to create one.",
-      { parse_mode: "HTML" },
-    );
+    const hint = sessionScoped
+      ? "No tunnels for this session.\n\nUse <code>/tunnel &lt;port&gt;</code> to create one."
+      : "No active tunnels.\n\nUse <code>/tunnel &lt;port&gt;</code> to create one.";
+    await ctx.reply(hint, { parse_mode: "HTML" });
     return;
   }
 


### PR DESCRIPTION
## Summary

- `/tunnels` in a **session topic** now shows only tunnels belonging to that session
- `/tunnels` in **assistant topic** (or other non-session context) shows all user tunnels
- README: removed Tunnel from nav heading, added "Tunnel & Port Forwarding" section under Features with link to docs

## Test plan

- [ ] In session topic: `/tunnel 3000 test` then `/tunnels` → shows only port 3000
- [ ] In assistant topic: `/tunnels` → shows all tunnels from all sessions
- [ ] Session with no tunnels: `/tunnels` → "No tunnels for this session"