### PR TITLE
fix: restore apply_patch diff stats/viewer and align tool card rendering

### DIFF
--- a/src/__tests__/extract-file-info.test.ts
+++ b/src/__tests__/extract-file-info.test.ts
@@ -211,5 +211,92 @@ describe('extractFileInfo', () => {
         oldContent: 'old',
       })
     })
+
+    it('extracts apply_patch file info from rawOutput metadata files', () => {
+      const rawOutput = {
+        metadata: {
+          files: [
+            {
+              filePath: '/src/main.ts',
+              before: 'const a = 1',
+              after: 'const a = 2',
+            },
+          ],
+        },
+      }
+
+      const result = extractFileInfo('apply_patch', 'other', null, null, null, rawOutput)
+      expect(result).toMatchObject({
+        filePath: '/src/main.ts',
+        content: 'const a = 2',
+        oldContent: 'const a = 1',
+      })
+    })
+
+    it('returns null for malformed apply_patch rawOutput', () => {
+      const rawOutput = {
+        metadata: {
+          files: [
+            { additions: 1, deletions: 1 },
+            { filePath: 123, after: 456 },
+          ],
+        },
+      }
+
+      const result = extractFileInfo('apply_patch', 'other', null, null, null, rawOutput)
+      expect(result).toBeNull()
+    })
+
+    it('extracts apply_patch rawOutput when tool_update name is missing but patchText exists', () => {
+      const rawInput = { patchText: '*** Begin Patch\n*** Update File: src/main.ts\n*** End Patch' }
+      const rawOutput = {
+        metadata: {
+          files: [
+            {
+              filePath: '/src/main.ts',
+              before: 'const a = 1',
+              after: 'const a = 2',
+            },
+          ],
+        },
+      }
+
+      const result = extractFileInfo('', 'other', null, rawInput, null, rawOutput)
+      expect(result).toMatchObject({
+        filePath: '/src/main.ts',
+        content: 'const a = 2',
+        oldContent: 'const a = 1',
+      })
+    })
+
+    it('prefers apply_patch file with largest diff score for viewer target', () => {
+      const rawOutput = {
+        metadata: {
+          files: [
+            {
+              filePath: '/src/small.ts',
+              before: 'a',
+              after: 'b',
+              additions: 1,
+              deletions: 1,
+            },
+            {
+              filePath: '/src/large.ts',
+              before: 'x',
+              after: 'y',
+              additions: 8,
+              deletions: 3,
+            },
+          ],
+        },
+      }
+
+      const result = extractFileInfo('apply_patch', 'other', null, null, null, rawOutput)
+      expect(result).toMatchObject({
+        filePath: '/src/large.ts',
+        content: 'y',
+        oldContent: 'x',
+      })
+    })
   })
 })

--- a/src/core/__tests__/message-transformer-extended.test.ts
+++ b/src/core/__tests__/message-transformer-extended.test.ts
@@ -283,6 +283,189 @@ describe("MessageTransformer - extended", () => {
     });
   });
 
