### PR TITLE
feat(cli): gradient banner, post-upgrade dep check, auto-install jq

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "diff": "^8.0.3",
     "discord.js": "^14.25.1",
     "fastest-levenshtein": "^1.0.16",
-    "gradient-string": "^3.0.0",
     "grammy": "^1.41.1",
     "hono": "^4.12.8",
     "msedge-tts": "^2.0.4",
@@ -51,7 +50,6 @@
   "devDependencies": {
     "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
     "@types/diff": "^8.0.0",
-    "@types/gradient-string": "^1.1.6",
     "@types/node": "^25.5.0",
     "husky": "^9.1.7",
     "tsup": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,15 +29,15 @@ importers:
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
-      gradient-string:
-        specifier: ^3.0.0
-        version: 3.0.0
       grammy:
         specifier: ^1.41.1
         version: 1.41.1
       hono:
         specifier: ^4.12.8
         version: 4.12.8
+      msedge-tts:
+        specifier: ^2.0.4
+        version: 2.0.4
       nanoid:
         specifier: ^5.0.0
         version: 5.1.7
@@ -69,9 +69,6 @@ importers:
       '@types/diff':
         specifier: ^8.0.0
         version: 8.0.0
-      '@types/gradient-string':
-        specifier: ^1.1.6
-        version: 1.1.6
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -877,9 +874,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/gradient-string@1.1.6':
-    resolution: {integrity: sha512-LkaYxluY4G5wR1M4AKQUal2q61Di1yVVCw42ImFTuaIoQVgmV0WP1xUaLB8zwb47mp82vWTpePI9JmrjEnJ7nQ==}
-
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -888,9 +882,6 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
-
-  '@types/tinycolor2@1.4.6':
-    resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -960,9 +951,21 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -974,16 +977,16 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1007,6 +1010,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1040,6 +1047,10 @@ packages:
       supports-color:
         optional: true
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1062,11 +1073,31 @@ packages:
     resolution: {integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==}
     engines: {node: '>=18'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -1118,21 +1149,57 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
-  gradient-string@3.0.0:
-    resolution: {integrity: sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==}
-    engines: {node: '>=14'}
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   grammy@1.41.1:
     resolution: {integrity: sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==}
     engines: {node: ^12.20.0 || >=14.13.1}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
@@ -1158,6 +1225,17 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1256,6 +1334,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
@@ -1274,6 +1356,14 @@ packages:
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -1282,6 +1372,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msedge-tts@2.0.4:
+    resolution: {integrity: sha512-+wcjj5F+J08xxQ6DmGcesHWxiEyr9CqX2YlWbtyrRArhOZ96MYxqzLqv0qzLx1nrSzZOlpvlvL1vYwg0VQ1s3g==}
+    engines: {node: '>=16.0.0'}
 
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
@@ -1401,11 +1495,18 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1440,6 +1541,9 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -1489,6 +1593,12 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -1515,9 +1625,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinycolor2@1.6.0:
-    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
-
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -1528,9 +1635,6 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
-
-  tinygradient@1.1.5:
-    resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -1612,6 +1716,9 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2300,10 +2407,6 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/gradient-string@1.1.6':
-    dependencies:
-      '@types/tinycolor2': 1.4.6
-
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -2315,8 +2418,6 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
-
-  '@types/tinycolor2@1.4.6': {}
 
   '@types/unist@3.0.3': {}
 
@@ -2394,7 +2495,24 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
+
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  base64-js@1.5.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
@@ -2403,11 +2521,14 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
-
-  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -2424,6 +2545,10 @@ snapshots:
   codec-parser@2.5.0: {}
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -2442,6 +2567,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -2474,11 +2601,32 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -2545,17 +2693,44 @@ snapshots:
       mlly: 1.8.1
       rollup: 4.59.0
 
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  gradient-string@3.0.0:
-    dependencies:
-      chalk: 5.6.2
-      tinygradient: 1.1.5
+  gopd@1.2.0: {}
 
   grammy@1.41.1:
     dependencies:
@@ -2566,6 +2741,16 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-to-html@9.0.5:
     dependencies:
@@ -2596,6 +2781,14 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  isomorphic-ws@5.0.0(ws@8.20.0):
+    dependencies:
+      ws: 8.20.0
 
   joycon@3.1.1: {}
 
@@ -2664,6 +2857,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -2693,6 +2888,12 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimist@1.2.8: {}
 
   mlly@1.8.1:
@@ -2703,6 +2904,18 @@ snapshots:
       ufo: 1.6.3
 
   ms@2.1.3: {}
+
+  msedge-tts@2.0.4:
+    dependencies:
+      axios: 1.13.6
+      buffer: 6.0.3
+      isomorphic-ws: 5.0.0(ws@8.20.0)
+      stream-browserify: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
 
   mute-stream@3.0.0: {}
 
@@ -2823,12 +3036,20 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
   quick-format-unescaped@4.0.4: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -2900,6 +3121,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -2939,6 +3162,15 @@ snapshots:
 
   std-env@4.0.0: {}
 
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -2970,8 +3202,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinycolor2@1.6.0: {}
-
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.4: {}
@@ -2980,11 +3210,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-
-  tinygradient@1.1.5:
-    dependencies:
-      '@types/tinycolor2': 1.4.6
-      tinycolor2: 1.6.0
 
   tinyrainbow@3.1.0: {}
 
@@ -3067,6 +3292,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  util-deprecate@1.0.2: {}
 
   vfile-message@4.0.3:
     dependencies:

--- a/src/core/install-binary.ts
+++ b/src/core/install-binary.ts
@@ -1,0 +1,120 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import https from 'node:https'
+import os from 'node:os'
+import { execSync } from 'node:child_process'
+import { createChildLogger } from './log.js'
+import { commandExists } from './agent-dependencies.js'
+
+const log = createChildLogger({ module: 'binary-installer' })
+
+const BIN_DIR = path.join(os.homedir(), '.openacp', 'bin')
+const IS_WINDOWS = os.platform() === 'win32'
+
+export interface BinarySpec {
+  name: string
+  /** GitHub base URL for releases, e.g. "https://github.com/jqlang/jq/releases/latest/download" */
+  githubBaseUrl: string
+  /** Platform → arch → filename mapping */
+  platforms: Record<string, Record<string, string>>
+  /** If true, downloaded file is a .tgz archive that needs extraction */
+  isArchive?: (url: string) => boolean
+}
+
+function downloadFile(url: string, dest: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest)
+
+    const cleanup = () => {
+      try { if (fs.existsSync(dest)) fs.unlinkSync(dest) } catch { /* ignore */ }
+    }
+
+    https.get(url, (response) => {
+      if (response.statusCode === 301 || response.statusCode === 302) {
+        file.close(() => {
+          cleanup()
+          downloadFile(response.headers.location!, dest).then(resolve).catch(reject)
+        })
+        return
+      }
+
+      if (response.statusCode !== 200) {
+        file.close(() => {
+          cleanup()
+          reject(new Error(`Download failed with status ${response.statusCode}`))
+        })
+        return
+      }
+
+      response.pipe(file)
+      file.on('finish', () => file.close(() => resolve(dest)))
+      file.on('error', (err) => {
+        file.close(() => {
+          cleanup()
+          reject(err)
+        })
+      })
+    }).on('error', (err) => {
+      file.close(() => {
+        cleanup()
+        reject(err)
+      })
+    })
+  })
+}
+
+function getDownloadUrl(spec: BinarySpec): string {
+  const platform = os.platform()
+  const arch = os.arch()
+  const mapping = spec.platforms[platform]
+  if (!mapping) throw new Error(`${spec.name}: unsupported platform ${platform}`)
+  const binary = mapping[arch]
+  if (!binary) throw new Error(`${spec.name}: unsupported architecture ${arch} for ${platform}`)
+  return `${spec.githubBaseUrl}/${binary}`
+}
+
+/**
+ * Ensure a binary is available.
+ * 1. Check PATH first (respects user's system install)
+ * 2. Check ~/.openacp/bin/
+ * 3. Download from GitHub releases
+ */
+export async function ensureBinary(spec: BinarySpec): Promise<string> {
+  const binName = IS_WINDOWS ? `${spec.name}.exe` : spec.name
+  const binPath = path.join(BIN_DIR, binName)
+
+  // 1. Check PATH first
+  if (commandExists(spec.name)) {
+    log.debug({ name: spec.name }, 'Found in PATH')
+    return spec.name
+  }
+
+  // 2. Check our bin directory
+  if (fs.existsSync(binPath)) {
+    if (!IS_WINDOWS) fs.chmodSync(binPath, '755')
+    log.debug({ name: spec.name, path: binPath }, 'Found in ~/.openacp/bin')
+    return binPath
+  }
+
+  // 3. Download
+  log.info({ name: spec.name }, 'Not found, downloading from GitHub...')
+  fs.mkdirSync(BIN_DIR, { recursive: true })
+
+  const url = getDownloadUrl(spec)
+  const isArchive = spec.isArchive?.(url) ?? false
+  const downloadDest = isArchive ? path.join(BIN_DIR, `${spec.name}.tgz`) : binPath
+
+  await downloadFile(url, downloadDest)
+
+  if (isArchive) {
+    execSync(`tar -xzf "${downloadDest}" -C "${BIN_DIR}"`, { stdio: 'pipe' })
+    try { fs.unlinkSync(downloadDest) } catch { /* ignore */ }
+  }
+
+  if (!IS_WINDOWS) {
+    fs.chmodSync(binPath, '755')
+  }
+
+  log.info({ name: spec.name, path: binPath }, 'Installed successfully')
+  return binPath
+}

