### PR TITLE
fix(tunnel): retry cloudflare tunnel up to 3 times on failure

### DIFF
--- a/src/tunnel/providers/cloudflare.ts
+++ b/src/tunnel/providers/cloudflare.ts
@@ -15,7 +15,27 @@ export class CloudflareTunnelProvider implements TunnelProvider {
   }
 
   async start(localPort: number): Promise<string> {
-    // Auto-install cloudflared if not present
+    const maxRetries = 3
+    let lastError: Error | null = null
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        const url = await this.tryStart(localPort)
+        return url
+      } catch (err) {
+        lastError = err as Error
+        if (attempt < maxRetries) {
+          const delay = attempt * 2000
+          log.warn({ attempt, maxRetries, err: lastError.message }, `Cloudflare tunnel failed, retrying in ${delay / 1000}s...`)
+          await new Promise(r => setTimeout(r, delay))
+        }
+      }
+    }
+
+    throw lastError!
+  }
+
+  private async tryStart(localPort: number): Promise<string> {
     const binaryPath = await ensureCloudflared()
 
     const args = ['tunnel', '--url', `http://localhost:${localPort}`]


### PR DESCRIPTION
## Summary

Cloudflare quick tunnels (trycloudflare.com) sometimes fail with `failed to parse quick Tunnel ID: invalid UUID length: 0` due to intermittent Cloudflare API issues.

Added retry logic: 3 attempts with progressive delay (2s, 4s, 6s). Logs each retry attempt. Only gives up after all retries exhausted.

## Change

`src/tunnel/providers/cloudflare.ts` — split `start()` into `start()` (retry loop) + `tryStart()` (single attempt)

## Test plan

- [ ] Normal start → tunnel connects on first attempt, no retry logs
- [ ] Cloudflare API intermittent failure → retries and succeeds
- [ ] All 3 attempts fail → error propagated correctly