### PR TITLE
fix(api-server): CORS headers for SSE and PUT method

### DIFF
--- a/src/plugins/api-server/server.ts
+++ b/src/plugins/api-server/server.ts
@@ -40,6 +40,7 @@ export async function createApiServer(options: ApiServerOptions): Promise<ApiSer
         cb(null, false);
       }
     },
+    methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
     credentials: true,
   });
   await app.register(fastifyRateLimit, { max: 100, timeWindow: '1 minute' });

--- a/src/plugins/api-server/sse-manager.ts
+++ b/src/plugins/api-server/sse-manager.ts
@@ -65,11 +65,17 @@ export class SSEManager {
     const parsedUrl = new URL(req.url || "", "http://localhost");
     const sessionFilter = parsedUrl.searchParams.get("sessionId");
 
-    res.writeHead(200, {
+    const origin = req.headers.origin;
+    const corsHeaders: Record<string, string> = {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
       Connection: "keep-alive",
-    });
+    };
+    if (origin && (origin.startsWith('http://localhost') || origin.startsWith('http://127.0.0.1'))) {
+      corsHeaders["Access-Control-Allow-Origin"] = origin;
+      corsHeaders["Access-Control-Allow-Credentials"] = "true";
+    }
+    res.writeHead(200, corsHeaders);
     res.flushHeaders();
 
     // Store filter metadata on the response for broadcast


### PR DESCRIPTION
## Summary
- Add explicit `methods` list to `@fastify/cors` config — fixes `Method PUT is not allowed by Access-Control-Allow-Methods` error
- Add `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials` headers to SSE handler — fixes `Origin is not allowed by Access-Control-Allow-Origin` for EventSource connections

SSE handler uses raw `http.ServerResponse` directly, bypassing Fastify's CORS middleware, so CORS headers must be set manually there.

## Test plan
- [ ] `pnpm build` passes
- [ ] UI at `localhost:1420` can connect to SSE endpoint without CORS errors
- [ ] PUT requests (e.g. config/model) work from UI without CORS errors