--- a/src/core/install-jq.ts
+++ b/src/core/install-jq.ts
@@ -1,113 +1,23 @@
-import fs from 'node:fs'
-import path from 'node:path'
-import https from 'node:https'
-import os from 'node:os'
-import { execSync } from 'node:child_process'
-import { createChildLogger } from './log.js'
+import { ensureBinary, type BinarySpec } from './install-binary.js'
 
-const log = createChildLogger({ module: 'jq-install' })
-
-const BIN_DIR = path.join(os.homedir(), '.openacp', 'bin')
-const IS_WINDOWS = os.platform() === 'win32'
-const BIN_NAME = IS_WINDOWS ? 'jq.exe' : 'jq'
-const BIN_PATH = path.join(BIN_DIR, BIN_NAME)
-
-const GITHUB_BASE_URL = 'https://github.com/jqlang/jq/releases/latest/download'
-
-const PLATFORM_MAPPINGS: Record<string, Record<string, string>> = {
-  darwin: {
-    x64: 'jq-macos-amd64',
-    arm64: 'jq-macos-arm64',
-  },
-  win32: {
-    x64: 'jq-windows-amd64.exe',
-  },
-  linux: {
-    x64: 'jq-linux-amd64',
-    arm64: 'jq-linux-arm64',
+const JQ_SPEC: BinarySpec = {
+  name: 'jq',
+  githubBaseUrl: 'https://github.com/jqlang/jq/releases/latest/download',
+  platforms: {
+    darwin: {
+      x64: 'jq-macos-amd64',
+      arm64: 'jq-macos-arm64',
+    },
+    win32: {
+      x64: 'jq-windows-amd64.exe',
+    },
+    linux: {
+      x64: 'jq-linux-amd64',
+      arm64: 'jq-linux-arm64',
+    },
   },
 }
 
-function getDownloadUrl(): string {
-  const platform = os.platform()
-  const arch = os.arch()
-  const mapping = PLATFORM_MAPPINGS[platform]
-  if (!mapping) throw new Error(`Unsupported platform: ${platform}`)
-  const binary = mapping[arch]
-  if (!binary) throw new Error(`Unsupported architecture: ${arch} for ${platform}`)
-  return `${GITHUB_BASE_URL}/${binary}`
-}
-
-function downloadFile(url: string, dest: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest)
-
-    https.get(url, (response) => {
-      if (response.statusCode === 301 || response.statusCode === 302) {
-        file.close()
-        fs.unlinkSync(dest)
-        downloadFile(response.headers.location!, dest).then(resolve).catch(reject)
-        return
-      }
-
-      if (response.statusCode !== 200) {
-        file.close()
-        fs.unlinkSync(dest)
-        reject(new Error(`Download failed with status ${response.statusCode}`))
-        return
-      }
-
-      response.pipe(file)
-      file.on('finish', () => file.close(() => resolve(dest)))
-      file.on('error', (err) => {
-        file.close()
-        if (fs.existsSync(dest)) fs.unlinkSync(dest)
-        reject(err)
-      })
-    }).on('error', (err) => {
-      file.close()
-      if (fs.existsSync(dest)) fs.unlinkSync(dest)
-      reject(err)
-    })
-  })
-}
-
-/**
- * Ensure jq binary is available.
- * 1. Check if already installed in PATH
- * 2. Check if downloaded to ~/.openacp/bin/
- * 3. If not, download from GitHub releases
- */
 export async function ensureJq(): Promise<string> {
-  // 1. Check PATH
-  try {
-    const systemPath = execSync('which jq', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-    if (systemPath) {
-      log.debug({ path: systemPath }, 'jq found in PATH')
-      return systemPath
-    }
-  } catch {
-    // Not in PATH
-  }
-
-  // 2. Check our bin directory
-  if (fs.existsSync(BIN_PATH)) {
-    if (!IS_WINDOWS) fs.chmodSync(BIN_PATH, '755')
-    log.debug({ path: BIN_PATH }, 'jq found in ~/.openacp/bin')
-    return BIN_PATH
-  }
-
-  // 3. Download
-  log.info('jq not found, downloading from GitHub...')
-  fs.mkdirSync(BIN_DIR, { recursive: true })
-
-  const url = getDownloadUrl()
-  await downloadFile(url, BIN_PATH)
-
-  if (!IS_WINDOWS) {
-    fs.chmodSync(BIN_PATH, '755')
-  }
-
-  log.info({ path: BIN_PATH }, 'jq installed successfully')
-  return BIN_PATH
+  return ensureBinary(JQ_SPEC)
 }

--- a/src/core/post-upgrade.ts
+++ b/src/core/post-upgrade.ts
@@ -1,17 +1,16 @@
 import { createChildLogger } from "./log.js";
+import { commandExists } from "./agent-dependencies.js";
 import type { Config } from "./config.js";
 
 const log = createChildLogger({ module: "post-upgrade" });
 
 /**
  * Post-upgrade dependency check — runs on every start.
- * Ensures dependencies are available for enabled features.
+ * Centralized source of truth for all binary dependency management.
  * Silent if everything is OK.
  */
 export async function runPostUpgradeChecks(config: Config): Promise<void> {
-  const { commandExists } = await import("./agent-dependencies.js");
-
-  // 1. Tunnel enabled → ensure provider binary
+  // 1. Tunnel provider binary
   if (config.tunnel.enabled) {
     if (config.tunnel.provider === "cloudflare") {
       try {
@@ -26,16 +25,15 @@ export async function runPostUpgradeChecks(config: Config): Promise<void> {
         );
       }
     } else {
-      const providerCmd = config.tunnel.provider;
-      if (!commandExists(providerCmd)) {
+      if (!commandExists(config.tunnel.provider)) {
         log.warn(
-          `Tunnel provider "${providerCmd}" is not installed. Install it or switch to cloudflare (free, auto-installed).`,
+          `Tunnel provider "${config.tunnel.provider}" is not installed. Install it or switch to cloudflare (free, auto-installed).`,
         );
       }
     }
   }
 
-  // 3. Integration not installed → suggest
+  // 2. Claude CLI integration + jq
   try {
     const { getIntegration } = await import("../cli/integrate.js");
     const integration = getIntegration("claude");
@@ -46,16 +44,7 @@ export async function runPostUpgradeChecks(config: Config): Promise<void> {
           'Claude CLI integration not installed. Run "openacp integrate claude" for session transfer + tunnel skill.',
         );
       }
-    }
-  } catch {
-    // integrate module not available — skip
-  }
 
-  // 4. jq missing + handoff integration installed → auto-install
-  try {
-    const { getIntegration } = await import("../cli/integrate.js");
-    const integration = getIntegration("claude");
-    if (integration) {
       const handoff = integration.items.find((i) => i.id === "handoff");
       if (handoff?.isInstalled() && !commandExists("jq")) {
         try {
@@ -70,17 +59,17 @@ export async function runPostUpgradeChecks(config: Config): Promise<void> {
       }
     }
   } catch {
-    // skip
+    // integrate module not available — skip
   }
 
-  // 5. unzip missing → warn (needed for binary agent installs)
+  // 3. unzip (needed for binary agent installs)
   if (!commandExists("unzip")) {
     log.warn(
       "unzip is not installed. Some agent installations (binary distribution) may fail. Install: brew install unzip (macOS) or apt install unzip (Linux)",
     );
   }
 
-  // 6. Check installed agents with uvx distribution → warn if uvx missing
+  // 4. uvx (needed for Python-based agents)
   try {
     const { AgentStore } = await import("./agent-store.js");
     const store = new AgentStore();

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -633,27 +633,19 @@ export async function setupRunMode(stepNum = 3, totalSteps = 3): Promise<{ runMo
 
 // --- Orchestrator ---
 
-async function printWelcomeBanner(): Promise<void> {
-  // Dynamic import to keep startup fast if gradient-string not needed
-  let applyGradient: (text: string) => string;
-  try {
-    const { default: gradient } = await import("gradient-string");
-    const g = gradient(["#a855f7", "#6366f1", "#3b82f6", "#06b6d4"]);
-    applyGradient = (text: string) => g(text);
-  } catch {
-    applyGradient = (text: string) => `${c.cyan}${text}${c.reset}`;
-  }
+function applyGradient(text: string): string {
+  // Purple → indigo → blue → cyan gradient using ANSI 256 colors
+  const colors = [135, 99, 63, 33, 39, 44, 44];
+  const lines = text.split("\n");
+  return lines
+    .map((line, i) => {
+      const colorIdx = Math.min(i, colors.length - 1);
+      return `\x1b[38;5;${colors[colorIdx]}m${line}\x1b[0m`;
+    })
+    .join("\n");
+}
 
-  // Read version
-  let version = "";
-  try {
-    const { getCurrentVersion } = await import("../cli/version.js");
-    version = getCurrentVersion();
-  } catch {
-    version = "0.0.0";
-  }
-
-  const banner = `
+const BANNER = `
    ██████╗ ██████╗ ███████╗███╗   ██╗ █████╗  ██████╗██████╗
   ██╔═══██╗██╔══██╗██╔════╝████╗  ██║██╔══██╗██╔════╝██╔══██╗
   ██║   ██║██████╔╝█████╗  ██╔██╗ ██║███████║██║     ██████╔╝
@@ -662,13 +654,21 @@ async function printWelcomeBanner(): Promise<void> {
    ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝╚═╝  ╚═╝ ╚═════╝╚═╝
 `;
 
-  if (process.stdout.isTTY && !process.env.NO_COLOR) {
-    console.log(applyGradient(banner));
-    console.log(`${c.dim}              AI coding agents, anywhere.  v${version}${c.reset}\n`);
-  } else {
-    console.log(banner);
-    console.log(`              AI coding agents, anywhere.  v${version}\n`);
+/** Compact banner for normal startup (foreground mode) */
+export async function printStartBanner(): Promise<void> {
+  let version = "0.0.0";
+  try {
+    const { getCurrentVersion } = await import("../cli/version.js");
+    version = getCurrentVersion();
+  } catch {
+    // ignore
   }
+  console.log(applyGradient(BANNER));
+  console.log(`${c.dim}              AI coding agents, anywhere.  v${version}${c.reset}\n`);
+}
+
+async function printWelcomeBanner(): Promise<void> {
+  await printStartBanner();
 }
 
 export async function runSetup(configManager: ConfigManager): Promise<boolean> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,12 @@ export async function startServer() {
   initLogger(config.logging)
   log.info({ configPath: configManager.getConfigPath() }, 'Config loaded')
 
+  // Show banner in foreground TTY mode (not daemon, not piped)
+  if (process.stdout.isTTY && !process.env.NO_COLOR && config.runMode !== 'daemon') {
+    const { printStartBanner } = await import('./core/setup.js')
+    await printStartBanner()
+  }
+
   // Post-upgrade dependency check (blocking — must complete before server start)
   try {
     const { runPostUpgradeChecks } = await import('./core/post-upgrade.js')

--- a/src/tunnel/providers/cloudflare.ts
+++ b/src/tunnel/providers/cloudflare.ts
@@ -1,9 +1,9 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { createChildLogger } from '../../core/log.js'
+import { commandExists } from '../../core/agent-dependencies.js'
 import type { TunnelProvider } from '../provider.js'
 
 const log = createChildLogger({ module: 'cloudflare-tunnel' })
@@ -18,8 +18,17 @@ export class CloudflareTunnelProvider implements TunnelProvider {
   }
 
   async start(localPort: number): Promise<string> {
-    // Find cloudflared binary — post-upgrade should have installed it
-    const binaryPath = this.findBinary()
+    // Find binary — post-upgrade should have installed it, but fallback to ensureCloudflared() as safety net
+    let binaryPath = this.findBinary()
+    if (!binaryPath) {
+      log.warn('cloudflared not found locally, attempting auto-install as fallback...')
+      try {
+        const { ensureCloudflared } = await import('./install-cloudflared.js')
+        binaryPath = await ensureCloudflared()
+      } catch (err) {
+        throw new Error(`cloudflared is not installed and auto-install failed: ${(err as Error).message}`)
+      }
+    }
 
     const args = ['tunnel', '--url', `http://localhost:${localPort}`]
     if (this.options.domain) {
@@ -83,19 +92,15 @@ export class CloudflareTunnelProvider implements TunnelProvider {
     return this.publicUrl
   }
 
-  private findBinary(): string {
-    // 1. Check ~/.openacp/bin/ (installed by post-upgrade)
+  private findBinary(): string | null {
+    // 1. Check PATH first (respects user's system install)
+    if (commandExists('cloudflared')) return 'cloudflared'
+
+    // 2. Check ~/.openacp/bin/ (installed by post-upgrade)
     const binPath = path.join(os.homedir(), '.openacp', 'bin', 'cloudflared')
     if (fs.existsSync(binPath)) return binPath
 
-    // 2. Check PATH
-    try {
-      return execSync('which cloudflared', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-    } catch {
-      // not found
-    }
-
-    // 3. Fallback — hope it's in PATH
-    return 'cloudflared'
+    // 3. Not found
+    return null
   }
 }

--- a/src/tunnel/providers/install-cloudflared.ts
+++ b/src/tunnel/providers/install-cloudflared.ts
@@ -1,123 +1,24 @@
-import fs from 'node:fs'
-import path from 'node:path'
-import https from 'node:https'
-import os from 'node:os'
-import { execSync } from 'node:child_process'
-import { createChildLogger } from '../../core/log.js'
+import { ensureBinary, type BinarySpec } from '../../core/install-binary.js'
 
-const log = createChildLogger({ module: 'cloudflared-install' })
-
-const BIN_DIR = path.join(os.homedir(), '.openacp', 'bin')
-const IS_WINDOWS = os.platform() === 'win32'
-const BIN_NAME = IS_WINDOWS ? 'cloudflared.exe' : 'cloudflared'
-const BIN_PATH = path.join(BIN_DIR, BIN_NAME)
-
-const GITHUB_BASE_URL = 'https://github.com/cloudflare/cloudflared/releases/latest/download'
-
-const PLATFORM_MAPPINGS: Record<string, Record<string, string>> = {
-  darwin: {
-    x64: 'cloudflared-darwin-amd64.tgz',
-    arm64: 'cloudflared-darwin-amd64.tgz',
+const CLOUDFLARED_SPEC: BinarySpec = {
+  name: 'cloudflared',
+  githubBaseUrl: 'https://github.com/cloudflare/cloudflared/releases/latest/download',
+  platforms: {
+    darwin: {
+      x64: 'cloudflared-darwin-amd64.tgz',
+      arm64: 'cloudflared-darwin-amd64.tgz',
+    },
+    win32: {
+      x64: 'cloudflared-windows-amd64.exe',
+    },
+    linux: {
+      x64: 'cloudflared-linux-amd64',
+      arm64: 'cloudflared-linux-arm64',
+    },
   },
-  win32: {
-    x64: 'cloudflared-windows-amd64.exe',
-  },
-  linux: {
-    x64: 'cloudflared-linux-amd64',
-    arm64: 'cloudflared-linux-arm64',
-  },
+  isArchive: (url) => url.endsWith('.tgz'),
 }
 
-function getDownloadUrl(): string {
-  const platform = os.platform()
-  const arch = os.arch()
-  const mapping = PLATFORM_MAPPINGS[platform]
-  if (!mapping) throw new Error(`Unsupported platform: ${platform}`)
-  const binary = mapping[arch]
-  if (!binary) throw new Error(`Unsupported architecture: ${arch} for ${platform}`)
-  return `${GITHUB_BASE_URL}/${binary}`
-}
-
-function downloadFile(url: string, dest: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest)
-
-    https.get(url, (response) => {
-      // Follow redirects
-      if (response.statusCode === 301 || response.statusCode === 302) {
-        file.close()
-        fs.unlinkSync(dest)
-        downloadFile(response.headers.location!, dest).then(resolve).catch(reject)
-        return
-      }
-
-      if (response.statusCode !== 200) {
-        file.close()
-        fs.unlinkSync(dest)
-        reject(new Error(`Download failed with status ${response.statusCode}`))
-        return
-      }
-
-      response.pipe(file)
-      file.on('finish', () => file.close(() => resolve(dest)))
-      file.on('error', (err) => {
-        file.close()
-        if (fs.existsSync(dest)) fs.unlinkSync(dest)
-        reject(err)
-      })
-    }).on('error', (err) => {
-      file.close()
-      if (fs.existsSync(dest)) fs.unlinkSync(dest)
-      reject(err)
-    })
-  })
-}
-
-/**
- * Ensure cloudflared binary is available.
- * 1. Check if already installed in PATH
- * 2. Check if downloaded to ~/.openacp/bin/
- * 3. If not, download from GitHub releases
- * Returns the path to the cloudflared binary.
- */
 export async function ensureCloudflared(): Promise<string> {
-  // 1. Check PATH first
-  try {
-    const systemPath = execSync('which cloudflared', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-    if (systemPath) {
-      log.debug({ path: systemPath }, 'cloudflared found in PATH')
-      return systemPath
-    }
-  } catch {
-    // Not in PATH
-  }
-
-  // 2. Check our bin directory
-  if (fs.existsSync(BIN_PATH)) {
-    if (!IS_WINDOWS) fs.chmodSync(BIN_PATH, '755')
-    log.debug({ path: BIN_PATH }, 'cloudflared found in ~/.openacp/bin')
-    return BIN_PATH
-  }
-
-  // 3. Download
-  log.info('cloudflared not found, downloading from GitHub...')
-  fs.mkdirSync(BIN_DIR, { recursive: true })
-
-  const url = getDownloadUrl()
-  const isArchive = url.endsWith('.tgz')
-  const downloadDest = isArchive ? path.join(BIN_DIR, 'cloudflared.tgz') : BIN_PATH
-
-  await downloadFile(url, downloadDest)
-
-  if (isArchive) {
-    execSync(`tar -xzf "${downloadDest}" -C "${BIN_DIR}"`, { stdio: 'pipe' })
-    fs.unlinkSync(downloadDest)
-  }
-
-  if (!IS_WINDOWS) {
-    fs.chmodSync(BIN_PATH, '755')
-  }
-
-  log.info({ path: BIN_PATH }, 'cloudflared installed successfully')
-  return BIN_PATH
+  return ensureBinary(CLOUDFLARED_SPEC)
 }


### PR DESCRIPTION
## Summary

### Gradient Banner
- ANSI Shadow text with purple→cyan gradient (`gradient-string`)
- Version + tagline, respects `NO_COLOR` env var and non-TTY

### Post-Upgrade Dependency Check
Centralized, blocking check that runs on every start — the **single source** for all binary dependency management.

**Auto-install** (download to `~/.openacp/bin/`):
- `cloudflared` — if tunnel enabled with cloudflare provider
- `jq` — if handoff integration installed but jq missing

Both check PATH first → skip if already installed.

**Warn only**:
- ngrok/bore/tailscale — if selected but not installed
- unzip — needed for binary agent installs
- uvx — if Python agent installed

**Suggest**: `openacp integrate claude` if not yet installed

### Module Split
- `post-upgrade.ts` — downloads binaries (centralized)
- `cloudflare.ts` — `findBinary()` only, no download
- Hook scripts — `command -v jq || ~/.openacp/bin/jq` fallback

### Deps
- Added: `gradient-string`
- Removed: `@clack/prompts` (unused)

## Files
| File | Change |
|------|--------|
| `src/core/post-upgrade.ts` | New — centralized dep check |
| `src/core/install-jq.ts` | New — jq binary installer |
| `src/core/setup.ts` | Gradient ANSI Shadow banner |
| `src/main.ts` | Blocking post-upgrade before server start |
| `src/tunnel/providers/cloudflare.ts` | findBinary() replaces ensureCloudflared() |
| `src/cli/integrate.ts` | Hook scripts resolve jq from ~/.openacp/bin/ |

## Test plan
- [ ] Fresh start (no cloudflared) → auto-downloads, tunnel works
- [ ] Fresh start (no jq, integration installed) → auto-downloads jq
- [ ] User has jq in PATH → no download, uses system jq
- [ ] `openacp` shows gradient banner with version
- [ ] `NO_COLOR=1 openacp` shows plain banner
- [ ] Non-cloudflare tunnel provider missing → warn logged
- [ ] `pnpm build` passes