### PR TITLE
fix(agents): implement global-to-instance agent fallback chain

### DIFF
--- a/src/core/agents/agent-catalog.ts
+++ b/src/core/agents/agent-catalog.ts
@@ -28,6 +28,7 @@ interface RegistryCache {
 
 export class AgentCatalog {
   private store: AgentStore;
+  private globalStore: AgentStore | null = null;
   private registryAgents: RegistryAgent[] = [];
   private cachePath: string;
   private agentsDir: string | undefined;
@@ -36,10 +37,18 @@ export class AgentCatalog {
     this.store = store ?? new AgentStore();
     this.cachePath = cachePath ?? path.join(os.homedir(), ".openacp", "registry-cache.json");
     this.agentsDir = agentsDir;
+
+    // If the instance store is NOT the global one, load global as fallback
+    const globalPath = path.join(os.homedir(), ".openacp", "agents.json");
+    const storePath = (store as any)?.filePath;
+    if (storePath && path.resolve(storePath) !== path.resolve(globalPath)) {
+      this.globalStore = new AgentStore(globalPath);
+    }
   }
 
   load(): void {
     this.store.load();
+    this.globalStore?.load();
     this.loadRegistryFromCacheOrSnapshot();
     this.enrichInstalledFromRegistry();
   }
@@ -87,18 +96,19 @@ export class AgentCatalog {
     return this.registryAgents.find((a) => getAgentAlias(a.id) === keyOrId);
   }
 
-  // --- Installed ---
+  // --- Installed (instance-first, global-fallback) ---
 
   getInstalled(): InstalledAgent[] {
-    return Object.values(this.store.getInstalled());
+    const merged = { ...this.globalStore?.getInstalled(), ...this.store.getInstalled() };
+    return Object.values(merged);
   }
 
   getInstalledEntries(): Record<string, InstalledAgent> {
-    return this.store.getInstalled();
+    return { ...this.globalStore?.getInstalled(), ...this.store.getInstalled() };
   }
 
   getInstalledAgent(key: string): InstalledAgent | undefined {
-    return this.store.getAgent(key);
+    return this.store.getAgent(key) ?? this.globalStore?.getAgent(key);
   }
 
   // --- Discovery ---

--- a/src/core/agents/agent-store.ts
+++ b/src/core/agents/agent-store.ts
@@ -29,7 +29,7 @@ type AgentStoreData = z.infer<typeof AgentStoreSchema>;
 
 export class AgentStore {
   private data: AgentStoreData = { version: 1, installed: {} };
-  private filePath: string;
+  readonly filePath: string;
 
   constructor(filePath?: string) {
     this.filePath = filePath ?? path.join(os.homedir(), ".openacp", "agents.json");

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -100,6 +100,7 @@ export class OpenACPCore {
       ctx?.paths.agentsDir,
     );
     this.agentCatalog.load();
+
     this.agentManager = new AgentManager(this.agentCatalog);
     const storePath = ctx?.paths.sessions ?? path.join(os.homedir(), ".openacp", "sessions.json");
     this.sessionStore = new JsonFileSessionStore(


### PR DESCRIPTION
## Problem

When users create new workspace instances, agents installed globally (via `openacp setup`) are not available in those workspaces. Each instance has its own `agents.json`, and `instances create` does not copy agents from the global `~/.openacp/agents.json`.

This means:
- User runs setup wizard → installs claude agent globally
- User creates new workspace → `GET /api/v1/agents` returns empty `[]`
- Composer shows "No agents available" — user cannot start a session

## Root Cause

`AgentCatalog` only reads from a single `AgentStore` (the instance-local `agents.json`). There is no inheritance from the global store where `openacp setup` installs agents.

## Solution

Implement a **fallback chain** in `AgentCatalog`: instance agents → global agents.

- On construction, if the instance store path differs from the global path (`~/.openacp/agents.json`), a second `AgentStore` is loaded as fallback
- All lookup methods (`getInstalledAgent`, `getInstalled`, `getInstalledEntries`) check instance first, then fall through to global
- Merge uses spread: `{ ...global, ...instance }` — instance always wins on key collision
- No file copying, no mutation of either store — pure read fallback

## Changes

| File | Change |
|------|--------|
| `src/core/agents/agent-store.ts` | `filePath`: `private` → `readonly` (needed for path comparison) |
| `src/core/agents/agent-catalog.ts` | Load global store as fallback; merge in getters |

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| New workspace, agent installed globally | ❌ Not found | ✅ Found via global fallback |
| Workspace has own agent (same key as global) | ✅ Uses local | ✅ Uses local (instance wins) |
| Global instance (`~/.openacp`) | ✅ Works | ✅ Works (no fallback loaded, same path) |
| No global `agents.json` | N/A | ✅ Graceful — global store loads empty |

## Test Plan

- [ ] Clean install: `rm -rf ~/.openacp && openacp setup --global --workspace /tmp/test --agent claude`
- [ ] Create workspace: `openacp instances create --dir /tmp/test && openacp start --dir /tmp/test --daemon`
- [ ] `GET /api/v1/agents` returns claude agent (from global fallback)
- [ ] Install agent locally in workspace → local version takes precedence
- [ ] Global instance still works normally (no double-loading)