### PR TITLE
fix(tunnel): apply review fixes from PR #171 code review

### DIFF
--- a/src/plugins/tunnel/__tests__/provider-patterns.test.ts
+++ b/src/plugins/tunnel/__tests__/provider-patterns.test.ts
@@ -67,11 +67,10 @@ describe('URL regex patterns', () => {
 })
 
 describe('cloudflared arm64 binary mapping', () => {
-  it('has separate arm64 and amd64 darwin entries', async () => {
-    // Dynamic import to get the spec
-    const mod = await import('../providers/install-cloudflared.js')
-    // Access the spec indirectly by checking the function exists
-    // The fix ensures arm64 != amd64 — verified at the source level
-    expect(mod.ensureCloudflared).toBeDefined()
+  it('darwin arm64 uses native arm64 binary not amd64', async () => {
+    const { CLOUDFLARED_SPEC } = await import('../providers/install-cloudflared.js')
+    expect(CLOUDFLARED_SPEC.platforms.darwin.arm64).toBe('cloudflared-darwin-arm64.tgz')
+    expect(CLOUDFLARED_SPEC.platforms.darwin.arm64).not.toBe('cloudflared-darwin-amd64.tgz')
+    expect(CLOUDFLARED_SPEC.platforms.darwin.x64).toBe('cloudflared-darwin-amd64.tgz')
   })
 })

--- a/src/plugins/tunnel/__tests__/tunnel-registry.test.ts
+++ b/src/plugins/tunnel/__tests__/tunnel-registry.test.ts
@@ -359,6 +359,39 @@ describe('TunnelRegistry — retry logic', () => {
     expect(mockProviderInstances.length).toBe(countBefore)
   })
 
+  it('stop() during mid-flight retry removes the tunnel', async () => {
+    const registry = new TunnelRegistry()
+    await registry.add(3100, { type: 'user', provider: 'cloudflare' })
+
+    // Slow mock for the retry — start() hangs until we resolve
+    let resolveRetry!: (url: string) => void
+    nextMockOverride = () => {
+      const mock = createMockProvider()
+      mock.start = vi.fn().mockReturnValue(
+        new Promise<string>(resolve => { resolveRetry = resolve })
+      )
+      return mock
+    }
+
+    // Crash → schedules retry at 2s
+    mockProviderInstances[0]._simulateCrash(1)
+    expect(registry.get(3100)?.status).toBe('failed')
+
+    // Fire retry timer synchronously — retry() starts but hangs inside add() (slow mock)
+    vi.advanceTimersByTime(2_500)
+
+    // Entry was deleted by retry(); stop() currently finds nothing and returns early (bug)
+    const stopPromise = registry.stop(3100)
+
+    // Resolve the slow add while stop() is pending
+    resolveRetry('https://retry.trycloudflare.com')
+
+    await stopPromise
+
+    // Tunnel must be gone — not re-added by the racing retry
+    expect(registry.get(3100)).toBeNull()
+  })
+
   it('does not retry during shutdown', async () => {
     const registry = new TunnelRegistry()
     await registry.add(3100, { type: 'system', provider: 'cloudflare' })

--- a/src/plugins/tunnel/index.ts
+++ b/src/plugins/tunnel/index.ts
@@ -1,5 +1,6 @@
 import type { OpenACPPlugin, InstallContext } from '../../core/plugin/types.js'
 import type { TunnelConfig } from '../../core/config/config.js'
+import { MAX_RETRIES } from './tunnel-registry.js'
 
 function createTunnelPlugin(): OpenACPPlugin {
   let service: { stop(): Promise<void> } | null = null
@@ -198,7 +199,7 @@ function createTunnelPlugin(): OpenACPPlugin {
             { label: 'System', detail: systemDetail },
             ...userTunnels.map(t => {
               const statusInfo = t.status === 'failed' && t.retryCount > 0
-                ? `${t.status} (retry ${t.retryCount}/${5})`
+                ? `${t.status} (retry ${t.retryCount}/${MAX_RETRIES})`
                 : t.status
               return {
                 label: t.label ?? `Port ${t.port}`,

--- a/src/plugins/tunnel/providers/bore.ts
+++ b/src/plugins/tunnel/providers/bore.ts
@@ -31,18 +31,21 @@ export class BoreTunnelProvider implements TunnelProvider {
     }
 
     return new Promise<string>((resolve, reject) => {
+      let settled = false
+      const settle = (fn: () => void) => { if (!settled) { settled = true; fn() } }
+
       const timeout = setTimeout(() => {
         this.stop()
-        reject(new Error('Bore tunnel timed out after 30s. Is bore installed?'))
+        settle(() => reject(new Error('Bore tunnel timed out after 30s. Is bore installed?')))
       }, 30_000)
 
       try {
         this.child = spawn('bore', args, { stdio: ['ignore', 'pipe', 'pipe'] })
       } catch {
         clearTimeout(timeout)
-        reject(new Error(
+        settle(() => reject(new Error(
           'Failed to start bore. Install it from https://github.com/ekzhang/bore'
-        ))
+        )))
         return
       }
 
@@ -56,7 +59,7 @@ export class BoreTunnelProvider implements TunnelProvider {
           clearTimeout(timeout)
           this.publicUrl = `http://${match[1]}:${match[2]}`
           log.info({ url: this.publicUrl }, 'Bore tunnel ready')
-          resolve(this.publicUrl)
+          settle(() => resolve(this.publicUrl))
         }
       }
 
@@ -65,15 +68,15 @@ export class BoreTunnelProvider implements TunnelProvider {
 
       this.child.on('error', (err) => {
         clearTimeout(timeout)
-        reject(new Error(
+        settle(() => reject(new Error(
           `bore failed to start: ${err.message}. Install it from https://github.com/ekzhang/bore`
-        ))
+        )))
       })
 
       this.child.on('exit', (code) => {
         if (!this.publicUrl) {
           clearTimeout(timeout)
-          reject(new Error(`bore exited with code ${code} before establishing tunnel`))
+          settle(() => reject(new Error(`bore exited with code ${code} before establishing tunnel`)))
         } else {
           log.error({ code }, 'bore exited unexpectedly after establishment')
           this.child = null

--- a/src/plugins/tunnel/providers/cloudflare.ts
+++ b/src/plugins/tunnel/providers/cloudflare.ts
@@ -43,16 +43,19 @@ export class CloudflareTunnelProvider implements TunnelProvider {
     }
 
     return new Promise<string>((resolve, reject) => {
+      let settled = false
+      const settle = (fn: () => void) => { if (!settled) { settled = true; fn() } }
+
       const timeout = setTimeout(() => {
         this.stop()
-        reject(new Error('Cloudflare tunnel timed out after 30s'))
+        settle(() => reject(new Error('Cloudflare tunnel timed out after 30s')))
       }, 30_000)
 
       try {
         this.child = spawn(binaryPath, args, { stdio: ['ignore', 'pipe', 'pipe'] })
       } catch {
         clearTimeout(timeout)
-        reject(new Error(`Failed to start cloudflared at ${binaryPath}`))
+        settle(() => reject(new Error(`Failed to start cloudflared at ${binaryPath}`)))
         return
       }
 
@@ -66,7 +69,7 @@ export class CloudflareTunnelProvider implements TunnelProvider {
           clearTimeout(timeout)
           this.publicUrl = match[0]
           log.info({ url: this.publicUrl }, 'Cloudflare tunnel ready')
-          resolve(this.publicUrl)
+          settle(() => resolve(this.publicUrl))
         }
       }
 
@@ -75,13 +78,13 @@ export class CloudflareTunnelProvider implements TunnelProvider {
 
       this.child.on('error', (err) => {
         clearTimeout(timeout)
-        reject(new Error(`cloudflared failed to start: ${err.message}`))
+        settle(() => reject(new Error(`cloudflared failed to start: ${err.message}`)))
       })
 
       this.child.on('exit', (code) => {
         if (!this.publicUrl) {
           clearTimeout(timeout)
-          reject(new Error(`cloudflared exited with code ${code} before establishing tunnel`))
+          settle(() => reject(new Error(`cloudflared exited with code ${code} before establishing tunnel`)))
         } else {
           // Post-establishment crash
           log.error({ code }, 'cloudflared exited unexpectedly after establishment')

--- a/src/plugins/tunnel/providers/install-cloudflared.ts
+++ b/src/plugins/tunnel/providers/install-cloudflared.ts
@@ -1,6 +1,6 @@
 import { ensureBinary, type BinarySpec } from '../../../core/utils/install-binary.js'
 
-const CLOUDFLARED_SPEC: BinarySpec = {
+export const CLOUDFLARED_SPEC: BinarySpec = {
   name: 'cloudflared',
   githubBaseUrl: 'https://github.com/cloudflare/cloudflared/releases/latest/download',
   platforms: {

--- a/src/plugins/tunnel/providers/ngrok.ts
+++ b/src/plugins/tunnel/providers/ngrok.ts
@@ -33,18 +33,21 @@ export class NgrokTunnelProvider implements TunnelProvider {
     }
 
     return new Promise<string>((resolve, reject) => {
+      let settled = false
+      const settle = (fn: () => void) => { if (!settled) { settled = true; fn() } }
+
       const timeout = setTimeout(() => {
         this.stop()
-        reject(new Error('ngrok tunnel timed out after 30s. Is ngrok installed?'))
+        settle(() => reject(new Error('ngrok tunnel timed out after 30s. Is ngrok installed?')))
       }, 30_000)
 
       try {
         this.child = spawn('ngrok', args, { stdio: ['ignore', 'pipe', 'pipe'] })
       } catch {
         clearTimeout(timeout)
-        reject(new Error(
+        settle(() => reject(new Error(
           'Failed to start ngrok. Install it from https://ngrok.com/download'
-        ))
+        )))
         return
       }
 
@@ -59,7 +62,7 @@ export class NgrokTunnelProvider implements TunnelProvider {
           clearTimeout(timeout)
           this.publicUrl = match[0]
           log.info({ url: this.publicUrl }, 'ngrok tunnel ready')
-          resolve(this.publicUrl)
+          settle(() => resolve(this.publicUrl))
         }
       }
 
@@ -68,15 +71,15 @@ export class NgrokTunnelProvider implements TunnelProvider {
 
       this.child.on('error', (err) => {
         clearTimeout(timeout)
-        reject(new Error(
+        settle(() => reject(new Error(
           `ngrok failed to start: ${err.message}. Install it from https://ngrok.com/download`
-        ))
+        )))
       })
 
       this.child.on('exit', (code) => {
         if (!this.publicUrl) {
           clearTimeout(timeout)
-          reject(new Error(`ngrok exited with code ${code} before establishing tunnel`))
+          settle(() => reject(new Error(`ngrok exited with code ${code} before establishing tunnel`)))
         } else {
           log.error({ code }, 'ngrok exited unexpectedly after establishment')
           this.child = null

--- a/src/plugins/tunnel/providers/tailscale.ts
+++ b/src/plugins/tunnel/providers/tailscale.ts
@@ -37,18 +37,21 @@ export class TailscaleTunnelProvider implements TunnelProvider {
     }
 
     return new Promise<string>((resolve, reject) => {
+      let settled = false
+      const settle = (fn: () => void) => { if (!settled) { settled = true; fn() } }
+
       const timeout = setTimeout(() => {
         this.stop()
-        reject(new Error('Tailscale funnel timed out after 30s. Is tailscale installed?'))
+        settle(() => reject(new Error('Tailscale funnel timed out after 30s. Is tailscale installed?')))
       }, 30_000)
 
       try {
         this.child = spawn('tailscale', args, { stdio: ['ignore', 'pipe', 'pipe'] })
       } catch {
         clearTimeout(timeout)
-        reject(new Error(
+        settle(() => reject(new Error(
           'Failed to start tailscale. Install it from https://tailscale.com/download'
-        ))
+        )))
         return
       }
 
@@ -63,7 +66,7 @@ export class TailscaleTunnelProvider implements TunnelProvider {
           clearTimeout(timeout)
           this.publicUrl = match[0]
           log.info({ url: this.publicUrl }, 'Tailscale funnel ready')
-          resolve(this.publicUrl)
+          settle(() => resolve(this.publicUrl))
         }
       }
 
@@ -72,9 +75,9 @@ export class TailscaleTunnelProvider implements TunnelProvider {
 
       this.child.on('error', (err) => {
         clearTimeout(timeout)
-        reject(new Error(
+        settle(() => reject(new Error(
           `tailscale failed to start: ${err.message}. Install it from https://tailscale.com/download`
-        ))
+        )))
       })
 
       this.child.on('exit', (code) => {
@@ -83,10 +86,11 @@ export class TailscaleTunnelProvider implements TunnelProvider {
           if (hostname) {
             // Tailscale funnel may exit immediately after configuring — construct URL with port
             this.publicUrl = `https://${hostname}:${localPort}`
+            this.child = null  // process is done; prevent stop() from sending SIGTERM to dead process
             log.info({ url: this.publicUrl }, 'Tailscale funnel ready (constructed from hostname)')
-            resolve(this.publicUrl)
+            settle(() => resolve(this.publicUrl))
           } else {
-            reject(new Error(`tailscale exited with code ${code} before establishing funnel`))
+            settle(() => reject(new Error(`tailscale exited with code ${code} before establishing funnel`)))
           }
         } else {
           log.error({ code }, 'tailscale exited unexpectedly after establishment')

--- a/src/plugins/tunnel/tunnel-registry.ts
+++ b/src/plugins/tunnel/tunnel-registry.ts
@@ -10,7 +10,7 @@ import { TailscaleTunnelProvider } from './providers/tailscale.js'
 
 const log = createChildLogger({ module: 'tunnel-registry' })
 
-const MAX_RETRIES = 5
+export const MAX_RETRIES = 5
 const BASE_RETRY_DELAY_MS = 2_000
 
 export interface TunnelEntry {


### PR DESCRIPTION
## Summary

Follow-up to #171 — addresses issues found in code review (previously attempted in #173 which was empty due to a git workflow error).

- **settled flag (C2):** Add `settled` boolean to all 4 providers' `start()` Promise. Prevents double-reject when timeout fires SIGTERM → process exits → exit handler calls reject again with wrong error message.
- **Tailscale immediate-exit (I1):** Set `this.child = null` after Tailscale's immediate-exit path. Prevents `stop()` from sending SIGTERM to an already-dead process (5s hang).
- **MAX_RETRIES export (I2):** Export `MAX_RETRIES` from `tunnel-registry.ts` and use it in `/tunnels` command display instead of hardcoded `5`.
- **arm64 test (M1):** Export `CLOUDFLARED_SPEC` and replace the no-op arm64 test with a real assertion verifying `darwin.arm64 = 'cloudflared-darwin-arm64.tgz'`.
- **Regression test:** Add test documenting that `stop()` during mid-flight retry works correctly (no race condition exists — `entries.set()` is synchronous before first await).

## Test plan
- [x] `pnpm test` — all tunnel tests pass
- [x] New regression test: `stop() during mid-flight retry removes the tunnel`
- [x] New regression test: `darwin arm64 uses native arm64 binary not amd64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)