+  describe("diffStats compatibility", () => {
+    it("extracts apply_patch diffStats from rawOutput.metadata.files", () => {
+      const event: AgentEvent = {
+        type: "tool_call",
+        id: "tc-apply-patch-files",
+        name: "apply_patch",
+        kind: "other",
+        status: "completed",
+        rawOutput: {
+          metadata: {
+            files: [
+              { additions: 4, deletions: 1 },
+              { additions: 3, deletions: 2 },
+            ],
+          },
+        },
+      };
+
+      const result = transformer.transform(event);
+      expect(result.metadata?.diffStats).toEqual({ added: 7, removed: 3 });
+    });
+
+    it("extracts apply_patch diffStats from rawOutput.metadata additions/deletions", () => {
+      const event: AgentEvent = {
+        type: "tool_call",
+        id: "tc-apply-patch-direct",
+        name: "apply_patch",
+        kind: "other",
+        status: "completed",
+        rawOutput: {
+          metadata: {
+            additions: 19,
+            deletions: 7,
+          },
+        },
+      };
+
+      const result = transformer.transform(event);
+      expect(result.metadata?.diffStats).toEqual({ added: 19, removed: 7 });
+    });
+
+    it("keeps rawInput-derived diffStats when already available", () => {
+      const event: AgentEvent = {
+        type: "tool_call",
+        id: "tc-write-existing-diffstats",
+        name: "Write",
+        kind: "write",
+        status: "completed",
+        rawInput: {
+          old_string: "a\nb",
+          new_string: "a\nb\nc",
+        },
+        rawOutput: {
+          metadata: {
+            additions: 99,
+            deletions: 99,
+          },
+        },
+      };
+
+      const result = transformer.transform(event);
+      expect(result.metadata?.diffStats).toEqual({ added: 1, removed: 0 });
+    });
+
+    it("builds viewer links for apply_patch from rawOutput metadata files", () => {
+      const tunnelStore = {
+        storeFile: vi.fn().mockReturnValue("file-id"),
+        storeDiff: vi.fn().mockReturnValue("diff-id"),
+      };
+      const tunnelService = {
+        getPublicUrl: vi.fn().mockReturnValue("https://tunnel.example"),
+        getStore: vi.fn().mockReturnValue(tunnelStore),
+        fileUrl: vi.fn().mockReturnValue("https://tunnel.example/view/file-id"),
+        diffUrl: vi.fn().mockReturnValue("https://tunnel.example/diff/diff-id"),
+      } as any;
+      const t = new MessageTransformer(tunnelService);
+
+      const event: AgentEvent = {
+        type: "tool_call",
+        id: "tc-apply-patch-viewer",
+        name: "apply_patch",
+        kind: "other",
+        status: "completed",
+        rawOutput: {
+          metadata: {
+            files: [
+              {
+                filePath: "/ws/src/main.ts",
+                before: "const a = 1;",
+                after: "const a = 2;",
+                additions: 1,
+                deletions: 1,
+              },
+            ],
+          },
+        },
+      };
+
+      const result = t.transform(event, { id: "sess-1", workingDirectory: "/ws" });
+
+      expect(result.metadata?.diffStats).toEqual({ added: 1, removed: 1 });
+      expect(result.metadata?.viewerLinks).toEqual({
+        file: "https://tunnel.example/view/file-id",
+        diff: "https://tunnel.example/diff/diff-id",
+      });
+      expect(result.metadata?.viewerFilePath).toBe("/ws/src/main.ts");
+    });
+
+    it("handles malformed apply_patch rawOutput safely", () => {
+      const event: AgentEvent = {
+        type: "tool_call",
+        id: "tc-apply-patch-malformed",
+        name: "apply_patch",
+        kind: "other",
+        status: "completed",
+        rawOutput: {
+          metadata: {
+            files: [null, { additions: "x", deletions: -1 }, { filePath: 123 }],
+            additions: "bad",
+            deletions: null,
+          },
+        },
+      };
+
+      const result = transformer.transform(event);
+      expect(result.metadata?.diffStats).toBeUndefined();
+      expect(result.metadata?.viewerLinks).toBeUndefined();
+    });
+
+    it("handles apply_patch tool_update without name using cached patchText", () => {
+      const tunnelStore = {
+        storeFile: vi.fn().mockReturnValue("file-id"),
+        storeDiff: vi.fn().mockReturnValue("diff-id"),
+      };
+      const tunnelService = {
+        getPublicUrl: vi.fn().mockReturnValue("https://tunnel.example"),
+        getStore: vi.fn().mockReturnValue(tunnelStore),
+        fileUrl: vi.fn().mockReturnValue("https://tunnel.example/view/file-id"),
+        diffUrl: vi.fn().mockReturnValue("https://tunnel.example/diff/diff-id"),
+      } as any;
+      const t = new MessageTransformer(tunnelService);
+
+      const callEvent: AgentEvent = {
+        type: "tool_call",
+        id: "tc-apply-patch-update",
+        name: "apply_patch",
+        kind: "other",
+        status: "running",
+        rawInput: {
+          patchText: "*** Begin Patch\n*** Update File: /ws/src/main.ts\n*** End Patch",
+        },
+      };
+      t.transform(callEvent, { id: "sess-1", workingDirectory: "/ws" });
+
+      const updateEvent: AgentEvent = {
+        type: "tool_update",
+        id: "tc-apply-patch-update",
+        kind: "other",
+        status: "completed",
+        rawOutput: {
+          metadata: {
+            files: [
+              {
+                filePath: "/ws/src/main.ts",
+                before: "const a = 1;",
+                after: "const a = 2;",
+                additions: 1,
+                deletions: 1,
+              },
+            ],
+          },
+        },
+      };
+
+      const result = t.transform(updateEvent, { id: "sess-1", workingDirectory: "/ws" });
+      expect(result.metadata?.diffStats).toEqual({ added: 1, removed: 1 });
+      expect(result.metadata?.viewerLinks).toEqual({
+        file: "https://tunnel.example/view/file-id",
+        diff: "https://tunnel.example/diff/diff-id",
+      });
+    });
+  });
+
   describe("enrichWithViewerLinks (tunnel integration)", () => {
     it("does nothing without tunnelService", () => {
       const event: AgentEvent = {

--- a/src/core/adapter-primitives/__tests__/display-spec-builder.test.ts
+++ b/src/core/adapter-primitives/__tests__/display-spec-builder.test.ts
@@ -344,6 +344,8 @@ describe("DisplaySpecBuilder.buildToolSpec", () => {
       });
       const spec = builder.buildToolSpec(entry, "medium");
       expect(spec.title).toBe("/repo/src/app.ts");
+      expect(spec.kind).toBe("edit");
+      expect(spec.icon).toBe("✏️");
     });
 
     it("todowrite title summarizes progress when kind is other", () => {

--- a/src/core/adapter-primitives/display-spec-builder.ts
+++ b/src/core/adapter-primitives/display-spec-builder.ts
@@ -172,24 +172,6 @@ function buildTitle(entry: ToolEntry, kind: string): string {
     return capitalize(entry.name);
   }
 
-  if (nameLower === "todowrite") {
-    const todos = Array.isArray(input.todos) ? input.todos : [];
-    if (todos.length > 0) {
-      const inProgress = todos.filter((t) => {
-        if (!t || typeof t !== "object") return false;
-        const status = (t as Record<string, unknown>).status;
-        return status === "in_progress";
-      }).length;
-      const completed = todos.filter((t) => {
-        if (!t || typeof t !== "object") return false;
-        const status = (t as Record<string, unknown>).status;
-        return status === "completed";
-      }).length;
-      return `Todo list (${completed}/${todos.length} done${inProgress > 0 ? `, ${inProgress} active` : ""})`;
-    }
-    return "Todo list";
-  }
-
   if (kind === "fetch" || kind === "web") {
     const url = typeof input.url === "string" ? input.url : null;
     if (url && url !== "undefined") return url.length > 60 ? url.slice(0, 57) + "..." : url;

--- a/src/core/adapter-primitives/display-spec-builder.ts
+++ b/src/core/adapter-primitives/display-spec-builder.ts
@@ -4,6 +4,7 @@ import { KIND_ICONS } from "./format-types.js";
 import type { OutputMode, ViewerLinks } from "./format-types.js";
 import type { ToolEntry } from "./stream-accumulator.js";
 import type { TunnelServiceInterface } from "../plugin/types.js";
+import { isApplyPatchOtherTool } from "../utils/apply-patch-detection.js";
 
 // ─── Output spec interfaces ────────────────────────────────────────────────
 
@@ -93,6 +94,22 @@ function buildTitle(entry: ToolEntry, kind: string): string {
   const input = asRecord(entry.rawInput);
   const nameLower = entry.name.toLowerCase();
 
+  // apply_patch: keep title parsing based on patchText even when we map display
+  // kind to "edit" for simpler icon/label compatibility.
+  if (isApplyPatchOtherTool(entry.kind, entry.name, entry.rawInput)) {
+    const patchText = getStringField(input, ["patchText", "patch_text"]);
+    if (patchText) {
+      const targets = parseApplyPatchTargets(patchText);
+      if (targets.length === 1) return targets[0];
+      if (targets.length > 1) {
+        const shown = targets.slice(0, 2).join(", ");
+        const rest = targets.length - 2;
+        return rest > 0 ? `${shown} (+${rest} more)` : shown;
+      }
+    }
+    return "apply_patch";
+  }
+
   if (kind === "read") {
     // Support both snake_case (Claude Code) and camelCase (OpenCode) field names
     const filePath = getStringField(input, ["file_path", "filePath", "path"]);
@@ -155,21 +172,6 @@ function buildTitle(entry: ToolEntry, kind: string): string {
     return capitalize(entry.name);
   }
 
-  // Fallbacks for tools that often come through with kind="other"
-  if (nameLower === "apply_patch") {
-    const patchText = getStringField(input, ["patchText", "patch_text"]);
-    if (patchText) {
-      const targets = parseApplyPatchTargets(patchText);
-      if (targets.length === 1) return targets[0];
-      if (targets.length > 1) {
-        const shown = targets.slice(0, 2).join(", ");
-        const remaining = targets.length - 2;
-        return remaining > 0 ? `${shown} (+${remaining} more)` : shown;
-      }
-    }
-    return "apply_patch";
-  }
-
   if (nameLower === "todowrite") {
     const todos = Array.isArray(input.todos) ? input.todos : [];
     if (todos.length > 0) {
@@ -199,22 +201,6 @@ function buildTitle(entry: ToolEntry, kind: string): string {
   // Show skill name for Skill tool calls (e.g. Claude Code's Skill tool)
   if (nameLower === "skill" && typeof input.skill === "string" && input.skill) {
     return input.skill;
-  }
-
-  // apply_patch: well-known tool used by multiple agents (OpenCode, Codex, etc.)
-  // Extract target file paths from the patch text for a meaningful title.
-  if (nameLower === "apply_patch") {
-    const patchText = getStringField(input, ["patchText", "patch_text"]);
-    if (patchText) {
-      const targets = parseApplyPatchTargets(patchText);
-      if (targets.length === 1) return targets[0];
-      if (targets.length > 1) {
-        const shown = targets.slice(0, 2).join(", ");
-        const rest = targets.length - 2;
-        return rest > 0 ? `${shown} (+${rest} more)` : shown;
-      }
-    }
-    return "apply_patch";
   }
 
   // todowrite / TodoWrite: well-known todo list tool (Claude Code, others)
@@ -261,7 +247,7 @@ export class DisplaySpecBuilder {
     mode: OutputMode,
     sessionContext?: { id: string; workingDirectory: string },
   ): ToolDisplaySpec {
-    const effectiveKind = entry.displayKind ?? entry.kind;
+    const effectiveKind = entry.displayKind ?? (isApplyPatchOtherTool(entry.kind, entry.name, entry.rawInput) ? "edit" : entry.kind);
     const icon = KIND_ICONS[effectiveKind] ?? KIND_ICONS["other"] ?? "🛠️";
     const title = buildTitle(entry, effectiveKind);
     const isHidden = entry.isNoise && mode !== "high";

--- a/src/core/message-transformer.ts
+++ b/src/core/message-transformer.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import type { AgentEvent, OutgoingMessage } from "./types.js";
 import type { TunnelServiceInterface } from "./plugin/types.js";
 import { extractFileInfo } from "./utils/extract-file-info.js";
+import { isApplyPatchOtherTool } from "./utils/apply-patch-detection.js";
 import { createChildLogger } from "./utils/log.js";
 
 const log = createChildLogger({ module: "message-transformer" });
@@ -44,6 +45,93 @@ function computeLineDiff(oldStr: string, newStr: string): { added: number; remov
     added: Math.max(0, newLines.length - prefixLen - suffixLen),
     removed: Math.max(0, oldLines.length - prefixLen - suffixLen),
   };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asNonNegativeNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+/**
+ * OpenCode ACP apply_patch may include diff counts in rawOutput.metadata:
+ * - metadata.files[].additions/deletions
+ * - metadata.additions/deletions
+ */
+function extractDiffStatsFromRawOutput(rawOutput: unknown): { added: number; removed: number } | null {
+  const output = asRecord(rawOutput);
+  const metadata = asRecord(output?.metadata);
+  if (!metadata) return null;
+
+  const files = Array.isArray(metadata.files) ? metadata.files : null;
+  if (files && files.length > 0) {
+    let added = 0;
+    let removed = 0;
+    let hasAny = false;
+
+    for (const file of files) {
+      const fileMeta = asRecord(file);
+      if (!fileMeta) continue;
+
+      const fileAdded = asNonNegativeNumber(fileMeta.additions);
+      const fileRemoved = asNonNegativeNumber(fileMeta.deletions);
+      if (fileAdded === null && fileRemoved === null) continue;
+
+      added += fileAdded ?? 0;
+      removed += fileRemoved ?? 0;
+      hasAny = true;
+    }
+
+    if (hasAny && (added > 0 || removed > 0)) return { added, removed };
+  }
+
+  const added = asNonNegativeNumber(metadata.additions);
+  const removed = asNonNegativeNumber(metadata.deletions);
+  if (added === null && removed === null) return null;
+  if ((added ?? 0) === 0 && (removed ?? 0) === 0) return null;
+
+  return {
+    added: added ?? 0,
+    removed: removed ?? 0,
+  };
+}
+
+function extractDiffStatsFromToolPayload(
+  name: string,
+  kind: string | undefined,
+  rawInput: unknown,
+  rawOutput: unknown,
+): { added: number; removed: number } | null {
+  if (kind === "edit" || kind === "write") {
+    const ri = asRecord(rawInput);
+    if (!ri) return null;
+
+    const oldStr = typeof ri.old_string === "string" ? ri.old_string : typeof ri.oldText === "string" ? ri.oldText : null;
+    const newStr = typeof ri.new_string === "string" ? ri.new_string : typeof ri.newText === "string" ? ri.newText : typeof ri.content === "string" ? ri.content : null;
+
+    if (oldStr !== null && newStr !== null) {
+      const stats = computeLineDiff(oldStr, newStr);
+      return stats.added > 0 || stats.removed > 0 ? stats : null;
+    }
+
+    if (oldStr === null && newStr !== null && kind === "write") {
+      // New file creation — no old content, count all new lines as added
+      const added = newStr.split("\n").length;
+      return added > 0 ? { added, removed: 0 } : null;
+    }
+
+    return null;
+  }
+
+  if (isApplyPatchOtherTool(kind, name, rawInput)) {
+    return extractDiffStatsFromRawOutput(rawOutput);
+  }
+
+  return null;
 }
 
 export class MessageTransformer {
@@ -218,24 +306,13 @@ export class MessageTransformer {
     metadata: Record<string, unknown>,
     sessionContext?: { id: string; workingDirectory: string },
   ): void {
-    // Compute diffStats from rawInput even without tunnelService
+    const name = "name" in event ? event.name || "" : "";
+    // Compute diffStats from tool payload even without tunnelService.
+    // Includes edit/write rawInput and apply_patch rawOutput compatibility.
     const kind = "kind" in event ? event.kind : undefined;
-    if (!metadata.diffStats && (kind === "edit" || kind === "write")) {
-      const ri = event.rawInput as Record<string, unknown> | undefined;
-      if (ri) {
-        const oldStr = typeof ri.old_string === "string" ? ri.old_string : typeof ri.oldText === "string" ? ri.oldText : null;
-        const newStr = typeof ri.new_string === "string" ? ri.new_string : typeof ri.newText === "string" ? ri.newText : typeof ri.content === "string" ? ri.content : null;
-        if (oldStr !== null && newStr !== null) {
-          const stats = computeLineDiff(oldStr, newStr);
-          if (stats.added > 0 || stats.removed > 0) {
-            metadata.diffStats = stats;
-          }
-        } else if (oldStr === null && newStr !== null && kind === "write") {
-          // New file creation — no old content, count all new lines as added
-          const added = newStr.split("\n").length;
-          if (added > 0) metadata.diffStats = { added, removed: 0 };
-        }
-      }
+    if (!metadata.diffStats) {
+      const stats = extractDiffStatsFromToolPayload(name, kind, event.rawInput, event.rawOutput);
+      if (stats) metadata.diffStats = stats;
     }
 
     if (!this.tunnelService || !sessionContext) {
@@ -245,8 +322,6 @@ export class MessageTransformer {
       );
       return;
     }
-
-    const name = "name" in event ? event.name || "" : "";
 
     log.debug(
       { name, kind, status: event.status, hasContent: !!event.content, hasRawInput: !!event.rawInput },
@@ -259,6 +334,7 @@ export class MessageTransformer {
       event.content,
       event.rawInput,
       event.meta,
+      event.rawOutput,
     );
     if (!fileInfo) {
       log.debug(

--- a/src/core/utils/apply-patch-detection.ts
+++ b/src/core/utils/apply-patch-detection.ts
@@ -1,0 +1,16 @@
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function hasApplyPatchPatchText(rawInput: unknown): boolean {
+  const input = asRecord(rawInput);
+  return !!input && (typeof input.patchText === "string" || typeof input.patch_text === "string");
+}
+
+export function isApplyPatchOtherTool(kind: string | undefined, name: string, rawInput: unknown): boolean {
+  if (kind !== "other") return false;
+  if (name.toLowerCase() === "apply_patch") return true;
+  return hasApplyPatchPatchText(rawInput);
+}

--- a/src/core/utils/extract-file-info.ts
+++ b/src/core/utils/extract-file-info.ts
@@ -1,3 +1,5 @@
+import { isApplyPatchOtherTool } from './apply-patch-detection.js'
+
 export interface FileInfo {
   filePath: string
   content: string
@@ -12,6 +14,7 @@ export interface FileInfo {
  * - Content wrapper: [{ type: "content", content: { type: "text", text: "..." } }]
  * - Text block: { type: "text", text: "..." }
  * - rawInput: { file_path: "...", content: "..." }
+ * - rawOutput (OpenCode apply_patch): { metadata: { files: [{ filePath, before, after }] } }
  */
 export function extractFileInfo(
   name: string,
@@ -19,8 +22,12 @@ export function extractFileInfo(
   content: unknown,
   rawInput?: unknown,
   meta?: unknown,
+  rawOutput?: unknown,
 ): FileInfo | null {
   // Only process file-related tool kinds
+  if (isApplyPatchOtherTool(kind, name, rawInput)) {
+    return parseApplyPatchRawOutput(rawOutput)
+  }
   if (kind && !['read', 'edit', 'write'].includes(kind)) return null
 
   let info: Partial<FileInfo> | null = null
@@ -98,6 +105,51 @@ export function extractFileInfo(
 
   if (!info.filePath || !info.content) return null
   return info as FileInfo
+}
+
+function parseApplyPatchRawOutput(rawOutput: unknown): FileInfo | null {
+  if (!rawOutput || typeof rawOutput !== 'object' || Array.isArray(rawOutput)) return null
+
+  const output = rawOutput as Record<string, unknown>
+  const metadata = output.metadata
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return null
+
+  const files = (metadata as Record<string, unknown>).files
+  if (!Array.isArray(files)) return null
+
+  const sortedFiles = [...files].sort((a, b) => getApplyPatchFileScore(b) - getApplyPatchFileScore(a))
+
+  for (const file of sortedFiles) {
+    if (!file || typeof file !== 'object' || Array.isArray(file)) continue
+    const f = file as Record<string, unknown>
+
+    const filePath = typeof f.filePath === 'string'
+      ? f.filePath
+      : typeof f.relativePath === 'string'
+        ? f.relativePath
+        : null
+    if (!filePath) continue
+
+    const after = typeof f.after === 'string' ? f.after : null
+    if (!after) continue
+
+    const before = typeof f.before === 'string' ? f.before : undefined
+    return {
+      filePath,
+      content: after,
+      oldContent: before,
+    }
+  }
+
+  return null
+}
+
+function getApplyPatchFileScore(file: unknown): number {
+  if (!file || typeof file !== 'object' || Array.isArray(file)) return 0
+  const f = file as Record<string, unknown>
+  const additions = typeof f.additions === 'number' && Number.isFinite(f.additions) && f.additions >= 0 ? f.additions : 0
+  const deletions = typeof f.deletions === 'number' && Number.isFinite(f.deletions) && f.deletions >= 0 ? f.deletions : 0
+  return additions + deletions
 }
 
 /**


### PR DESCRIPTION
## Summary

Improve apply_patch compatibility for OpenCode-style ACP payloads so Telegram tool cards can consistently show line-change stats and viewer links, including tool_update events that omit the tool name. Also render apply_patch with existing edit-style tool card semantics for simpler, backward-compatible UI behavior.

## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔌 New adapter / plugin
- [ ] 📝 Documentation
- [ ] ♻️ Refactor (no functional change)
- [ ] ⚡ Performance improvement
- [x] 🧪 Tests
- [ ] 🔧 CI / Build / Config

## Changes Made

- Unified diff-stat extraction path in `MessageTransformer` and added a safe apply_patch compatibility branch for `kind=other` payloads.
- Added robust parsing for OpenCode apply_patch `rawOutput.metadata` (`files[].additions/deletions`, optional top-level totals) without affecting non-apply_patch agents.
- Extended `extractFileInfo` with an apply_patch-only early branch (including `patchText`/`patch_text` fallback) so viewer links are generated from `rawOutput.metadata.files[].before/after`.
- Added handling for tool_update cases where `name` is missing by recognizing cached patch text input.
- Updated display-spec behavior so apply_patch `kind=other` reuses edit-style card rendering while preserving patch target title extraction from patch text.
- Added/updated tests covering diffStats compatibility, viewer-link extraction, malformed payload safety, and display-spec mapping.

## Testing

- [x] Ran `pnpm test` — all tests pass
- [ ] Tested manually with: <!-- which platform? Telegram / Discord / Slack -->
- [x] Added new tests for this change
- [ ] No tests needed (explain why)

Test commands executed:
- `pnpm vitest run src/core/adapter-primitives/__tests__/display-spec-builder.test.ts src/core/__tests__/message-transformer-extended.test.ts src/__tests__/extract-file-info.test.ts`
- `pnpm build`

## Platform Impact

- [x] Telegram
- [ ] Discord
- [ ] Slack
- [ ] CLI
- [ ] REST API
- [ ] Web UI
- [x] All / Core

## Screenshots / Recordings

Screenshots(original): 
<img width="992" height="644" alt="1" src="https://github.com/user-attachments/assets/c6f6c7e3-eb08-4927-8363-20edd8a35149" />

Screenshots(after patching):
<img width="994" height="392" alt="2" src="https://github.com/user-attachments/assets/8c99f228-251e-45b7-b2de-ac06a06fa2e8" />


## Checklist

- [x] My code follows the project's TypeScript conventions (ESM, `.js` extensions)
- [ ] I have updated relevant documentation (if needed)
- [x] I have added/updated tests (if applicable)
- [x] My changes don't introduce new warnings or errors
- [x] I have run `pnpm build` successfully
- [x] My changes are backward compatible with existing config and data formats
- [ ] If changing plugin API / PluginContext: I have updated `src/cli/plugin-template/`