### PR TITLE
fix(archive): rewrite /archive to delete topic and end session

### DIFF
--- a/src/__tests__/archive-session.test.ts
+++ b/src/__tests__/archive-session.test.ts
@@ -9,72 +9,67 @@ function mockCtx(threadId?: number) {
 }
 
 describe("handleArchive", () => {
-  it("shows guidance when no session found in topic", async () => {
-    const ctx = mockCtx(999);
-    const core = {
-      sessionManager: {
-        getSessionByThread: vi.fn(() => undefined),
-      },
-    } as any;
-
-    await handleArchive(ctx, core);
-    expect(ctx.reply).toHaveBeenCalledWith(
-      expect.stringContaining("/archive"),
-      expect.any(Object),
-    );
-  });
-
-  it("shows confirmation prompt when session exists", async () => {
+  it("shows confirmation for active session", async () => {
     const ctx = mockCtx(456);
     const core = {
       sessionManager: {
-        getSessionByThread: vi.fn(() => ({
-          id: "sess-1",
-          status: "active",
-        })),
+        getSessionByThread: vi.fn(() => ({ id: "sess-1", status: "active" })),
+        getRecordByThread: vi.fn(),
       },
     } as any;
 
     await handleArchive(ctx, core);
     expect(ctx.reply).toHaveBeenCalledWith(
-      expect.stringContaining("Archive this session topic"),
+      expect.stringContaining("Archive this session"),
       expect.objectContaining({ reply_markup: expect.any(Object) }),
     );
   });
 
-  it("rejects if session is initializing", async () => {
+  it("shows confirmation for initializing session", async () => {
     const ctx = mockCtx(456);
     const core = {
       sessionManager: {
-        getSessionByThread: vi.fn(() => ({
-          id: "sess-1",
-          status: "initializing",
-        })),
+        getSessionByThread: vi.fn(() => ({ id: "sess-1", status: "initializing" })),
+        getRecordByThread: vi.fn(),
       },
     } as any;
 
     await handleArchive(ctx, core);
     expect(ctx.reply).toHaveBeenCalledWith(
-      expect.stringContaining("wait for session"),
-      expect.any(Object),
+      expect.stringContaining("Archive this session"),
+      expect.objectContaining({ reply_markup: expect.any(Object) }),
     );
   });
 
-  it("rejects finished session with specific message", async () => {
-    const ctx = mockCtx(456);
+  it("shows confirmation for orphan topic (no session, no record)", async () => {
+    const ctx = mockCtx(999);
     const core = {
       sessionManager: {
-        getSessionByThread: vi.fn(() => ({
-          id: "sess-1",
-          status: "finished",
-        })),
+        getSessionByThread: vi.fn(() => undefined),
+        getRecordByThread: vi.fn(() => undefined),
       },
     } as any;
 
     await handleArchive(ctx, core);
     expect(ctx.reply).toHaveBeenCalledWith(
-      expect.stringContaining("session is finished"),
-      expect.any(Object),
+      expect.stringContaining("Archive this session"),
+      expect.objectContaining({ reply_markup: expect.any(Object) }),
+    );
+  });
+
+  it("shows confirmation for stored record (after restart)", async () => {
+    const ctx = mockCtx(456);
+    const core = {
+      sessionManager: {
+        getSessionByThread: vi.fn(() => undefined),
+        getRecordByThread: vi.fn(() => ({ sessionId: "stored-1" })),
+      },
+    } as any;
+
+    await handleArchive(ctx, core);
+    expect(ctx.reply).toHaveBeenCalledWith(
+      expect.stringContaining("Archive this session"),
+      expect.objectContaining({ reply_markup: expect.any(Object) }),
     );
   });
 
@@ -102,23 +97,24 @@ describe("handleArchiveConfirm", () => {
     );
   });
 
-  it("calls core.archiveSession on confirm and sends to new topic", async () => {
+  it("calls core.archiveSession on confirm and notifies", async () => {
     const core = {
-      archiveSession: vi.fn(() => Promise.resolve({ ok: true, newThreadId: "789" })),
+      archiveSession: vi.fn(() => Promise.resolve({ ok: true })),
+      notificationManager: { notifyAll: vi.fn(() => Promise.resolve()) },
     } as any;
     const ctx = {
       callbackQuery: { data: "ar:yes:sess-1" },
       answerCallbackQuery: vi.fn(() => Promise.resolve()),
       editMessageText: vi.fn(() => Promise.resolve()),
-      api: { sendMessage: vi.fn(() => Promise.resolve()) },
     } as any;
 
     await handleArchiveConfirm(ctx, core, 123);
     expect(core.archiveSession).toHaveBeenCalledWith("sess-1");
-    expect(ctx.api.sendMessage).toHaveBeenCalledWith(
-      123,
-      expect.stringContaining("archived"),
-      expect.objectContaining({ message_thread_id: 789 }),
+    expect(core.notificationManager.notifyAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "sess-1",
+        type: "completed",
+      }),
     );
   });
 
@@ -139,79 +135,46 @@ describe("handleArchiveConfirm", () => {
     );
   });
 
-  it("notifies when both edit and topic are gone", async () => {
+  it("handles orphan topic deletion", async () => {
     const core = {
-      archiveSession: vi.fn(() => Promise.resolve({ ok: false, error: "Create failed" })),
-      notificationManager: {
-        notifyAll: vi.fn(() => Promise.resolve()),
-      },
+      notificationManager: { notifyAll: vi.fn(() => Promise.resolve()) },
     } as any;
-    let editCallCount = 0;
     const ctx = {
-      callbackQuery: { data: "ar:yes:sess-1" },
+      callbackQuery: { data: "ar:yes:topic:999" },
       answerCallbackQuery: vi.fn(() => Promise.resolve()),
-      editMessageText: vi.fn(() => {
-        editCallCount++;
-        // First call ("Archiving...") succeeds, second call (error) fails
-        if (editCallCount <= 1) return Promise.resolve();
-        return Promise.reject(new Error("topic deleted"));
+      editMessageText: vi.fn(() => Promise.resolve()),
+      api: { deleteForumTopic: vi.fn(() => Promise.resolve()) },
+    } as any;
+
+    await handleArchiveConfirm(ctx, core, 123);
+    expect(ctx.api.deleteForumTopic).toHaveBeenCalledWith(123, 999);
+    expect(core.notificationManager.notifyAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "system",
+        sessionName: "Orphan topic #999",
+        type: "completed",
       }),
+    );
+  });
+
+  it("notifies on orphan topic delete failure", async () => {
+    const core = {
+      notificationManager: { notifyAll: vi.fn(() => Promise.resolve()) },
+    } as any;
+    const ctx = {
+      callbackQuery: { data: "ar:yes:topic:999" },
+      answerCallbackQuery: vi.fn(() => Promise.resolve()),
+      editMessageText: vi.fn(() => Promise.resolve()),
+      api: { deleteForumTopic: vi.fn(() => Promise.reject(new Error("forbidden"))) },
     } as any;
 
     await handleArchiveConfirm(ctx, core, 123);
     expect(core.notificationManager.notifyAll).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionId: "sess-1",
+        sessionId: "system",
         type: "error",
+        summary: expect.stringContaining("forbidden"),
       }),
     );
-  });
-});
-
-describe("archiveSession (core integration)", () => {
-  function makeCoreArchive(session: any, adapter: any) {
-    return async (sessionId: string) => {
-      if (!session) return { ok: false as const, error: "Session not found" };
-      if (session.status === "initializing") return { ok: false as const, error: "Session is still initializing" };
-      if (session.status !== "active") return { ok: false as const, error: `Session is ${session.status}` };
-      if (!adapter) return { ok: false as const, error: "Adapter not found for session" };
-      try {
-        const result = await adapter.archiveSessionTopic(sessionId);
-        if (!result) return { ok: false as const, error: "Adapter does not support archiving" };
-        return { ok: true as const, newThreadId: result.newThreadId };
-      } catch (err: any) {
-        return { ok: false as const, error: err.message };
-      }
-    };
-  }
-
-  it("returns error for non-existent session", async () => {
-    const archive = makeCoreArchive(null, null);
-    expect(await archive("x")).toEqual({ ok: false, error: "Session not found" });
-  });
-
-  it("returns error for initializing session", async () => {
-    const archive = makeCoreArchive({ status: "initializing" }, {});
-    expect(await archive("x")).toEqual({ ok: false, error: "Session is still initializing" });
-  });
-
-  it("delegates to adapter on success", async () => {
-    const adapter = { archiveSessionTopic: vi.fn(() => Promise.resolve({ newThreadId: "999" })) };
-    const archive = makeCoreArchive({ status: "active" }, adapter);
-    const result = await archive("s1");
-    expect(result).toEqual({ ok: true, newThreadId: "999" });
-    expect(adapter.archiveSessionTopic).toHaveBeenCalledWith("s1");
-  });
-
-  it("returns error when adapter throws", async () => {
-    const adapter = { archiveSessionTopic: vi.fn(() => Promise.reject(new Error("Telegram 403"))) };
-    const archive = makeCoreArchive({ status: "active" }, adapter);
-    expect(await archive("s1")).toEqual({ ok: false, error: "Telegram 403" });
-  });
-
-  it("returns error when adapter returns null", async () => {
-    const adapter = { archiveSessionTopic: vi.fn(() => Promise.resolve(null)) };
-    const archive = makeCoreArchive({ status: "active" }, adapter);
-    expect(await archive("s1")).toEqual({ ok: false, error: "Adapter does not support archiving" });
   });
 });

--- a/src/adapters/telegram/adapter.ts
+++ b/src/adapters/telegram/adapter.ts
@@ -915,37 +915,32 @@ export class TelegramAdapter extends ChannelAdapter<OpenACPCore> {
     await this.skillManager.cleanup(sessionId);
   }
 
-  async archiveSessionTopic(sessionId: string): Promise<{ newThreadId: string } | null> {
+  async archiveSessionTopic(sessionId: string): Promise<void> {
     const core = this.core as OpenACPCore;
     const session = core.sessionManager.getSession(sessionId);
-    if (!session) return null;
+    if (!session) return;
 
     const chatId = this.telegramConfig.chatId;
     const oldTopicId = Number(session.threadId);
 
-    // 1. Set archiving flag — sendMessage will skip while this is true
+    // Set archiving flag — sendMessage will skip while this is true.
+    // Flag stays true until core finishes cancelSession (prevents race window).
     session.archiving = true;
 
-    try {
-      // 2. Finalize any pending draft
-      await this.draftManager.finalize(session.id, this.assistantSession?.id);
+    // Finalize any pending draft
+    await this.draftManager.finalize(session.id, this.assistantSession?.id);
 
-      // 3. Cleanup all trackers
-      this.draftManager.cleanup(session.id);
-      this.toolTracker.cleanup(session.id);
-      await this.skillManager.cleanup(session.id);
-      const tracker = this.sessionTrackers.get(session.id);
-      if (tracker) {
-        tracker.destroy();
-        this.sessionTrackers.delete(session.id);
-      }
-
-      // 4. Delete topic (removes all messages)
-      await deleteSessionTopic(this.bot, chatId, oldTopicId);
-    } finally {
-      session.archiving = false;
+    // Cleanup all trackers
+    this.draftManager.cleanup(session.id);
+    this.toolTracker.cleanup(session.id);
+    await this.skillManager.cleanup(session.id);
+    const tracker = this.sessionTrackers.get(session.id);
+    if (tracker) {
+      tracker.destroy();
+      this.sessionTrackers.delete(session.id);
     }
 
-    return { newThreadId: "" };
+    // Delete topic (removes all messages)
+    await deleteSessionTopic(this.bot, chatId, oldTopicId);
   }
 }

--- a/src/adapters/telegram/commands/session.ts
+++ b/src/adapters/telegram/commands/session.ts
@@ -443,15 +443,17 @@ export async function handleArchiveConfirm(
     try {
       await ctx.api.deleteForumTopic(chatId, topicId);
       core.notificationManager.notifyAll({
-        sessionId: `topic-${topicId}`,
+        sessionId: "system",
+        sessionName: `Orphan topic #${topicId}`,
         type: "completed",
-        summary: "Orphan topic archived and deleted.",
+        summary: `Orphan topic #${topicId} archived and deleted.`,
       });
     } catch (err) {
       core.notificationManager.notifyAll({
-        sessionId: `topic-${topicId}`,
+        sessionId: "system",
+        sessionName: `Orphan topic #${topicId}`,
         type: "error",
-        summary: `Failed to delete topic: ${(err as Error).message}`,
+        summary: `Failed to delete orphan topic #${topicId}: ${(err as Error).message}`,
       });
     }
     return;

--- a/src/core/channel.ts
+++ b/src/core/channel.ts
@@ -49,7 +49,5 @@ export abstract class ChannelAdapter<TCore = unknown> implements IChannelAdapter
   async cleanupSkillCommands(_sessionId: string): Promise<void> {}
 
   // Archive — override in adapters that support topic archiving
-  async archiveSessionTopic(_sessionId: string): Promise<{ newThreadId: string } | null> {
-    return null;
-  }
+  async archiveSessionTopic(_sessionId: string): Promise<void> {}
 }

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -220,6 +220,10 @@ export class OpenACPCore {
           await this.sessionManager.cancelSession(sessionId);
         } catch {
           // Session may already be finished/cancelled
+        } finally {
+          // Clear archiving flag after cancel completes — prevents race window
+          // where agent events try to send to deleted topic
+          session.archiving = false;
         }
       }
 
@@ -228,6 +232,8 @@ export class OpenACPCore {
 
       return { ok: true };
     } catch (err) {
+      // Clear archiving flag on error too
+      if (session) session.archiving = false;
       return { ok: false, error: (err as Error).message };
     }
   }


### PR DESCRIPTION
## Summary
  - **/archive** now fully deletes the topic + all messages and ends the session (previously it recreated the topic
  keeping the session alive)
  - Allow archiving regardless of session status (active, initializing, finished, etc.)
  - Support archiving sessions not loaded in memory (stored records from before bot restart)
  - Support archiving orphan topics that have no session record at all
  - Fix duplicate `archiveSession` method in core.ts (merge artifact)

  ## Test plan
  - [ ] Create a new session with `/new`, send some messages, then `/archive` → topic and all messages deleted
  - [ ] Create a new session with `/new`, immediately `/archive` without sending messages → still works
  - [ ] Restart bot, then `/archive` in an old session topic → works via stored record
  - [ ] `/archive` in an orphan topic (no record) → deletes topic directly