### PR TITLE
feat(comments): add JSDoc and inline comments across codebase

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,19 @@
 #!/usr/bin/env node
 
+// CLI entry point — resolves instance-level flags, then dispatches to subcommands.
+//
+// Flow:
+//   1. Global flags (--dir, --local, --from, --name) are stripped from argv before
+//      Commander sees them, so they work uniformly across all subcommands.
+//   2. Instance root is resolved from flags, CWD traversal, or env var.
+//   3. Global instance migration runs once (backward compat for pre-multi-instance setups).
+//   4. Commands that don't need an instance (update, adopt, instances, dev, -v, -h) run immediately.
+//   5. All other commands get the resolved instance root via a prompt if it wasn't auto-detected.
+
 import { setDefaultAutoSelectFamily } from "node:net";
+// Disable Happy Eyeballs (RFC 6555) — the dual-stack connection racing strategy that node:net
+// enables by default. It causes flaky behaviour in local/containerised environments where
+// IPv6 is advertised but not actually routable, leading to 300ms connection delays.
 setDefaultAutoSelectFamily(false);
 
 import path from 'node:path'
@@ -36,10 +49,20 @@ import {
 } from './cli/commands/index.js'
 import { resolveInstanceRoot } from './core/instance/instance-context.js'
 
+/**
+ * Global instance-targeting flags accepted by every CLI command.
+ *
+ * These are extracted from argv before Commander parses the command,
+ * so they are available uniformly without each subcommand declaring them.
+ */
 export interface InstanceFlags {
+  /** Use the instance in the current working directory (`.openacp/` in CWD). */
   local: boolean
+  /** Explicit path to the workspace directory (parent of `.openacp/`). */
   dir?: string
+  /** Clone a new instance from this source path. */
   from?: string
+  /** Human-readable label for the instance. */
   name?: string
 }
 
@@ -64,10 +87,21 @@ function extractInstanceFlags(args: string[]): { flags: InstanceFlags; remaining
 let resolvedInstanceRoot: string | null = null
 let instanceFlags: InstanceFlags = { local: false }
 
+/**
+ * Returns the instance root resolved during CLI startup.
+ *
+ * Available to subcommands that need the resolved path without re-resolving it.
+ * May be null if the command does not require an instance (e.g., `update`, `adopt`).
+ */
 export function getResolvedInstanceRoot(): string | null {
   return resolvedInstanceRoot
 }
 
+/**
+ * Returns the global instance-targeting flags parsed from argv.
+ *
+ * Useful for subcommands that need to inspect raw flags (e.g., to read `--name`).
+ */
 export function getInstanceFlags(): InstanceFlags {
   return instanceFlags
 }

--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -2,6 +2,9 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
 
+// The daemon writes its bound port to api.port once it is ready to accept requests.
+// The CLI reads this file to discover how to talk to the daemon.
+
 function defaultPortFile(root: string): string {
   return path.join(root, 'api.port')
 }
@@ -13,6 +16,9 @@ function defaultSecretFile(root: string): string {
 /**
  * Poll the api.port file until it appears (daemon has bound its port) or timeout.
  * Returns the port number, or null if the daemon did not start within timeoutMs.
+ *
+ * Used after `openacp start` to wait for the daemon to become ready before
+ * reporting the port in JSON output.
  */
 export async function waitForPortFile(
   portFilePath: string,
@@ -25,9 +31,15 @@ export async function waitForPortFile(
     if (port !== null) return port
     await sleep(intervalMs)
   }
+  // One final attempt at deadline in case the write landed in the last interval
   return readApiPort(portFilePath)
 }
 
+/**
+ * Read the daemon's API port from the port file.
+ * Returns null if the file doesn't exist or contains an invalid value,
+ * which indicates the daemon is not running.
+ */
 export function readApiPort(portFilePath?: string, instanceRoot?: string): number | null {
   const filePath = portFilePath ?? defaultPortFile(instanceRoot!)
   try {
@@ -39,6 +51,10 @@ export function readApiPort(portFilePath?: string, instanceRoot?: string): numbe
   }
 }
 
+/**
+ * Read the shared secret used to authenticate CLI requests to the daemon.
+ * Returns null if the file doesn't exist (daemon not running or API auth disabled).
+ */
 export function readApiSecret(secretFilePath?: string, instanceRoot?: string): string | null {
   const filePath = secretFilePath ?? defaultSecretFile(instanceRoot!)
   try {
@@ -49,6 +65,10 @@ export function readApiSecret(secretFilePath?: string, instanceRoot?: string): s
   }
 }
 
+/**
+ * Remove a stale api.port file left behind by an unclean daemon shutdown.
+ * Stale files cause the CLI to think the daemon is running when it isn't.
+ */
 export function removeStalePortFile(portFilePath?: string, instanceRoot?: string): void {
   const filePath = portFilePath ?? defaultPortFile(instanceRoot!)
   try {
@@ -58,6 +78,12 @@ export function removeStalePortFile(portFilePath?: string, instanceRoot?: string
   }
 }
 
+/**
+ * Make an authenticated HTTP request to the running daemon.
+ *
+ * All daemon API calls go to 127.0.0.1 (loopback only — no external exposure).
+ * The shared secret is injected as a Bearer token for each request.
+ */
 export async function apiCall(
   port: number,
   urlPath: string,

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -4,6 +4,11 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 import { createChildLogger } from '../core/utils/log.js'
 
+// Autostart integrates with the OS process supervisor so the daemon restarts after login.
+// macOS uses launchd (LaunchAgents), Linux uses systemd user units.
+// Each instance gets its own service, identified by instanceId, so multiple instances
+// can coexist without conflicting plist/unit names.
+
 const log = createChildLogger({ module: 'autostart' })
 
 // Legacy paths — no instanceId, used for migration only
@@ -26,10 +31,15 @@ function getSystemdServicePath(instanceId: string): string {
   return path.join(os.homedir(), '.config', 'systemd', 'user', `${getSystemdServiceName(instanceId)}.service`)
 }
 
+/** Returns true if the current platform supports auto-start management. */
 export function isAutoStartSupported(): boolean {
   return process.platform === 'darwin' || process.platform === 'linux'
 }
 
+/**
+ * Escape a string for safe embedding in an XML plist value.
+ * launchd plists are XML — unescaped special chars cause parse failures.
+ */
 export function escapeXml(str: string): string {
   return str
     .replace(/&/g, '&amp;')
@@ -39,6 +49,10 @@ export function escapeXml(str: string): string {
     .replace(/'/g, '&apos;')
 }
 
+/**
+ * Escape a string for safe use as a quoted value in a systemd unit file.
+ * Systemd uses its own escaping rules: backslash, quotes, `$` (env expand), and `%` (specifiers).
+ */
 export function escapeSystemdValue(str: string): string {
   const escaped = str
     .replace(/\\/g, '\\\\')
@@ -48,6 +62,13 @@ export function escapeSystemdValue(str: string): string {
   return `"${escaped}"`
 }
 
+/**
+ * Generate a launchd plist for the given instance.
+ *
+ * The plist starts the daemon via `node <cli> --daemon-child`, with OPENACP_INSTANCE_ROOT
+ * set so the child knows which instance to load. KeepAlive.SuccessfulExit=false means
+ * launchd restarts on crash but not on clean exit (e.g. `openacp stop`).
+ */
 export function generateLaunchdPlist(nodePath: string, cliPath: string, logDir: string, instanceRoot: string, instanceId: string): string {
   const label = getLaunchdLabel(instanceId)
   const logFile = path.join(logDir, 'openacp.log')
@@ -84,6 +105,13 @@ export function generateLaunchdPlist(nodePath: string, cliPath: string, logDir: 
 `
 }
 
+/**
+ * Generate a systemd user unit for the given instance.
+ *
+ * `Restart=on-failure` mirrors launchd's KeepAlive.SuccessfulExit=false behavior —
+ * the daemon is restarted on crash but not after a clean SIGTERM from `openacp stop`.
+ * Uses `WantedBy=default.target` so it activates on user login (not system boot).
+ */
 export function generateSystemdUnit(nodePath: string, cliPath: string, instanceRoot: string, instanceId: string): string {
   const serviceName = getSystemdServiceName(instanceId)
   return `[Unit]
@@ -118,6 +146,13 @@ function migrateLegacy(): void {
   }
 }
 
+/**
+ * Register the daemon as a login-time service for the given instance.
+ *
+ * macOS: writes a LaunchAgent plist and bootstraps it into the user's GUI session.
+ * Linux: writes a systemd user unit, reloads the daemon, and enables the service.
+ * Runs `migrateLegacy()` first to remove the old single-instance service if present.
+ */
 export function installAutoStart(logDir: string, instanceRoot: string, instanceId: string): { success: boolean; error?: string } {
   if (!isAutoStartSupported()) {
     return { success: false, error: 'Auto-start not supported on this platform' }
@@ -168,6 +203,10 @@ export function installAutoStart(logDir: string, instanceRoot: string, instanceI
   }
 }
 
+/**
+ * Remove the login-time service registration for the given instance.
+ * No-op if the service is not installed.
+ */
 export function uninstallAutoStart(instanceId: string): { success: boolean; error?: string } {
   if (!isAutoStartSupported()) {
     return { success: false, error: 'Auto-start not supported on this platform' }
@@ -205,6 +244,7 @@ export function uninstallAutoStart(instanceId: string): { success: boolean; erro
   }
 }
 
+/** Returns true if the login-time service is currently registered for this instance. */
 export function isAutoStartInstalled(instanceId: string): boolean {
   if (process.platform === 'darwin') {
     return fs.existsSync(getLaunchdPlistPath(instanceId))

--- a/src/cli/commands/adopt.ts
+++ b/src/cli/commands/adopt.ts
@@ -3,6 +3,15 @@ import { wantsHelp } from './helpers.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 import { resolveRunningInstance } from '../../core/instance/instance-context.js'
 
+/**
+ * `openacp adopt` — Transfer an existing external agent session into OpenACP.
+ *
+ * Finds the running daemon instance closest to --cwd (via resolveRunningInstance),
+ * then calls the daemon's /api/sessions/adopt endpoint. The daemon creates an OpenACP
+ * session wrapping the external session ID, making it visible in the messaging platform.
+ *
+ * This command is typically called from agent handoff scripts (openacp-handoff.sh).
+ */
 export async function cmdAdopt(args: string[]): Promise<void> {
   if (wantsHelp(args)) {
     console.log(`

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -1,6 +1,7 @@
 import { wantsHelp } from './helpers.js'
 import { isJsonMode, jsonSuccess, jsonError, ErrorCodes, muteForJson } from '../output.js'
 
+/** Create an AgentCatalog bound to the given instance root for install/list operations. */
 async function createCatalog(instanceRoot: string) {
   const { AgentCatalog } = await import("../../core/agents/agent-catalog.js");
   const { AgentStore } = await import("../../core/agents/agent-store.js");
@@ -9,6 +10,12 @@ async function createCatalog(instanceRoot: string) {
   return new AgentCatalog(store, pathMod.join(instanceRoot, 'registry-cache.json'), pathMod.join(instanceRoot, 'agents'));
 }
 
+/**
+ * `openacp agents` — Browse, install, uninstall, and inspect AI coding agents.
+ *
+ * Dispatches to subcommands: install, uninstall, info, run, list, refresh.
+ * Uses fuzzy matching (suggestMatch) to hint at the correct subcommand on typos.
+ */
 export async function cmdAgents(args: string[], instanceRoot?: string): Promise<void> {
   const subcommand = args[0];
 
@@ -145,6 +152,10 @@ async function agentsList(instanceRoot?: string, json = false): Promise<void> {
   console.log("");
 }
 
+/**
+ * Install an agent from the ACP Registry. After installation, automatically installs
+ * the handoff integration if the agent supports it, and prints any setup steps.
+ */
 async function agentsInstall(nameOrId: string | undefined, force: boolean, help = false, instanceRoot?: string, json = false): Promise<void> {
   if (json) await muteForJson()
 
@@ -466,13 +477,14 @@ ACP-specific flags are automatically stripped.
     return;
   }
 
-  // Strip leading "--" separator if present
+  // Strip leading "--" separator if present (convention to pass args through to the agent)
   const userArgs = extraArgs[0] === "--" ? extraArgs.slice(1) : extraArgs;
 
   const { spawnSync } = await import("node:child_process");
   const command = installed.command;
 
   // Include agent's base args (e.g., package name for npx) but strip ACP-specific flags
+  // so running the agent interactively doesn't accidentally enable ACP mode.
   const acpFlags = new Set(["--acp", "acp", "--acp=true", "--experimental-skills"]);
   const baseArgs: string[] = [];
   for (let i = 0; i < installed.args.length; i++) {

--- a/src/cli/commands/api.ts
+++ b/src/cli/commands/api.ts
@@ -67,6 +67,17 @@ function printApiHelp(): void {
 `)
 }
 
+/**
+ * `openacp api` — Interact with the running daemon via its REST API.
+ *
+ * All subcommands require a running daemon. Reads the port from api.port and
+ * sends authenticated HTTP requests. Removes stale port files on connection
+ * failure so subsequent checks correctly report the daemon as offline.
+ *
+ * Subcommands: status, session, new, send, cancel, bypass, session-config,
+ *              topics, delete-topic, cleanup, health, agents, adapters,
+ *              tunnel, config, config set, notify, restart, version
+ */
 export async function cmdApi(args: string[], instanceRoot?: string): Promise<void> {
   const subCmd = args[0]
 
@@ -839,6 +850,9 @@ Shows the version of the currently running daemon process.
   } catch (err) {
     // jsonSuccess/jsonError call process.exit which may throw in certain environments
     if (err instanceof Error && err.message.startsWith('process.exit')) throw err
+    // Node.js wraps low-level TCP errors from fetch() as TypeError with a cause.code —
+    // ECONNREFUSED means the port file exists but nothing is listening on that port (stale).
+    // Remove the port file so the next `openacp start` doesn't refuse to launch.
     if (err instanceof TypeError && (err.cause as Record<string, unknown> | undefined)?.code === 'ECONNREFUSED') {
       if (json) jsonError(ErrorCodes.API_ERROR, 'OpenACP is not running (stale port file)')
       console.error('OpenACP is not running (stale port file)')

--- a/src/cli/commands/attach.ts
+++ b/src/cli/commands/attach.ts
@@ -1,6 +1,12 @@
 import { wantsHelp } from './helpers.js'
 import path from 'node:path'
 
+/**
+ * `openacp attach` — Attach to a running daemon: show status then stream logs.
+ *
+ * Combines `openacp status` output with `tail -f` on the log file.
+ * Exits if the daemon is not running. Press Ctrl+C to detach.
+ */
 export async function cmdAttach(args: string[] = [], instanceRoot?: string): Promise<void> {
   const root = instanceRoot!
   if (wantsHelp(args)) {

--- a/src/cli/commands/autostart.ts
+++ b/src/cli/commands/autostart.ts
@@ -1,6 +1,14 @@
 import path from 'node:path'
 import { wantsHelp } from './helpers.js'
 
+/**
+ * `openacp autostart` — Manage OS-level auto-start for the daemon.
+ *
+ * Subcommands:
+ * - install: registers a LaunchAgent (macOS) or systemd user unit (Linux)
+ * - uninstall: removes the service registration
+ * - status: checks whether the service is currently installed
+ */
 export async function cmdAutostart(args: string[] = [], instanceRoot?: string): Promise<void> {
   const subcommand = args[0]
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -3,6 +3,17 @@ import { readApiPort, apiCall } from '../api-client.js'
 import { wantsHelp, buildNestedUpdateFromPath } from './helpers.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 
+/**
+ * `openacp config` — View and edit the instance configuration.
+ *
+ * Subcommands:
+ * - (bare): opens the interactive TUI config editor
+ * - set <key> <value>: non-interactive path-value update
+ *
+ * When the daemon is running, config set uses the live API (PATCH /api/config)
+ * so changes take effect without restart where possible. When stopped, edits
+ * config.json directly.
+ */
 export async function cmdConfig(args: string[] = [], instanceRoot?: string): Promise<void> {
   const subCmd = args[0] // 'set' or undefined
 

--- a/src/cli/commands/default.ts
+++ b/src/cli/commands/default.ts
@@ -8,6 +8,18 @@ import { printInstanceHint } from '../instance-hint.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 import { resolveInstanceId } from '../resolve-instance-id.js'
 
+/**
+ * The default command — runs when no recognized subcommand is given.
+ *
+ * Behavior:
+ * - If no config exists: runs the setup wizard, then starts the server.
+ * - If config exists and runMode is 'daemon': starts the daemon. If daemon is already
+ *   running, shows an interactive menu (restart, stop, logs, etc.).
+ * - If config exists and runMode is 'foreground' (or --foreground flag): starts the
+ *   server in-process and blocks until shutdown.
+ *
+ * Also handles unknown command detection (typos) before reaching this path.
+ */
 export async function cmdDefault(command: string | undefined, instanceRoot?: string): Promise<void> {
   const args = command ? [command] : []
   const json = isJsonMode(args)
@@ -128,6 +140,10 @@ export async function cmdDefault(command: string | undefined, instanceRoot?: str
   await startServer({ instanceContext: ctx })
 }
 
+/**
+ * Show an interactive menu when the user runs `openacp` and the daemon is already running.
+ * Falls back to a plain text suggestion on non-TTY (scripts, CI).
+ */
 async function showAlreadyRunningMenu(root: string): Promise<void> {
   const { formatInstanceStatus } = await import('./status.js')
 

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -2,6 +2,16 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { wantsHelp } from './helpers.js'
 
+/**
+ * `openacp dev` — Run OpenACP with a local plugin in development mode.
+ *
+ * If the plugin has a tsconfig.json, performs an initial tsc compile before starting.
+ * Unless --no-watch is passed, also spawns `tsc --watch` in the background so TypeScript
+ * errors are surfaced as you edit. The server uses OPENACP_DEV_PLUGIN_PATH to load the
+ * local plugin instead of (or in addition to) installed plugins.
+ *
+ * Sets OPENACP_DEV_LOOP=1 to suppress the update check, which would block the dev loop.
+ */
 export async function cmdDev(args: string[] = []): Promise<void> {
   if (wantsHelp(args)) {
     console.log(`

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,6 +1,13 @@
 import { wantsHelp } from './helpers.js'
 import { isJsonMode, jsonSuccess, muteForJson } from '../output.js'
 
+/**
+ * `openacp doctor` — Run system diagnostics and optionally fix issues.
+ *
+ * In dry-run mode (or with --json), checks are reported but no fixes are applied.
+ * In interactive mode, fixable issues prompt the user before applying.
+ * Exits with code 1 if any check fails.
+ */
 export async function cmdDoctor(args: string[], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,3 +1,8 @@
+/**
+ * Prints the full CLI help text to stdout, covering all commands, flags, and usage examples.
+ *
+ * Called when the user runs `openacp --help` or `openacp -h` with no subcommand.
+ */
 export function printHelp(): void {
   console.log(`
 \x1b[1mOpenACP\x1b[0m — Self-hosted bridge for AI coding agents

--- a/src/cli/commands/helpers.ts
+++ b/src/cli/commands/helpers.ts
@@ -1,7 +1,14 @@
+/** Returns true if the user passed -h or --help in the command arguments. */
 export function wantsHelp(args: string[]): boolean {
   return args.includes('--help') || args.includes('-h')
 }
 
+/**
+ * Convert a dot-notation path and value into a nested object for config updates.
+ *
+ * For example: `buildNestedUpdateFromPath('logging.logDir', '/tmp')` produces
+ * `{ logging: { logDir: '/tmp' } }`, which ConfigManager.save() merges into the config.
+ */
 export function buildNestedUpdateFromPath(dotPath: string, value: unknown): Record<string, unknown> {
   const parts = dotPath.split('.')
   const result: Record<string, unknown> = {}

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -4,6 +4,12 @@ import * as path from 'node:path'
 import { wantsHelp } from './helpers.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 
+/**
+ * `openacp install` — Install an adapter plugin from npm into the instance's plugins directory.
+ *
+ * Initializes the plugins directory and its package.json if they don't exist, then
+ * delegates to `npm install` to fetch and install the package.
+ */
 export async function cmdInstall(args: string[], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/instances.ts
+++ b/src/cli/commands/instances.ts
@@ -10,15 +10,22 @@ import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../
 import { wantsHelp } from './helpers.js'
 
 
+/** Summary entry for a registered instance, used in list and JSON output. */
 export interface InstanceListEntry {
   id: string
   name: string | null
+  /** Parent directory of the .openacp/ folder (the workspace directory). */
   directory: string
+  /** Full path to the .openacp/ folder. */
   root: string
   status: 'running' | 'stopped'
   port: number | null
 }
 
+/**
+ * Build a summary list of all registered instances from the global registry.
+ * Reads live status (PID, API port) directly from each instance root.
+ */
 export async function buildInstanceListEntries(): Promise<InstanceListEntry[]> {
   const registryPath = path.join(getGlobalRoot(), 'instances.json')
   const registry = new InstanceRegistry(registryPath)
@@ -36,6 +43,14 @@ export async function buildInstanceListEntries(): Promise<InstanceListEntry[]> {
   })
 }
 
+/**
+ * `openacp instances` — Manage registered OpenACP instances.
+ *
+ * Subcommands: list, create
+ *
+ * parentFlags carries workspace flags (--dir, --from, --name) that were consumed by
+ * the top-level extractInstanceFlags() parser and must be re-injected for create.
+ */
 export async function cmdInstances(args: string[] = [], parentFlags?: { dir?: string; from?: string; name?: string }): Promise<void> {
   if (wantsHelp(args)) {
     printInstancesHelp()
@@ -102,6 +117,14 @@ async function cmdInstancesList(args: string[]): Promise<void> {
   console.log('')
 }
 
+/**
+ * Create or register an instance at --dir.
+ *
+ * If .openacp already exists: reconciles the ID (config.json vs registry),
+ * applies --name if provided, and warns without overwriting.
+ * If .openacp does not exist: creates it from scratch or clones from --from.
+ * Orphaned registry entries for deleted .openacp directories are cleaned up.
+ */
 export async function cmdInstancesCreate(args: string[]): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/integrate.ts
+++ b/src/cli/commands/integrate.ts
@@ -1,5 +1,11 @@
 import { wantsHelp } from './helpers.js'
 
+/**
+ * `openacp integrate` — Install or remove agent handoff/tunnel integrations.
+ *
+ * Iterates all items in the agent's AgentIntegration and installs or uninstalls each.
+ * Uses suggestMatch for typo hints when the agent name isn't found.
+ */
 export async function cmdIntegrate(args: string[]): Promise<void> {
   if (wantsHelp(args)) {
     console.log(`

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -1,5 +1,11 @@
 import { wantsHelp } from './helpers.js'
 
+/**
+ * `openacp logs` — Tail the daemon log file.
+ *
+ * Reads the log directory from config (falls back to <root>/logs if config is missing),
+ * then spawns `tail -f` to stream the last 50 lines and follow new output.
+ */
 export async function cmdLogs(args: string[] = [], instanceRoot?: string): Promise<void> {
   if (wantsHelp(args)) {
     console.log(`

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -1,5 +1,12 @@
 import * as path from 'node:path'
 
+/**
+ * `openacp onboard` — Re-run the configuration wizard.
+ *
+ * If the instance already has a config, runs `runReconfigure` (update existing settings).
+ * Otherwise runs the full `runSetup` with skipRunMode=true (preserves the current
+ * run mode rather than prompting again).
+ */
 export async function cmdOnboard(instanceRoot?: string): Promise<void> {
   const { ConfigManager } = await import('../../core/config/config.js')
   const { SettingsManager } = await import('../../core/plugin/settings-manager.js')

--- a/src/cli/commands/plugin-create.ts
+++ b/src/cli/commands/plugin-create.ts
@@ -35,8 +35,11 @@ function parseCreateArgs(args: string[]): { name?: string; description?: string;
 }
 
 /**
- * Re-extract --name from process.argv for plugin create, since the top-level
- * extractInstanceFlags() consumes --name as an instance flag.
+ * Re-extract --name from process.argv for plugin create.
+ *
+ * The top-level extractInstanceFlags() in cli.ts consumes --name as a workspace flag,
+ * so by the time cmdPluginCreate receives args it is already stripped. We walk
+ * process.argv directly after the 'create' token to recover it.
  */
 function recoverNameFromProcessArgs(): string | undefined {
   const argv = process.argv
@@ -52,6 +55,16 @@ function recoverNameFromProcessArgs(): string | undefined {
   return undefined
 }
 
+/**
+ * `openacp plugin create` — Scaffold a new OpenACP plugin project.
+ *
+ * Interactive mode: prompts for name, description, author, and license via @clack/prompts.
+ * Non-interactive mode: accepts --name (required) and optional --description, --author,
+ * --license, --output flags.
+ *
+ * Generates: package.json, tsconfig.json, src/index.ts, test file, CLAUDE.md,
+ * PLUGIN_GUIDE.md, README.md, and standard dotfiles.
+ */
 export async function cmdPluginCreate(args: string[] = []): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`

--- a/src/cli/commands/plugin-search.ts
+++ b/src/cli/commands/plugin-search.ts
@@ -1,6 +1,10 @@
 import { RegistryClient } from '../../core/plugin/registry-client.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 
+/**
+ * `openacp plugin search` — Search the OpenACP plugin registry.
+ * Queries the remote registry and displays matching plugins with install instructions.
+ */
 export async function cmdPluginSearch(args: string[]): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -1,6 +1,10 @@
 import { wantsHelp } from './helpers.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 
+/**
+ * `openacp plugins` — List all installed plugins.
+ * Short alias for `openacp plugin list`.
+ */
 export async function cmdPlugins(args: string[] = [], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()
@@ -248,6 +252,8 @@ async function installPlugin(input: string, instanceRoot?: string, json = false)
   const root = instanceRoot!
 
   // Parse input: "translator", "translator@1.2.0", "@lucas/pkg@2.0.0"
+  // Scoped packages require special handling because the first '@' is the scope prefix,
+  // not a version separator — the version '@' comes after the package name.
   let pkgName: string
   let pkgVersion: string | undefined
 

--- a/src/cli/commands/remote.ts
+++ b/src/cli/commands/remote.ts
@@ -5,6 +5,15 @@ import os from 'node:os'
 import qrcode from 'qrcode-terminal'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 
+/**
+ * `openacp remote` — Generate a one-time access code for remote login.
+ *
+ * Creates a short-lived auth code via the daemon's /api/v1/auth/codes endpoint,
+ * then outputs local and tunnel URLs with a QR code for quick scanning on mobile.
+ * The code is single-use and expires after 30 minutes (enforced server-side).
+ *
+ * Requires a running daemon with the API server enabled.
+ */
 export async function cmdRemote(args: string[], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/reset.ts
+++ b/src/cli/commands/reset.ts
@@ -1,5 +1,11 @@
 import { wantsHelp } from './helpers.js'
 
+/**
+ * `openacp reset` — Destructively delete all instance data and restart fresh.
+ *
+ * Requires the daemon to be stopped first. Prompts for confirmation before deletion.
+ * Also removes the autostart service so the deleted instance doesn't get restarted.
+ */
 export async function cmdReset(args: string[] = [], instanceRoot?: string): Promise<void> {
   if (wantsHelp(args)) {
     console.log(`

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -7,6 +7,17 @@ import { createInstanceContext, getGlobalRoot } from '../../core/instance/instan
 import { InstanceRegistry } from '../../core/instance/instance-registry.js'
 import { randomUUID } from 'node:crypto'
 
+/**
+ * `openacp restart` — Stop and restart the daemon.
+ *
+ * Mode selection: explicit --foreground/--daemon flags win; otherwise, if a daemon
+ * was running we restart as daemon, else we honour config.runMode. This logic prevents
+ * a daemon that was started with `openacp start` (runMode='foreground') from accidentally
+ * restarting in foreground mode.
+ *
+ * When restarting as daemon, reinstalls autostart to refresh the node path (handles nvm
+ * version changes between restarts).
+ */
 export async function cmdRestart(args: string[] = [], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -17,6 +17,13 @@ function readConfigField(instanceRoot: string, field: string): string | null {
   } catch { return null }
 }
 
+/**
+ * `openacp setup` — Non-interactive instance initialisation for scripted/programmatic use.
+ *
+ * Writes minimal instance files (config.json with agent and runMode) without running
+ * the interactive wizard. Used by the OpenACP App and CI pipelines to bootstrap instances.
+ * The default instanceName is derived from the workspace directory basename if not given.
+ */
 export async function cmdSetup(args: string[], instanceRoot: string): Promise<void> {
   const agentRaw = parseFlag(args, '--agent');
   const json = args.includes('--json');

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -5,6 +5,13 @@ import { printInstanceHint } from '../instance-hint.js'
 import { resolveInstanceId } from '../resolve-instance-id.js'
 import path from 'node:path'
 
+/**
+ * `openacp start` — Start the daemon in the background.
+ *
+ * Forks a detached child process via startDaemon(), installs the login-time autostart
+ * service, then returns immediately. In JSON mode, waits for the daemon to write api.port
+ * before outputting the result so callers get the actual bound port.
+ */
 export async function cmdStart(args: string[] = [], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()
@@ -52,6 +59,8 @@ Requires an existing config — run 'openacp' first to set up.
       process.exit(1)
     }
     // Install autostart before JSON output (jsonSuccess exits)
+    // instanceId is resolved here so installAutoStart can use it for per-instance
+    // service naming — each workspace gets its own launchd/systemd service entry.
     const instanceId = resolveInstanceId(root)
     try {
       const { installAutoStart } = await import('../autostart.js')

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -5,6 +5,14 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 
+/**
+ * `openacp status` — Show daemon status for one or all instances.
+ *
+ * Supports:
+ * - Default: status of the resolved instance root
+ * - --all: table listing all registry entries
+ * - --id <id>: status of a specific instance by ID
+ */
 export async function cmdStatus(args: string[] = [], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()
@@ -119,15 +127,26 @@ async function showSingleInstance(root: string, json = false): Promise<void> {
   }
 }
 
+/** Runtime information about a single instance, read directly from its data files. */
 export interface InstanceInfo {
   name: string | null
+  /** PID of the running daemon, or null if not running. */
   pid: number | null
   apiPort: number | null
+  /** Port of the system-level tunnel (from tunnels.json), or null if not active. */
   tunnelPort: number | null
   runMode: string | null
+  /** IDs of enabled messaging channel adapters (e.g. ['telegram', 'discord']). */
   channels: string[]
 }
 
+/**
+ * Read instance runtime information directly from the instance root's data files.
+ *
+ * Does not require the daemon to be running — reads config.json, openacp.pid,
+ * api.port, tunnels.json, and plugins.json from disk. Uses `process.kill(pid, 0)`
+ * as a liveness check for the recorded PID.
+ */
 export function readInstanceInfo(root: string): InstanceInfo {
   const result: InstanceInfo = {
     name: null, pid: null, apiPort: null,
@@ -182,6 +201,10 @@ export function readInstanceInfo(root: string): InstanceInfo {
   return result
 }
 
+/**
+ * Format instance status as display lines for use in `openacp attach` and `cmdDefault`.
+ * Returns null if the daemon is not running (nothing to show).
+ */
 export function formatInstanceStatus(root: string): { info: InstanceInfo; lines: string[] } | null {
   const info = readInstanceInfo(root)
   if (!info.pid) return null

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -1,6 +1,13 @@
 import { wantsHelp } from './helpers.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 import { resolveInstanceId } from '../resolve-instance-id.js'
+
+/**
+ * `openacp stop` — Stop the running daemon.
+ *
+ * Sends SIGTERM and waits for the process to exit. Also uninstalls the autostart
+ * service so the daemon stays stopped after the next login/reboot.
+ */
 export async function cmdStop(args: string[] = [], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/tunnel.ts
+++ b/src/cli/commands/tunnel.ts
@@ -1,6 +1,14 @@
 import { readApiPort, apiCall } from '../api-client.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 
+/**
+ * `openacp tunnel` — Manage port-forwarding tunnels via the running daemon.
+ *
+ * All operations go through the daemon's REST API; the daemon manages the actual
+ * tunnel process (cloudflared, ngrok, etc.). Requires a running daemon.
+ *
+ * Subcommands: add, list, stop, stop-all
+ */
 export async function cmdTunnel(args: string[], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -4,6 +4,11 @@ import * as path from 'node:path'
 import { wantsHelp } from './helpers.js'
 import { isJsonMode, jsonSuccess, jsonError, muteForJson, ErrorCodes } from '../output.js'
 
+/**
+ * `openacp uninstall` — Remove an adapter plugin from the instance's plugins directory.
+ *
+ * Delegates to `npm uninstall` to remove the package from the plugins directory.
+ */
 export async function cmdUninstall(args: string[], instanceRoot?: string): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,6 +1,10 @@
 import { getCurrentVersion, getLatestVersion, compareVersions, runUpdate } from '../version.js'
 import { wantsHelp } from './helpers.js'
 
+/**
+ * `openacp update` — Check for a newer CLI version and install it.
+ * Exits with code 1 if the registry cannot be reached or the update fails.
+ */
 export async function cmdUpdate(args: string[] = []): Promise<void> {
   if (wantsHelp(args)) {
     console.log(`

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -1,5 +1,6 @@
 import { isJsonMode, jsonSuccess, muteForJson } from '../output.js'
 
+/** `openacp --version` / `openacp -v` — Print the current CLI version. */
 export async function cmdVersion(args: string[] = []): Promise<void> {
   const json = isJsonMode(args)
   if (json) await muteForJson()

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -3,24 +3,38 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { expandHome } from '../core/config/config.js'
 
+// Daemon lifecycle utilities.
+// The daemon model runs the server as a detached child process (PID file tracking).
+// This allows `openacp start` to return immediately while the server keeps running
+// independently of the terminal session.
+
+/** Returns the path to the PID file for the given instance root. */
 export function getPidPath(root: string): string {
   return path.join(root, 'openacp.pid')
 }
 
+/** Returns the default log directory for the given instance root. */
 export function getLogDir(root: string): string {
   return path.join(root, 'logs')
 }
 
+/**
+ * Returns the path to the "running" marker file.
+ * The marker exists while the daemon is intentionally running, so launchd/systemd
+ * knows whether to restart it after a crash vs. leaving it stopped after `openacp stop`.
+ */
 export function getRunningMarker(root: string): string {
   return path.join(root, 'running')
 }
 
+/** Write a PID file, creating the parent directory if needed. */
 export function writePidFile(pidPath: string, pid: number): void {
   const dir = path.dirname(pidPath)
   fs.mkdirSync(dir, { recursive: true })
   fs.writeFileSync(pidPath, String(pid))
 }
 
+/** Read a PID from a file. Returns null if the file is missing or malformed. */
 export function readPidFile(pidPath: string): number | null {
   try {
     const content = fs.readFileSync(pidPath, 'utf-8').trim()
@@ -31,6 +45,7 @@ export function readPidFile(pidPath: string): number | null {
   }
 }
 
+/** Remove the PID file. Silently ignores ENOENT (already gone). */
 export function removePidFile(pidPath: string): void {
   try {
     fs.unlinkSync(pidPath)
@@ -39,6 +54,13 @@ export function removePidFile(pidPath: string): void {
   }
 }
 
+/**
+ * Check whether the process recorded in the PID file is alive.
+ *
+ * Uses `process.kill(pid, 0)` as a non-destructive liveness probe — it throws
+ * ESRCH if the PID doesn't exist, or EPERM if owned by another user.
+ * Cleans up stale PID files for dead processes.
+ */
 export function isProcessRunning(pidPath: string): boolean {
   const pid = readPidFile(pidPath)
   if (pid === null) return false
@@ -52,6 +74,10 @@ export function isProcessRunning(pidPath: string): boolean {
   }
 }
 
+/**
+ * Return the running status and PID of the daemon.
+ * Cleans up stale PID files if the recorded process is no longer alive.
+ */
 export function getStatus(pidPath: string): { running: boolean; pid?: number } {
   const pid = readPidFile(pidPath)
   if (pid === null) return { running: false }
@@ -64,6 +90,19 @@ export function getStatus(pidPath: string): { running: boolean; pid?: number } {
   }
 }
 
+/**
+ * Fork the daemon as a detached background process.
+ *
+ * Spawn mechanics:
+ * - The child runs `node <cli> --daemon-child` with OPENACP_INSTANCE_ROOT in its env.
+ * - `detached: true` creates a new process group so the child survives terminal close.
+ * - stdout/stderr are redirected to the log file (append mode); the parent closes its
+ *   copies immediately after spawn so the child holds the only references.
+ * - `child.unref()` removes the child from the parent's event loop reference count,
+ *   allowing the parent (`openacp start`) to exit while the child keeps running.
+ * - The PID file is written by both parent (early report) and child (authoritative write
+ *   in main.ts startServer) to handle race conditions with launchd/systemd starts.
+ */
 export function startDaemon(pidPath: string, logDir: string | undefined, instanceRoot: string): { pid: number } | { error: string } {
   // Mark as running so auto-start works on next boot
   markRunning(instanceRoot)
@@ -78,7 +117,7 @@ export function startDaemon(pidPath: string, logDir: string | undefined, instanc
   fs.mkdirSync(resolvedLogDir, { recursive: true })
   const logFile = path.join(resolvedLogDir, 'openacp.log')
 
-  // Find the CLI entry point
+  // Find the CLI entry point — must be the same binary that invoked this function
   const cliPath = path.resolve(process.argv[1])
   const nodePath = process.execPath
 
@@ -116,6 +155,11 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+/**
+ * Three-way liveness probe: alive, dead (ESRCH), or EPERM.
+ * EPERM means the PID exists but belongs to a different user — the PID file was
+ * likely reused by the OS for an unrelated process after the daemon exited.
+ */
 function isProcessAlive(pid: number): 'alive' | 'dead' | 'eperm' {
   try {
     process.kill(pid, 0)
@@ -127,6 +171,16 @@ function isProcessAlive(pid: number): 'alive' | 'dead' | 'eperm' {
   }
 }
 
+/**
+ * Gracefully stop the daemon, escalating to SIGKILL if it doesn't exit.
+ *
+ * Stop sequence:
+ * 1. Send SIGTERM; poll every 100ms for up to 5 seconds.
+ * 2. If still alive after 5s, send SIGKILL; poll for up to 1 more second.
+ * 3. If still alive after SIGKILL, the process is in uninterruptible I/O — very rare.
+ *
+ * Also clears the "running" marker so the daemon is not restarted on next login.
+ */
 export async function stopDaemon(pidPath: string, instanceRoot: string): Promise<{ stopped: boolean; pid?: number; error?: string }> {
   const pid = readPidFile(pidPath)
   if (pid === null) return { stopped: false, error: 'Not running (no PID file)' }

--- a/src/cli/integrate.ts
+++ b/src/cli/integrate.ts
@@ -8,11 +8,17 @@ import type {
   AgentPluginIntegrationSpec,
 } from "../core/agents/agent-dependencies.js";
 
+/** Result of an install/uninstall operation with a human-readable log. */
 export interface IntegrationResult {
   success: boolean;
+  /** Log lines describing what was created, updated, or removed. */
   logs: string[];
 }
 
+/**
+ * A single installable integration component (e.g., handoff scripts, tunnel skill).
+ * Each integration consists of one or more items installed/uninstalled independently.
+ */
 export interface IntegrationItem {
   id: string;
   name: string;
@@ -22,10 +28,13 @@ export interface IntegrationItem {
   uninstall(): Promise<IntegrationResult>;
 }
 
+/** All integration items for a specific agent. */
 export interface AgentIntegration {
   items: IntegrationItem[];
 }
 
+// The filename used to detect whether the inject hook is already installed in an agent's
+// hook event. Checked before adding to prevent duplicate entries across re-runs.
 const HOOK_MARKER = "openacp-inject-session.sh";
 
 function isPluginIntegrationSpec(spec: AgentIntegrationSpec): spec is AgentPluginIntegrationSpec {
@@ -42,6 +51,15 @@ function expandPath(p: string): string {
 
 // --- Script generators ---
 
+/**
+ * Generate the session inject hook script for a hooks-based agent integration.
+ *
+ * The inject script runs before each agent prompt. It reads the ACP session ID and CWD
+ * from the agent's hook input (JSON or plaintext), then outputs them as context variables
+ * that the agent can pass to `openacp adopt` via the handoff command.
+ *
+ * Uses `jq` for JSON parsing; falls back to `~/.openacp/bin/jq` if not on PATH.
+ */
 function generateInjectScript(_agentKey: string, spec: AgentHooksIntegrationSpec): string {
   const sidVar = spec.sessionIdVar ?? "SESSION_ID";
   const cwdVar = spec.workingDirVar ?? "WORKING_DIR";
@@ -77,6 +95,10 @@ exit 0
 `;
 }
 
+/**
+ * Generate the handoff shell script that the agent calls to transfer the session.
+ * Wraps `openacp adopt <agent> <session_id>` with optional --cwd and --channel flags.
+ */
 function generateHandoffScript(agentKey: string): string {
   return `#!/bin/bash
 SESSION_ID=$1
@@ -92,6 +114,11 @@ openacp adopt ${agentKey} "$SESSION_ID" \${CWD:+--cwd "$CWD"} \${CHANNEL:+--chan
 `;
 }
 
+/**
+ * Generate the tunnel skill markdown file.
+ * This is a slash command / skill description that tells the AI agent when and how
+ * to use `openacp tunnel` commands to expose local ports.
+ */
 function generateTunnelCommand(): string {
   return `---
 description: Expose local ports to the internet. Use when user wants to share, preview, or access their local dev server remotely. Triggers on phrases like "expose port", "map port", "share my app", "make it public", "open tunnel", "public URL", "share localhost", "preview on phone", "access from outside", "forward port", "ngrok", "cloudflare tunnel", etc.
@@ -205,7 +232,13 @@ function generateOpencodePlugin(spec: AgentPluginIntegrationSpec): string {
 }
 
 // --- Settings mergers ---
+// These functions add the inject hook to an agent's settings file without clobbering
+// existing hooks. A backup (.bak) is written before any modification.
 
+/**
+ * Add the inject hook to a Claude-style settings.json (hooks nested under groups).
+ * Skips if the hook is already present (idempotent).
+ */
 function mergeSettingsJson(settingsPath: string, hookEvent: string, hookScriptPath: string): void {
   const fullPath = expandPath(settingsPath);
   let settings: Record<string, unknown> = {};
@@ -236,6 +269,11 @@ function mergeSettingsJson(settingsPath: string, hookEvent: string, hookScriptPa
   writeFileSync(fullPath, JSON.stringify(settings, null, 2) + "\n");
 }
 
+/**
+ * Add the inject hook to a flat hooks.json (hooks as direct array entries).
+ * Used for agents that follow the hooks.json format (e.g. Cursor, Cline).
+ * Skips if the hook is already present (idempotent).
+ */
 function mergeHooksJson(settingsPath: string, hookEvent: string, hookScriptPath: string): void {
   const fullPath = expandPath(settingsPath);
   let config: Record<string, unknown> = { version: 1 };
@@ -473,6 +511,10 @@ async function uninstallPluginIntegration(_agentKey: string, spec: AgentPluginIn
   }
 }
 
+/**
+ * Install the integration for an agent based on its spec strategy.
+ * Routes to hooks-based or plugin-based installation depending on `spec.strategy`.
+ */
 export async function installIntegration(agentKey: string, spec: AgentIntegrationSpec): Promise<IntegrationResult> {
   if (isHooksIntegrationSpec(spec)) {
     return installHooksIntegration(agentKey, spec);
@@ -480,6 +522,10 @@ export async function installIntegration(agentKey: string, spec: AgentIntegratio
   return installPluginIntegration(agentKey, spec);
 }
 
+/**
+ * Uninstall the integration for an agent based on its spec strategy.
+ * Routes to hooks-based or plugin-based removal depending on `spec.strategy`.
+ */
 export async function uninstallIntegration(agentKey: string, spec: AgentIntegrationSpec): Promise<IntegrationResult> {
   if (isHooksIntegrationSpec(spec)) {
     return uninstallHooksIntegration(agentKey, spec);
@@ -487,7 +533,8 @@ export async function uninstallIntegration(agentKey: string, spec: AgentIntegrat
   return uninstallPluginIntegration(agentKey, spec);
 }
 
-// --- Public API (backward compat with existing cmdIntegrate / Telegram integrate) ---
+// --- Public API ---
+// These functions build IntegrationItem objects for display and management in cmdIntegrate.
 
 function buildHandoffItem(agentKey: string, spec: AgentIntegrationSpec): IntegrationItem {
   return {
@@ -512,10 +559,10 @@ function buildHandoffItem(agentKey: string, spec: AgentIntegrationSpec): Integra
 }
 
 function getSkillBasePath(spec: AgentHooksIntegrationSpec): string {
-  // Skills go into the agent's skills directory (sibling to commands)
+  // Skills go into the agent's skills directory (sibling to commands/).
   // Claude: ~/.claude/skills/, Cursor: ~/.cursor/skills/
   const base = spec.commandsPath!;
-  // If commandsPath is commands/, use skills/ instead
+  // If commandsPath ends with commands/, replace it with skills/ for skill-format agents
   const skillsBase = base.replace(/\/commands\/?$/, "/skills/");
   return expandPath(skillsBase);
 }
@@ -566,6 +613,10 @@ function buildTunnelItem(spec: AgentIntegrationSpec): IntegrationItem | null {
   };
 }
 
+/**
+ * Return all integration items for the given agent, or undefined if the agent
+ * has no integration support. Includes both handoff and tunnel items where applicable.
+ */
 export function getIntegration(agentName: string): AgentIntegration | undefined {
   const caps = getAgentCapabilities(agentName);
   if (!caps.integration) return undefined;
@@ -575,6 +626,7 @@ export function getIntegration(agentName: string): AgentIntegration | undefined 
   return { items };
 }
 
+/** Return the list of agent keys that have integration support defined. */
 export function listIntegrations(): string[] {
   return listAgentsWithIntegration();
 }

--- a/src/cli/interactive-menu.ts
+++ b/src/cli/interactive-menu.ts
@@ -1,23 +1,30 @@
+/** A single option in the interactive menu. */
 export interface MenuOption {
+  /** Single character key the user presses to select this option. */
   key: string
   label: string
   action: () => Promise<void> | void
 }
 
+// Strip ANSI escape codes to compute the visual width of a string for column alignment.
 function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*m/g, '')
 }
 
 /**
- * Show an interactive single-keypress menu (TTY only).
- * Returns true if a menu was shown, false if non-TTY.
+ * Display a single-keypress menu on TTY and wait for the user to choose an option.
+ *
+ * Uses raw mode (`setRawMode(true)`) to read individual keystrokes without requiring Enter.
+ * Options are displayed in two columns for compact layout. Ctrl+C exits the process.
+ * Returns true if a menu was shown and an option was selected, false if non-TTY (allows
+ * callers to fall back to a plain text hint for piped/scripted contexts).
  */
 export function showInteractiveMenu(options: MenuOption[]): Promise<boolean> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     return Promise.resolve(false)
   }
 
-  // Print options in two columns
+  // Print options in two columns: first half on the left, second half on the right
   const half = Math.ceil(options.length / 2)
   for (let i = 0; i < half; i++) {
     const left = options[i]!
@@ -41,7 +48,7 @@ export function showInteractiveMenu(options: MenuOption[]): Promise<boolean> {
     const onData = async (buf: Buffer) => {
       const ch = buf.toString().toLowerCase()
 
-      // Handle Ctrl+C
+      // Handle Ctrl+C — restore terminal state before exiting
       if (ch === '\x03') {
         cleanup()
         process.exit(0)

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,10 +1,18 @@
+// CLI output utilities: machine-readable JSON mode and human-readable text mode.
+//
+// When --json is passed, all output is a single JSON line on stdout; human-readable
+// text (pino logs, progress messages) is suppressed via muteForJson(). This makes
+// commands scriptable and consumable by tools like the OpenACP App.
+
 // --- Types ---
 
+/** Successful JSON response envelope. */
 export interface JsonSuccess<T = unknown> {
   success: true
   data: T
 }
 
+/** Error JSON response envelope. */
 export interface JsonError {
   success: false
   error: {
@@ -13,10 +21,12 @@ export interface JsonError {
   }
 }
 
+/** Union type for all JSON CLI output shapes. */
 export type JsonOutput<T = unknown> = JsonSuccess<T> | JsonError
 
 // --- Error Codes ---
 
+/** Stable machine-readable error codes for JSON output. Do not rename existing values. */
 export const ErrorCodes = {
   DAEMON_NOT_RUNNING: 'DAEMON_NOT_RUNNING',
   INSTANCE_NOT_FOUND: 'INSTANCE_NOT_FOUND',
@@ -39,20 +49,34 @@ export type ErrorCode = typeof ErrorCodes[keyof typeof ErrorCodes]
 
 // --- Functions ---
 
+/** Returns true if the command was invoked with --json output mode. */
 export function isJsonMode(args: string[]): boolean {
   return args.includes('--json')
 }
 
+/**
+ * Emit a success JSON envelope and exit 0.
+ * Declared as `never` because it always calls `process.exit`.
+ */
 export function jsonSuccess(data: unknown): never {
   console.log(JSON.stringify({ success: true, data }))
   process.exit(0)
 }
 
+/**
+ * Emit an error JSON envelope and exit 1.
+ * Declared as `never` because it always calls `process.exit`.
+ */
 export function jsonError(code: ErrorCode, message: string): never {
   console.log(JSON.stringify({ success: false, error: { code, message } }))
   process.exit(1)
 }
 
+/**
+ * Suppress pino logger output when running in --json mode.
+ * Pino logs to stdout by default; in JSON mode that would corrupt the machine-readable output.
+ * Dynamic import so commands that never use JSON don't pay the pino import cost.
+ */
 export async function muteForJson(): Promise<void> {
   try {
     const { muteLogger } = await import('../core/utils/log.js')

--- a/src/cli/plugin-template/claude-md.ts
+++ b/src/cli/plugin-template/claude-md.ts
@@ -1,5 +1,15 @@
 import type { TemplateParams } from './package-json.js'
 
+/**
+ * Generate CLAUDE.md — the AI agent context file embedded in every plugin.
+ *
+ * This file is the primary reference for AI coding agents (Claude Code, Cursor, etc.)
+ * working on a plugin. It covers: plugin lifecycle, PluginContext API, event types,
+ * middleware hooks, service registry, testing patterns, and links to external docs.
+ *
+ * Must stay in sync with the actual OpenACP plugin API (see CLAUDE.md in repo root
+ * for the update rule). Outdated content here leads AI agents to generate incorrect code.
+ */
 export function generateClaudeMd(params: TemplateParams): string {
   return `# CLAUDE.md
 

--- a/src/cli/plugin-template/dotfiles.ts
+++ b/src/cli/plugin-template/dotfiles.ts
@@ -1,11 +1,17 @@
+/** Generate .gitignore — excludes build output and platform files from version control. */
 export function generateGitignore(): string {
   return ['node_modules/', 'dist/', '*.tsbuildinfo', '.DS_Store', ''].join('\n')
 }
 
+/**
+ * Generate .npmignore — excludes source, config, and test files from the published package.
+ * Only dist/ (compiled output) and package.json/README/LICENSE are included in the tarball.
+ */
 export function generateNpmignore(): string {
   return ['src/', 'tsconfig.json', '.editorconfig', '.gitignore', '*.test.ts', '__tests__/', ''].join('\n')
 }
 
+/** Generate .editorconfig — consistent coding style across editors. */
 export function generateEditorconfig(): string {
   return [
     'root = true',

--- a/src/cli/plugin-template/index.ts
+++ b/src/cli/plugin-template/index.ts
@@ -1,3 +1,6 @@
+// Plugin scaffold template re-exports.
+// All generate* functions accept TemplateParams and return file content as a string.
+// Used by cmdPluginCreate to write the complete plugin project structure.
 export type { TemplateParams } from './package-json.js'
 export { generatePackageJson } from './package-json.js'
 export { generateTsconfig } from './tsconfig.js'

--- a/src/cli/plugin-template/package-json.ts
+++ b/src/cli/plugin-template/package-json.ts
@@ -1,11 +1,20 @@
+/** Parameters collected from the user and used across all template generators. */
 export interface TemplateParams {
   pluginName: string
   description: string
   author: string
   license: string
+  /** Current CLI version — used to pin the openacp engine constraint and SDK version. */
   cliVersion: string
 }
 
+/**
+ * Generate package.json for a new plugin.
+ *
+ * The `engines.openacp` field declares the minimum OpenACP CLI version required.
+ * The `peerDependencies` entry on `@openacp/cli` is what npm uses for compatibility
+ * warnings. Plugin SDK is a devDependency (types only, not bundled).
+ */
 export function generatePackageJson(params: TemplateParams): string {
   const packageJson = {
     name: params.pluginName,

--- a/src/cli/plugin-template/plugin-guide.ts
+++ b/src/cli/plugin-template/plugin-guide.ts
@@ -1,5 +1,15 @@
 import type { TemplateParams } from './package-json.js'
 
+/**
+ * Generate PLUGIN_GUIDE.md — the human-readable developer guide embedded in every plugin.
+ *
+ * Contains practical how-to sections: adding commands, registering services, listening to
+ * events, using middleware, and writing tests. Aimed at plugin authors who prefer docs
+ * over reading the API types directly.
+ *
+ * This file is kept in sync with the actual OpenACP plugin API. When the API changes,
+ * this generator must be updated so newly scaffolded plugins start with accurate examples.
+ */
 export function generatePluginGuide(params: TemplateParams): string {
   return `# Plugin Developer Guide
 

--- a/src/cli/plugin-template/plugin-source.ts
+++ b/src/cli/plugin-template/plugin-source.ts
@@ -1,5 +1,14 @@
 import type { TemplateParams } from './package-json.js'
 
+/**
+ * Generate the main plugin source file (src/index.ts).
+ *
+ * Produces a fully annotated OpenACPPlugin object with all lifecycle hooks stubbed out
+ * (setup, teardown, install, configure, migrate, uninstall). Each hook includes
+ * commented examples showing how to register services, commands, and event listeners.
+ *
+ * The generated file is the primary editing surface for plugin authors.
+ */
 export function generatePluginSource(params: TemplateParams): string {
   const dirName = params.pluginName.replace(/^@[^/]+\//, '')
   const escapedDescription = (params.description || '').replace(/'/g, "\\'")

--- a/src/cli/plugin-template/readme.ts
+++ b/src/cli/plugin-template/readme.ts
@@ -1,5 +1,9 @@
 import type { TemplateParams } from './package-json.js'
 
+/**
+ * Generate a minimal README.md with installation and development instructions.
+ * Intended as a starting point — plugin authors fill in the description and usage details.
+ */
 export function generateReadme(params: TemplateParams): string {
   return [
     `# ${params.pluginName}`,

--- a/src/cli/plugin-template/tsconfig.ts
+++ b/src/cli/plugin-template/tsconfig.ts
@@ -1,3 +1,10 @@
+/**
+ * Generate tsconfig.json for a new plugin.
+ *
+ * Uses NodeNext module resolution (required for ESM with .js imports),
+ * strict mode, and targets ES2022 — matching the OpenACP core configuration.
+ * Tests are excluded from the build output (compiled separately by vitest).
+ */
 export function generateTsconfig(): string {
   const tsconfig = {
     compilerOptions: {

--- a/src/cli/post-upgrade.ts
+++ b/src/cli/post-upgrade.ts
@@ -6,9 +6,17 @@ import type { InstanceContext } from "../core/instance/instance-context.js";
 const log = createChildLogger({ module: "post-upgrade" });
 
 /**
- * Post-upgrade dependency check — runs on every start.
- * Centralized source of truth for all binary dependency management.
- * Silent if everything is OK.
+ * Run dependency and integration health checks after each start.
+ *
+ * Checks are best-effort: each section is wrapped in a try/catch so a failure in
+ * one check never blocks the daemon from starting. All checks are read-only unless
+ * auto-install is triggered (e.g., cloudflared, jq). Silent when everything is OK.
+ *
+ * Checks performed:
+ * 1. Tunnel provider binary (cloudflared auto-install, or warn for others)
+ * 2. Claude CLI integration + jq (warns if handoff is installed but jq is missing)
+ * 3. unzip (needed for binary agent distribution installs)
+ * 4. uvx (needed for Python-based agents via uv)
  */
 export async function runPostUpgradeChecks(config: Config, ctx?: InstanceContext): Promise<void> {
   // 1. Tunnel provider binary — read from plugin settings (tunnel migrated out of config.json)

--- a/src/cli/suggest.ts
+++ b/src/cli/suggest.ts
@@ -1,5 +1,16 @@
 import { distance } from "fastest-levenshtein";
 
+/**
+ * Find the closest matching candidate for a mistyped user input.
+ *
+ * Matching priority:
+ * 1. Prefix match — favors shortest candidate starting with the input.
+ * 2. Substring match — input appears anywhere in the candidate (min 3 chars).
+ * 3. Levenshtein distance — allows up to maxDistance edits; short candidates
+ *    (≤3 chars) are stricter (max 1 edit) to avoid spurious suggestions.
+ *
+ * Returns undefined if there is no close match, or if the input is an exact match.
+ */
 export function suggestMatch(
   input: string,
   candidates: string[],

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -4,6 +4,8 @@ import { existsSync, readFileSync } from 'node:fs'
 
 const NPM_PACKAGE = '@openacp/cli'
 
+// Walk up from the current module's directory to find package.json.
+// Necessary because the compiled output lives in dist/ but package.json is at the root.
 function findPackageJson(): string | null {
   let dir = dirname(fileURLToPath(import.meta.url))
   for (let i = 0; i < 5; i++) {
@@ -16,6 +18,10 @@ function findPackageJson(): string | null {
   return null
 }
 
+/**
+ * Return the installed CLI version from package.json.
+ * Returns '0.0.0-dev' when running from source (no package.json found or parseable).
+ */
 export function getCurrentVersion(): string {
   try {
     const pkgPath = findPackageJson()
@@ -27,6 +33,11 @@ export function getCurrentVersion(): string {
   }
 }
 
+/**
+ * Fetch the latest published version from the npm registry.
+ * Returns null on any error (network failure, rate limit, etc.) — callers treat null as "unknown".
+ * Timeout is 5 seconds to avoid blocking the CLI on slow connections.
+ */
 export async function getLatestVersion(): Promise<string | null> {
   try {
     const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE}/latest`, {
@@ -40,6 +51,10 @@ export async function getLatestVersion(): Promise<string | null> {
   }
 }
 
+/**
+ * Numerically compare two semver strings (major.minor.patch).
+ * Returns -1 if current < latest, 0 if equal, 1 if current > latest.
+ */
 export function compareVersions(current: string, latest: string): -1 | 0 | 1 {
   const a = current.split('.').map(Number)
   const b = latest.split('.').map(Number)
@@ -50,6 +65,10 @@ export function compareVersions(current: string, latest: string): -1 | 0 | 1 {
   return 0
 }
 
+/**
+ * Run `npm install -g @openacp/cli@latest` as a child process.
+ * Forwards signals to the child so Ctrl+C during update cancels cleanly.
+ */
 export async function runUpdate(): Promise<boolean> {
   const { spawn } = await import('node:child_process')
   return new Promise((resolve) => {
@@ -71,6 +90,13 @@ export async function runUpdate(): Promise<boolean> {
   })
 }
 
+/**
+ * Check for a newer CLI version and interactively offer to update before continuing.
+ *
+ * Skipped in dev mode, CI, non-TTY environments, and when OPENACP_SKIP_UPDATE_CHECK is set.
+ * After a successful update the process exits with 0 — the user must re-run their command
+ * against the newly installed binary.
+ */
 export async function checkAndPromptUpdate(): Promise<void> {
   if (process.env.OPENACP_DEV_LOOP || process.env.OPENACP_SKIP_UPDATE_CHECK || !process.stdin.isTTY) return
 

--- a/src/core/adapter-primitives/display-spec-builder.ts
+++ b/src/core/adapter-primitives/display-spec-builder.ts
@@ -8,6 +8,11 @@ import { isApplyPatchOtherTool } from "../utils/apply-patch-detection.js";
 
 // ─── Output spec interfaces ────────────────────────────────────────────────
 
+/**
+ * A fully resolved, platform-agnostic description of how to display a tool call.
+ * Built by DisplaySpecBuilder from a ToolEntry + output mode, then consumed
+ * by adapters to render tool cards.
+ */
 export interface ToolDisplaySpec {
   id: string;
   kind: string;
@@ -30,8 +35,10 @@ export interface ToolDisplaySpec {
   isHidden: boolean;
 }
 
+/** Display specification for an agent's extended thinking block. */
 export interface ThoughtDisplaySpec {
   indicator: string;
+  /** Full thought text, only populated at high verbosity. */
   content: string | null;
 }
 
@@ -221,9 +228,23 @@ function isTitleFromCommand(title: string, command: string): boolean {
 
 // ─── DisplaySpecBuilder ───────────────────────────────────────────────────
 
+/**
+ * Transforms raw ToolEntry state into display-ready ToolDisplaySpec objects.
+ *
+ * This is the central place where output mode (low/medium/high) controls what
+ * information is included in tool cards. Low mode strips metadata; medium mode
+ * includes summaries; high mode includes full output content and viewer links.
+ */
 export class DisplaySpecBuilder {
   constructor(private tunnelService?: TunnelServiceInterface) {}
 
+  /**
+   * Builds a display spec for a single tool call entry.
+   *
+   * Deduplicates fields to avoid repeating the same info (e.g., if the title
+   * was derived from the command, the command field is omitted). For long
+   * output, generates a viewer link via the tunnel service when available.
+   */
   buildToolSpec(
     entry: ToolEntry,
     mode: OutputMode,
@@ -312,6 +333,7 @@ export class DisplaySpecBuilder {
     };
   }
 
+  /** Builds a display spec for an agent thought. Content is only included at high verbosity. */
   buildThoughtSpec(content: string, mode: OutputMode): ThoughtDisplaySpec {
     const indicator = "Thinking...";
     return {

--- a/src/core/adapter-primitives/format-types.ts
+++ b/src/core/adapter-primitives/format-types.ts
@@ -1,16 +1,32 @@
 // src/adapters/shared/format-types.ts
+//
+// Shared type definitions for message formatting, tool display, and
+// output verbosity across all adapters.
 
+/**
+ * Controls how much detail is shown in agent output.
+ * - `"low"` — minimal: hides thoughts, usage, noisy tool calls
+ * - `"medium"` — balanced: shows tool summaries, hides noise
+ * - `"high"` — full: shows everything including tool output and thoughts
+ */
 export type OutputMode = "low" | "medium" | "high";
 /** @deprecated Use OutputMode instead */
 export type DisplayVerbosity = OutputMode;
 
+/**
+ * Action to take for a tool call classified as noise.
+ * - `"hide"` — suppress entirely (not shown at any verbosity except high)
+ * - `"collapse"` — show minimally (hidden only at low verbosity)
+ */
 export type NoiseAction = "hide" | "collapse";
 
+/** Rule that classifies a tool call as noise based on its name, kind, and input. */
 export interface NoiseRule {
   match: (name: string, kind: string, rawInput: unknown) => boolean;
   action: NoiseAction;
 }
 
+/** Visual style category for rendering a formatted message. */
 export type MessageStyle =
   | "text"
   | "thought"
@@ -21,6 +37,7 @@ export type MessageStyle =
   | "error"
   | "attachment";
 
+/** Structured metadata attached to a formatted message for rendering decisions. */
 export interface MessageMetadata {
   toolName?: string;
   toolStatus?: string;
@@ -35,7 +52,11 @@ export interface MessageMetadata {
   viewerFilePath?: string;
 }
 
-/** summary and detail are always plain text (never pre-escaped HTML/markdown) — renderers handle escaping */
+/**
+ * Platform-agnostic formatted message ready for rendering.
+ * Summary and detail are always plain text — renderers handle
+ * escaping for their target format (HTML, markdown, etc.).
+ */
 export interface FormattedMessage {
   summary: string;
   detail?: string;
@@ -46,6 +67,7 @@ export interface FormattedMessage {
   metadata?: MessageMetadata;
 }
 
+/** Maps tool call status strings to emoji icons for display. */
 export const STATUS_ICONS: Record<string, string> = {
   pending: "⏳",
   in_progress: "🔄",
@@ -57,6 +79,7 @@ export const STATUS_ICONS: Record<string, string> = {
   error: "❌",
 };
 
+/** Maps tool kind strings to emoji icons for display. */
 export const KIND_ICONS: Record<string, string> = {
   read: "📖",
   edit: "✏️",
@@ -76,6 +99,7 @@ export const KIND_ICONS: Record<string, string> = {
   other: "🛠️",
 };
 
+/** Maps tool kind strings to human-readable labels for UI display. */
 export const KIND_LABELS: Record<string, string> = {
   read: "Read",
   edit: "Edit",
@@ -94,25 +118,35 @@ export const KIND_LABELS: Record<string, string> = {
   move: "Move",
 };
 
+/** Links to the web viewer for file contents or diffs. */
 export interface ViewerLinks {
   file?: string;
   diff?: string;
 }
 
+/**
+ * Metadata extracted from a tool_call agent event.
+ * Carried on OutgoingMessage.metadata for rendering by adapters.
+ */
 export interface ToolCallMeta {
   id: string;
   name: string;
+  /** Semantic kind (read, edit, execute, search, etc.) used for icon/label selection. */
   kind?: string;
   status?: string;
   content?: unknown;
   rawInput?: unknown;
   viewerLinks?: ViewerLinks;
   viewerFilePath?: string;
+  /** Agent-provided summary override (takes precedence over auto-generated summary). */
   displaySummary?: string;
+  /** Agent-provided title override (takes precedence over auto-generated title). */
   displayTitle?: string;
+  /** Agent-provided kind override (takes precedence over inferred kind). */
   displayKind?: string;
 }
 
+/** Metadata for a tool_update event — same as ToolCallMeta but status is required. */
 export interface ToolUpdateMeta extends ToolCallMeta {
   status: string;
 }

--- a/src/core/adapter-primitives/format-utils.ts
+++ b/src/core/adapter-primitives/format-utils.ts
@@ -1,8 +1,10 @@
+/** Renders a text-based progress bar (e.g., "▓▓▓▓░░░░░░") for token usage display. */
 export function progressBar(ratio: number, length = 10): string {
   const filled = Math.round(Math.min(ratio, 1) * length);
   return "▓".repeat(filled) + "░".repeat(length - filled);
 }
 
+/** Formats a token count with SI suffixes (e.g., 1500 -> "1.5k", 2000000 -> "2M"). */
 export function formatTokens(n: number): string {
   if (n >= 1_000_000) {
     const m = n / 1_000_000;
@@ -15,6 +17,7 @@ export function formatTokens(n: number): string {
   return String(n);
 }
 
+/** Strips markdown code fences (```lang ... ```) from text, leaving only the content. */
 export function stripCodeFences(text: string): string {
   return text
     .replace(/```\w*\n?/g, "")
@@ -22,11 +25,22 @@ export function stripCodeFences(text: string): string {
     .trim();
 }
 
+/** Truncates text to maxLen characters, appending a truncation marker if cut. */
 export function truncateContent(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return text.slice(0, maxLen) + "\n… (truncated)";
 }
 
+/**
+ * Splits a long message into chunks that fit within maxLength.
+ *
+ * Splitting strategy:
+ * 1. Prefer paragraph boundaries (\n\n), then line boundaries (\n)
+ * 2. If remaining text is only slightly over the limit (< 1.3x), split
+ *    near the midpoint to avoid leaving a tiny trailing chunk
+ * 3. Avoid splitting inside markdown code fences — extend past the closing
+ *    fence if it doesn't exceed 2x maxLength
+ */
 export function splitMessage(text: string, maxLength: number): string[] {
   if (text.length <= maxLength) return [text];
   const chunks: string[] = [];
@@ -37,11 +51,14 @@ export function splitMessage(text: string, maxLength: number): string[] {
       break;
     }
 
+    // If splitting would leave a very small trailing chunk, split closer
+    // to the middle to produce two balanced chunks instead.
     const wouldLeaveSmall = remaining.length < maxLength * 1.3;
     const searchLimit = wouldLeaveSmall
       ? Math.floor(remaining.length / 2) + 300
       : maxLength;
 
+    // Find the best split point: paragraph > line > hard limit
     const threshold = maxLength * 0.2;
     let splitAt = remaining.lastIndexOf("\n\n", searchLimit);
     if (splitAt === -1 || splitAt < threshold) {
@@ -51,6 +68,7 @@ export function splitMessage(text: string, maxLength: number): string[] {
       splitAt = searchLimit;
     }
 
+    // If we'd split inside an open code fence, extend to include the closing fence
     const candidate = remaining.slice(0, splitAt);
     const fences = candidate.match(/```/g);
     if (fences && fences.length % 2 !== 0) {
@@ -59,7 +77,6 @@ export function splitMessage(text: string, maxLength: number): string[] {
         const afterFence = remaining.indexOf("\n", closingFence + 3);
         const fenceSplit =
           afterFence !== -1 ? afterFence + 1 : closingFence + 3;
-        // Only extend to include the closing fence if it doesn't exceed 2x maxLength
         if (fenceSplit <= maxLength * 2) {
           splitAt = fenceSplit;
         }

--- a/src/core/adapter-primitives/message-formatter.ts
+++ b/src/core/adapter-primitives/message-formatter.ts
@@ -1,6 +1,15 @@
 import type { NoiseAction, NoiseRule } from "./format-types.js";
 import { STATUS_ICONS, KIND_ICONS } from "./format-types.js";
 
+/**
+ * Recursively extracts plain text from an agent's response content.
+ *
+ * Agent responses can be strings, arrays of content blocks, or nested
+ * objects with `text`, `content`, `input`, or `output` fields. This
+ * function normalizes all variants into a single string. Falls back
+ * to JSON serialization for unrecognized structures to avoid silently
+ * dropping edge-case responses.
+ */
 export function extractContentText(content: unknown, depth = 0): string {
   if (!content || depth > 5) return "";
   if (typeof content === "string") return content;
@@ -53,8 +62,12 @@ function parseRawInput(rawInput: unknown): Record<string, unknown> {
   return {};
 }
 
-// --- Step 5: formatToolSummary with displaySummary override ---
-
+/**
+ * Builds a human-readable summary line for a tool call (used at medium/high verbosity).
+ *
+ * Includes an icon and key arguments (e.g., "Read src/foo.ts (50 lines)").
+ * If the agent provides a `displaySummary` override, it takes precedence.
+ */
 export function formatToolSummary(
   name: string,
   rawInput: unknown,
@@ -113,8 +126,12 @@ export function formatToolSummary(
   return `🔧 ${name}`;
 }
 
-// --- Step 6: formatToolTitle for low verbosity ---
-
+/**
+ * Builds a compact title for a tool call (used at low verbosity).
+ *
+ * Returns just the key identifier (file path, command, pattern) without
+ * icons or extra decoration. If `displayTitle` is provided, it takes precedence.
+ */
 export function formatToolTitle(
   name: string,
   rawInput: unknown,
@@ -156,8 +173,10 @@ export function formatToolTitle(
   return name;
 }
 
-// --- Step 7: resolveToolIcon ---
-
+/**
+ * Selects the appropriate emoji icon for a tool call card.
+ * Priority: status icon (e.g., running, done, error) > kind icon (e.g., read, execute) > default.
+ */
 export function resolveToolIcon(tool: {
   status?: string;
   displayKind?: string;
@@ -170,7 +189,8 @@ export function resolveToolIcon(tool: {
   return "🔧";
 }
 
-// --- Step 8: Noise filtering ---
+// Noise filtering — determines which tool calls are low-signal and can be
+// hidden or collapsed at lower verbosity levels to reduce chat clutter.
 
 const NOISE_RULES: NoiseRule[] = [
   {
@@ -196,6 +216,10 @@ const NOISE_RULES: NoiseRule[] = [
   },
 ];
 
+/**
+ * Evaluates whether a tool call is considered "noise" based on its name, kind, and input.
+ * Returns `"hide"` (suppress entirely) or `"collapse"` (show minimally), or `null` if not noise.
+ */
 export function evaluateNoise(
   name: string,
   kind: string,

--- a/src/core/adapter-primitives/messaging-adapter.ts
+++ b/src/core/adapter-primitives/messaging-adapter.ts
@@ -12,29 +12,53 @@ import type { DisplayVerbosity, ToolCallMeta } from "./format-types.js";
 import type { IRenderer } from "./rendering/renderer.js";
 import { evaluateNoise } from "./message-formatter.js";
 
+/** Runtime services available to adapters via dependency injection. */
 export interface AdapterContext {
   configManager: { get(): Record<string, unknown> };
   fileService?: unknown;
 }
 
+/** Configuration for adapters that extend MessagingAdapter. */
 export interface MessagingAdapterConfig extends ChannelConfig {
+  /** Platform-imposed limit on a single message body (e.g., 4096 for Telegram). */
   maxMessageLength: number;
+  /** How often (ms) to flush buffered streaming text to the platform. */
   flushInterval?: number;
+  /** Minimum interval (ms) between consecutive send-queue operations. */
   sendInterval?: number;
+  /** How often (ms) to refresh the typing indicator during agent thinking. */
   thinkingRefreshInterval?: number;
+  /** Max duration (ms) to show the typing indicator before auto-dismissing. */
   thinkingDuration?: number;
+  /** Default output verbosity for this adapter (can be overridden per-session). */
   displayVerbosity?: DisplayVerbosity;
 }
 
+/** Represents a message that was successfully sent to the platform. */
 export interface SentMessage {
   messageId: string;
 }
 
+/** Message types that are hidden entirely at "low" verbosity. */
 const HIDDEN_ON_LOW = new Set(["thought", "usage"]);
 
+/**
+ * Abstract base class for platform-specific messaging adapters (Telegram, Slack, etc.).
+ *
+ * Provides a dispatch pipeline: incoming OutgoingMessage -> verbosity filter -> type-based
+ * handler. Subclasses override the `handle*` methods to implement platform-specific rendering
+ * and delivery. The base implementations are no-ops, so subclasses only override what they need.
+ */
 export abstract class MessagingAdapter implements IChannelAdapter {
   abstract readonly name: string;
+  /** Platform-specific renderer that converts OutgoingMessage to formatted output. */
   abstract readonly renderer: IRenderer;
+  /**
+   * Declares what this adapter can do. The platform-specific subclass sets these flags,
+   * and core/stream-adapter use them to decide how to route and format output — e.g.,
+   * whether to stream text in-place (streaming), send to threads/topics (threads),
+   * render markdown (richFormatting), upload files (fileUpload), or play audio (voice).
+   */
   abstract readonly capabilities: AdapterCapabilities;
 
   constructor(
@@ -44,6 +68,11 @@ export abstract class MessagingAdapter implements IChannelAdapter {
 
   // === Message dispatch flow ===
 
+  /**
+   * Entry point for all outbound messages from sessions to the platform.
+   * Resolves the current verbosity, filters messages that should be hidden,
+   * then dispatches to the appropriate type-specific handler.
+   */
   async sendMessage(
     sessionId: string,
     content: OutgoingMessage,
@@ -53,6 +82,11 @@ export abstract class MessagingAdapter implements IChannelAdapter {
     await this.dispatchMessage(sessionId, content, verbosity);
   }
 
+  /**
+   * Routes a message to its type-specific handler.
+   * Subclasses can override this for custom dispatch logic, but typically
+   * override individual handle* methods instead.
+   */
   protected async dispatchMessage(
     sessionId: string,
     content: OutgoingMessage,
@@ -95,6 +129,8 @@ export abstract class MessagingAdapter implements IChannelAdapter {
   }
 
   // === Default handlers — all protected, all overridable ===
+  // Each handler is a no-op by default. Subclasses override only the message
+  // types they support (e.g., Telegram overrides handleText, handleToolCall, etc.).
 
   protected async handleText(
     _sessionId: string,
@@ -168,6 +204,10 @@ export abstract class MessagingAdapter implements IChannelAdapter {
 
   // === Helpers ===
 
+  /**
+   * Resolves the current output verbosity by checking (in priority order):
+   * per-channel config, global config, then adapter default. Falls back to "medium".
+   */
   protected getVerbosity(): DisplayVerbosity {
     const config = this.context.configManager.get();
     const channelConfig = (config as Record<string, unknown>).channels as
@@ -183,6 +223,13 @@ export abstract class MessagingAdapter implements IChannelAdapter {
     return "medium";
   }
 
+  /**
+   * Determines whether a message should be displayed at the given verbosity.
+   *
+   * Noise filtering: tool calls matching noise rules (e.g., `ls`, `glob`, `grep`)
+   * are hidden at medium/low verbosity to reduce clutter. Thoughts and usage
+   * stats are hidden entirely at "low".
+   */
   protected shouldDisplay(
     content: OutgoingMessage,
     verbosity: DisplayVerbosity,
@@ -203,19 +250,25 @@ export abstract class MessagingAdapter implements IChannelAdapter {
 
   // === Abstract — adapter MUST implement ===
 
+  /** Initializes the adapter (e.g., connect to platform API, start polling). */
   abstract start(): Promise<void>;
+  /** Gracefully shuts down the adapter and releases resources. */
   abstract stop(): Promise<void>;
+  /** Creates a platform-specific thread/topic for a session. Returns the thread ID. */
   abstract createSessionThread(
     sessionId: string,
     name: string,
   ): Promise<string>;
+  /** Renames an existing session thread/topic on the platform. */
   abstract renameSessionThread(
     sessionId: string,
     newName: string,
   ): Promise<void>;
+  /** Sends a permission request to the user with approve/deny actions. */
   abstract sendPermissionRequest(
     sessionId: string,
     request: PermissionRequest,
   ): Promise<void>;
+  /** Sends a cross-session notification (e.g., session completed, budget warning). */
   abstract sendNotification(notification: NotificationMessage): Promise<void>;
 }

--- a/src/core/adapter-primitives/output-mode-resolver.ts
+++ b/src/core/adapter-primitives/output-mode-resolver.ts
@@ -1,4 +1,8 @@
 // src/core/adapter-primitives/output-mode-resolver.ts
+//
+// Resolves the effective output mode for a given session by applying
+// a cascade of overrides: global -> per-adapter -> per-session.
+
 import type { OutputMode } from "./format-types.js";
 
 interface ConfigManagerLike {
@@ -14,7 +18,16 @@ function toOutputMode(v: unknown): OutputMode | undefined {
   return typeof v === "string" && VALID_MODES.has(v) ? (v as OutputMode) : undefined;
 }
 
+/**
+ * Resolves the effective output mode (low/medium/high) for a session.
+ *
+ * Override cascade (most specific wins):
+ * 1. Global config `outputMode` (default: "medium")
+ * 2. Per-adapter config `channels.<adapterName>.outputMode`
+ * 3. Per-session override stored on the session record
+ */
 export class OutputModeResolver {
+  /** Resolves the effective output mode by walking the override cascade. */
   resolve(
     configManager: ConfigManagerLike,
     adapterName: string,
@@ -22,14 +35,13 @@ export class OutputModeResolver {
     sessionManager?: SessionManagerLike,
   ): OutputMode {
     const config = configManager.get();
-    // 1. Global default
     let mode: OutputMode = toOutputMode(config.outputMode) ?? "medium";
-    // 2. Per-adapter override
+
     const channels = config.channels as Record<string, unknown> | undefined;
     const channelCfg = channels?.[adapterName] as Record<string, unknown> | undefined;
     const adapterMode = toOutputMode(channelCfg?.outputMode);
     if (adapterMode) mode = adapterMode;
-    // 3. Per-session override (most specific)
+
     if (sessionId && sessionManager) {
       const record = sessionManager.getSessionRecord(sessionId);
       const sessionMode = toOutputMode(record?.outputMode);

--- a/src/core/adapter-primitives/primitives/activity-tracker.ts
+++ b/src/core/adapter-primitives/primitives/activity-tracker.ts
@@ -1,8 +1,12 @@
+/** Timing configuration for the thinking indicator lifecycle. */
 export interface ActivityConfig {
+  /** How often (ms) to refresh the typing indicator (e.g., re-send "typing..." action). */
   thinkingRefreshInterval: number
+  /** Maximum duration (ms) before auto-dismissing the indicator to avoid stale UI. */
   maxThinkingDuration: number
 }
 
+/** Platform-specific callbacks for showing/updating/removing typing indicators. */
 export interface ActivityCallbacks {
   sendThinkingIndicator(): Promise<void>
   updateThinkingIndicator(): Promise<void>
@@ -16,11 +20,20 @@ interface SessionState {
   dismissed: boolean
 }
 
+/**
+ * Manages typing/thinking indicators across sessions.
+ *
+ * When the agent starts processing, a typing indicator is shown. It is
+ * periodically refreshed (platforms like Telegram expire typing status after
+ * ~5 seconds) and auto-dismissed either when text output begins or when
+ * the max thinking duration is reached.
+ */
 export class ActivityTracker {
   private sessions = new Map<string, SessionState>()
 
   constructor(private config: ActivityConfig) {}
 
+  /** Shows the typing indicator and starts the periodic refresh timer. */
   onThinkingStart(sessionId: string, callbacks: ActivityCallbacks): void {
     this.cleanup(sessionId)
 
@@ -38,6 +51,7 @@ export class ActivityTracker {
     }, 0)
   }
 
+  /** Dismisses the typing indicator when the agent starts producing text output. */
   onTextStart(sessionId: string): void {
     const state = this.sessions.get(sessionId)
     if (!state || state.dismissed) return
@@ -46,10 +60,12 @@ export class ActivityTracker {
     state.callbacks.removeThinkingIndicator().catch(() => {})
   }
 
+  /** Cleans up the typing indicator when the session ends. */
   onSessionEnd(sessionId: string): void {
     this.cleanup(sessionId)
   }
 
+  /** Cleans up all sessions (e.g., during adapter shutdown). */
   destroy(): void {
     for (const [id] of this.sessions) {
       this.cleanup(id)

--- a/src/core/adapter-primitives/primitives/draft-manager.ts
+++ b/src/core/adapter-primitives/primitives/draft-manager.ts
@@ -1,13 +1,29 @@
+/** Configuration for draft message flushing behavior. */
 export interface DraftConfig {
+  /** How often (ms) to flush buffered text to the platform. */
   flushInterval: number
   maxLength: number
+  /**
+   * Called to send or update a message on the platform.
+   * Returns the platform message ID on first send (isEdit=false);
+   * subsequent calls are edits (isEdit=true).
+   */
   onFlush: (sessionId: string, text: string, isEdit: boolean) => Promise<string | undefined>
   onError?: (sessionId: string, error: Error) => void
 }
 
+/**
+ * Manages a single in-progress (draft) message for streaming text output.
+ *
+ * As text chunks arrive from the agent, they are appended to an internal buffer.
+ * The buffer is flushed to the platform on a timer. The first flush creates the
+ * message; subsequent flushes edit it in place. This avoids sending many small
+ * messages and instead shows a live-updating message.
+ */
 export class Draft {
   private buffer = ''
   private _messageId?: string
+  /** Guards against concurrent first-flush — ensures only one sendMessage creates the draft. */
   private firstFlushPending = false
   private flushTimer?: ReturnType<typeof setTimeout>
   private flushPromise: Promise<void> = Promise.resolve()
@@ -18,14 +34,20 @@ export class Draft {
   ) {}
 
   get isEmpty(): boolean { return !this.buffer }
+  /** Platform message ID, set after the first successful flush. */
   get messageId(): string | undefined { return this._messageId }
 
+  /** Appends streaming text to the buffer and schedules a flush. */
   append(text: string): void {
     if (!text) return
     this.buffer += text
     this.scheduleFlush()
   }
 
+  /**
+   * Flushes any remaining buffered text and returns the platform message ID.
+   * Called when the streaming response completes.
+   */
   async finalize(): Promise<string | undefined> {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer)
@@ -38,6 +60,7 @@ export class Draft {
     return this._messageId
   }
 
+  /** Discards buffered text and cancels any pending flush. */
   destroy(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer)
@@ -59,6 +82,8 @@ export class Draft {
   private async flush(): Promise<void> {
     if (!this.buffer || this.firstFlushPending) return
 
+    // Snapshot the buffer before awaiting — append() can be called
+    // concurrently during the async flush operation.
     const snapshot = this.buffer
     const isEdit = !!this._messageId
 
@@ -84,11 +109,18 @@ export class Draft {
   }
 }
 
+/**
+ * Manages draft messages across multiple sessions.
+ *
+ * Each session gets at most one active draft. When a session's streaming
+ * response completes, the draft is finalized (final flush + cleanup).
+ */
 export class DraftManager {
   private drafts = new Map<string, Draft>()
 
   constructor(private config: DraftConfig) {}
 
+  /** Returns the existing draft for a session, or creates a new one. */
   getOrCreate(sessionId: string): Draft {
     let draft = this.drafts.get(sessionId)
     if (!draft) {
@@ -98,6 +130,7 @@ export class DraftManager {
     return draft
   }
 
+  /** Finalizes and removes the draft for a session. */
   async finalize(sessionId: string): Promise<void> {
     const draft = this.drafts.get(sessionId)
     if (!draft) return
@@ -105,10 +138,12 @@ export class DraftManager {
     this.drafts.delete(sessionId)
   }
 
+  /** Finalizes all active drafts (e.g., during adapter shutdown). */
   async finalizeAll(): Promise<void> {
     await Promise.all([...this.drafts.values()].map(d => d.finalize()))
   }
 
+  /** Destroys a draft without flushing (e.g., on session error). */
   destroy(sessionId: string): void {
     const draft = this.drafts.get(sessionId)
     if (draft) {
@@ -117,6 +152,7 @@ export class DraftManager {
     }
   }
 
+  /** Destroys all drafts without flushing. */
   destroyAll(): void {
     for (const draft of this.drafts.values()) {
       draft.destroy()

--- a/src/core/adapter-primitives/primitives/send-queue.ts
+++ b/src/core/adapter-primitives/primitives/send-queue.ts
@@ -1,15 +1,26 @@
+/**
+ * Item type determines deduplication behavior:
+ * - `"text"` items with the same key replace each other (only latest is sent)
+ * - `"other"` items are always queued individually
+ */
 export type QueueItemType = 'text' | 'other'
 
+/** Configuration for the SendQueue rate limiter. */
 export interface SendQueueConfig {
+  /** Minimum interval (ms) between consecutive operations. */
   minInterval: number
+  /** Per-category interval overrides (e.g., separate limits for edits vs. sends). */
   categoryIntervals?: Record<string, number>
   onRateLimited?: () => void
   onError?: (error: Error) => void
 }
 
+/** Options for enqueuing an operation. */
 export interface EnqueueOptions {
   type?: QueueItemType
+  /** Deduplication key — text items with the same key replace earlier ones. */
   key?: string
+  /** Category for per-category rate limiting. */
   category?: string
 }
 
@@ -23,6 +34,15 @@ interface QueueItem<T = unknown> {
   promise: Promise<T | undefined>
 }
 
+/**
+ * Serializes outbound platform API calls to respect rate limits and maintain ordering.
+ *
+ * Key behaviors:
+ * - Enforces a minimum interval between consecutive operations
+ * - Supports per-category intervals (e.g., different limits for message edits vs. sends)
+ * - Deduplicates text-type items with the same key (only the latest update is sent)
+ * - On rate limit, drops all pending text items to reduce backlog
+ */
 export class SendQueue {
   private items: QueueItem[] = []
   private processing = false
@@ -35,6 +55,13 @@ export class SendQueue {
     return this.items.length
   }
 
+  /**
+   * Queues an async operation for rate-limited execution.
+   *
+   * For text-type items with a key, replaces any existing queued item with
+   * the same key (deduplication). This is used for streaming draft updates
+   * where only the latest content matters.
+   */
   enqueue<T>(
     fn: () => Promise<T>,
     opts?: EnqueueOptions,
@@ -52,6 +79,7 @@ export class SendQueue {
     // Suppress unhandled rejection — callers are expected to handle via .catch or await
     promise.catch(() => {})
 
+    // Deduplication: replace an existing text item with the same key
     if (type === 'text' && key) {
       const idx = this.items.findIndex(
         (item) => item.type === 'text' && item.key === key,
@@ -69,6 +97,11 @@ export class SendQueue {
     return promise
   }
 
+  /**
+   * Called when a platform rate limit is hit. Drops all pending text items
+   * (draft updates) to reduce backlog, keeping only non-text items that
+   * represent important operations (e.g., permission requests).
+   */
   onRateLimited(): void {
     this.config.onRateLimited?.()
     const remaining: QueueItem[] = []
@@ -89,6 +122,10 @@ export class SendQueue {
     this.items = []
   }
 
+  /**
+   * Schedules the next item for processing after the rate-limit delay.
+   * Uses per-category timing when available, falling back to the global minInterval.
+   */
   private scheduleProcess(): void {
     if (this.processing) return
     if (this.items.length === 0) return

--- a/src/core/adapter-primitives/primitives/tool-call-tracker.ts
+++ b/src/core/adapter-primitives/primitives/tool-call-tracker.ts
@@ -1,12 +1,20 @@
 import type { ToolCallMeta } from '../format-types.js'
 
+/** A tool call associated with the platform message ID where it is displayed. */
 export interface TrackedToolCall extends ToolCallMeta {
+  /** Platform message ID of the tool card message, used for in-place updates. */
   messageId: string
 }
 
+/**
+ * Tracks active tool calls per session, associating each with the platform
+ * message that displays it. Used by adapters that render individual tool
+ * cards and need to update them in-place when tool status changes.
+ */
 export class ToolCallTracker {
   private sessions = new Map<string, Map<string, TrackedToolCall>>()
 
+  /** Registers a new tool call and associates it with its platform message ID. */
   track(sessionId: string, meta: ToolCallMeta, messageId: string): void {
     if (!this.sessions.has(sessionId)) {
       this.sessions.set(sessionId, new Map())
@@ -14,6 +22,7 @@ export class ToolCallTracker {
     this.sessions.get(sessionId)!.set(meta.id, { ...meta, messageId })
   }
 
+  /** Updates a tracked tool call's status and optional metadata. Returns null if not found. */
   update(
     sessionId: string,
     toolId: string,
@@ -32,11 +41,13 @@ export class ToolCallTracker {
     return tool
   }
 
+  /** Returns all tracked tool calls for a session (regardless of status). */
   getActive(sessionId: string): TrackedToolCall[] {
     const session = this.sessions.get(sessionId)
     return session ? [...session.values()] : []
   }
 
+  /** Removes all tracked tool calls for a session (called at turn end). */
   clear(sessionId: string): void {
     this.sessions.delete(sessionId)
   }

--- a/src/core/adapter-primitives/primitives/tool-card-state.ts
+++ b/src/core/adapter-primitives/primitives/tool-card-state.ts
@@ -1,35 +1,54 @@
 import type { ToolDisplaySpec } from "../display-spec-builder.js";
 import type { PlanEntry } from "../../types.js";
 
+/** Debounce interval for batching rapid tool state updates into a single render. */
 const DEBOUNCE_MS = 500;
 
 export type { ToolDisplaySpec };
 
+/** Token usage and cost data appended to the tool card after the turn completes. */
 export interface UsageData {
   tokensUsed?: number;
   contextSize?: number;
   cost?: number;
 }
 
+/**
+ * A point-in-time snapshot of all tool cards in a turn, used for rendering.
+ * Includes completion counts so adapters can show progress (e.g., "3/5 tools done").
+ */
 export interface ToolCardSnapshot {
   specs: ToolDisplaySpec[];
   planEntries?: PlanEntry[];
   usage?: UsageData;
   totalVisible: number;
   completedVisible: number;
+  /** True when all visible tools have reached a terminal status. */
   allComplete: boolean;
 }
 
 export interface ToolCardStateConfig {
+  /** Called with a snapshot whenever the tool card content changes. */
   onFlush: (snapshot: ToolCardSnapshot) => void;
 }
 
 const DONE_STATUSES = new Set(["completed", "done", "failed", "error"]);
 
+/**
+ * Aggregates tool display specs, plan entries, and usage data for a single
+ * turn, then flushes snapshots to the adapter for rendering.
+ *
+ * Uses debouncing to batch rapid updates (e.g., multiple tools starting
+ * in quick succession) into a single render pass. The first update flushes
+ * immediately for responsiveness; subsequent updates are debounced.
+ */
 export class ToolCardState {
   private specs: ToolDisplaySpec[] = [];
   private planEntries?: PlanEntry[];
   private usage?: UsageData;
+  // Lifecycle: active (first flush pending) → active (subsequent updates debounced) → finalized.
+  // Once finalized, all updateFromSpec/updatePlan/appendUsage/finalize() calls are no-ops —
+  // guards against events arriving after the session has ended or the tool has already completed.
   private finalized = false;
   private isFirstFlush = true;
   private debounceTimer?: ReturnType<typeof setTimeout>;
@@ -39,6 +58,7 @@ export class ToolCardState {
     this.onFlush = config.onFlush;
   }
 
+  /** Adds or updates a tool spec. First call flushes immediately; subsequent calls are debounced. */
   updateFromSpec(spec: ToolDisplaySpec): void {
     if (this.finalized) return;
 
@@ -57,6 +77,7 @@ export class ToolCardState {
     }
   }
 
+  /** Updates the plan entries displayed alongside tool cards. */
   updatePlan(entries: PlanEntry[]): void {
     if (this.finalized) return;
     this.planEntries = entries;
@@ -69,12 +90,14 @@ export class ToolCardState {
     }
   }
 
+  /** Appends token usage data to the tool card (typically at end of turn). */
   appendUsage(usage: UsageData): void {
     if (this.finalized) return;
     this.usage = usage;
     this.scheduleFlush();
   }
 
+  /** Marks the turn as complete and flushes the final snapshot immediately. */
   finalize(): void {
     if (this.finalized) return;
     this.finalized = true;
@@ -82,6 +105,7 @@ export class ToolCardState {
     this.flush();
   }
 
+  /** Stops all pending flushes without emitting a final snapshot. */
   destroy(): void {
     this.finalized = true;
     this.clearDebounce();

--- a/src/core/adapter-primitives/rendering/renderer.ts
+++ b/src/core/adapter-primitives/rendering/renderer.ts
@@ -15,25 +15,34 @@ import {
 } from "../message-formatter.js";
 import { progressBar, formatTokens } from "../format-utils.js";
 
+/**
+ * A rendered message ready for platform delivery.
+ * The `format` field tells the adapter how to interpret the body
+ * (e.g., pass as HTML to Telegram, or as plain text to SSE).
+ */
 export interface RenderedMessage<TComponents = unknown> {
   body: string;
   format: "html" | "markdown" | "plain" | "structured";
   attachments?: RenderedAttachment[];
+  /** Platform-specific UI components (e.g., Telegram inline keyboards). */
   components?: TComponents;
 }
 
+/** A rendered permission request with approve/deny action buttons. */
 export interface RenderedPermission<
   TComponents = unknown,
 > extends RenderedMessage<TComponents> {
   actions: RenderedAction[];
 }
 
+/** A single action button for permission requests. */
 export interface RenderedAction {
   id: string;
   label: string;
   isAllow?: boolean;
 }
 
+/** A file, image, or audio attachment to include with a rendered message. */
 export interface RenderedAttachment {
   type: "file" | "image" | "audio";
   data: Buffer | string;
@@ -41,6 +50,14 @@ export interface RenderedAttachment {
   filename?: string;
 }
 
+/**
+ * Rendering contract for platform-specific message formatting.
+ *
+ * Each adapter provides its own IRenderer implementation (e.g., TelegramRenderer
+ * outputs HTML, a CLI renderer might output ANSI). Required methods handle the
+ * core message types; optional methods handle less common types and fall back
+ * to no-ops if not implemented.
+ */
 export interface IRenderer {
   renderText(
     content: OutgoingMessage,
@@ -86,7 +103,11 @@ export interface IRenderer {
 }
 
 /**
- * BaseRenderer — plain text defaults. Extend for platform-specific rendering.
+ * Default renderer producing plain-text output for all message types.
+ *
+ * Platform-specific renderers (e.g., TelegramRenderer) extend this class
+ * and override methods to produce HTML, markdown, or structured output.
+ * Methods not overridden fall back to these plain-text defaults.
  */
 export class BaseRenderer implements IRenderer {
   renderText(content: OutgoingMessage): RenderedMessage {

--- a/src/core/adapter-primitives/stream-accumulator.ts
+++ b/src/core/adapter-primitives/stream-accumulator.ts
@@ -1,13 +1,18 @@
 // src/core/adapter-primitives/stream-accumulator.ts
+//
+// Buffers and accumulates streaming agent output (tool calls, thoughts)
+// into structured state that adapters can render at any point during a turn.
 
 import type { ToolCallMeta, ViewerLinks } from "./format-types.js";
 import { evaluateNoise } from "./message-formatter.js";
 
+/** Accumulated state for a single tool call during a streaming response. */
 export interface ToolEntry {
   id: string;
   name: string;
   kind: string;
   rawInput: unknown;
+  /** Tool output content, populated when the tool completes. */
   content: string | null;
   status: string;
   viewerLinks?: ViewerLinks;
@@ -15,9 +20,11 @@ export interface ToolEntry {
   displaySummary?: string;
   displayTitle?: string;
   displayKind?: string;
+  /** Whether this tool is considered noise (e.g., ls, glob) and should be hidden at lower verbosities. */
   isNoise: boolean;
 }
 
+/** Buffered update for a tool whose initial `tool_call` event has not arrived yet. */
 interface PendingUpdate {
   status: string;
   rawInput?: unknown;
@@ -26,6 +33,13 @@ interface PendingUpdate {
   diffStats?: { added: number; removed: number };
 }
 
+/**
+ * Tracks all tool calls within a single streaming turn.
+ *
+ * Tool call events and update events can arrive out of order (e.g., a
+ * `tool_update` may arrive before the corresponding `tool_call`). This map
+ * handles that by buffering updates until the initial call arrives.
+ */
 export class ToolStateMap {
   private entries: Map<string, ToolEntry> = new Map();
   private pendingUpdates: Map<string, PendingUpdate> = new Map();
@@ -103,30 +117,42 @@ export class ToolStateMap {
     }
   }
 
+  /** Retrieves a tool entry by ID, or undefined if not yet tracked. */
   get(id: string): ToolEntry | undefined {
     return this.entries.get(id);
   }
 
+  /** Resets all state between turns. */
   clear(): void {
     this.entries.clear();
     this.pendingUpdates.clear();
   }
 }
 
+/**
+ * Buffers partial thought text chunks from the agent's extended thinking.
+ *
+ * Chunks are appended until `seal()` is called, which marks the thought
+ * as complete and returns the full text. Once sealed, further appends
+ * are ignored.
+ */
 export class ThoughtBuffer {
   private chunks: string[] = [];
   private sealed = false;
 
+  /** Appends a thought text chunk. Ignored if already sealed. */
   append(chunk: string): void {
     if (this.sealed) return;
     this.chunks.push(chunk);
   }
 
+  /** Marks the thought as complete and returns the full accumulated text. */
   seal(): string {
     this.sealed = true;
     return this.chunks.join("");
   }
 
+  /** Returns the text accumulated so far without sealing. */
   getText(): string {
     return this.chunks.join("");
   }
@@ -135,6 +161,7 @@ export class ThoughtBuffer {
     return this.sealed;
   }
 
+  /** Resets the buffer for reuse in a new turn. */
   reset(): void {
     this.chunks = [];
     this.sealed = false;

--- a/src/core/adapter-primitives/stream-adapter.ts
+++ b/src/core/adapter-primitives/stream-adapter.ts
@@ -8,6 +8,7 @@ import type {
   NotificationMessage,
 } from '../types.js'
 
+/** A structured event emitted over the stream (SSE, WebSocket, etc.). */
 export interface StreamEvent {
   type: string
   sessionId?: string
@@ -15,6 +16,15 @@ export interface StreamEvent {
   timestamp: number
 }
 
+/**
+ * Base class for stream-based adapters (SSE, WebSocket) that push events
+ * directly to connected clients rather than rendering messages on a platform.
+ *
+ * Unlike MessagingAdapter (which renders and sends formatted messages),
+ * StreamAdapter wraps each outgoing message as a StreamEvent and emits it
+ * to all connections watching that session. The client is responsible for
+ * rendering.
+ */
 export abstract class StreamAdapter implements IChannelAdapter {
   abstract readonly name: string
 
@@ -32,6 +42,7 @@ export abstract class StreamAdapter implements IChannelAdapter {
     }
   }
 
+  /** Wraps the outgoing message as a StreamEvent and emits it to the session's listeners. */
   async sendMessage(sessionId: string, content: OutgoingMessage): Promise<void> {
     await this.emit(sessionId, {
       type: content.type,
@@ -41,6 +52,7 @@ export abstract class StreamAdapter implements IChannelAdapter {
     })
   }
 
+  /** Emits a permission request event so the client can render approve/deny UI. */
   async sendPermissionRequest(sessionId: string, request: PermissionRequest): Promise<void> {
     await this.emit(sessionId, {
       type: 'permission_request',
@@ -50,6 +62,7 @@ export abstract class StreamAdapter implements IChannelAdapter {
     })
   }
 
+  /** Broadcasts a notification to all connected clients (not scoped to a session). */
   async sendNotification(notification: NotificationMessage): Promise<void> {
     await this.broadcast({
       type: 'notification',
@@ -58,10 +71,15 @@ export abstract class StreamAdapter implements IChannelAdapter {
     })
   }
 
+  /**
+   * No-op for stream adapters — threads are a platform concept (Telegram topics, Slack threads).
+   * Stream clients manage their own session UI.
+   */
   async createSessionThread(_sessionId: string, _name: string): Promise<string> {
     return ''
   }
 
+  /** Emits a rename event so connected clients can update their session title. */
   async renameSessionThread(sessionId: string, name: string): Promise<void> {
     await this.emit(sessionId, {
       type: 'session_rename',
@@ -71,7 +89,9 @@ export abstract class StreamAdapter implements IChannelAdapter {
     })
   }
 
+  /** Sends an event to all connections watching a specific session. */
   protected abstract emit(sessionId: string, event: StreamEvent): Promise<void>
+  /** Sends an event to all connected clients regardless of session. */
   protected abstract broadcast(event: StreamEvent): Promise<void>
   abstract start(): Promise<void>
   abstract stop(): Promise<void>

--- a/src/core/adapter-primitives/types.ts
+++ b/src/core/adapter-primitives/types.ts
@@ -1,9 +1,24 @@
+/**
+ * Accumulates text chunks from a streaming agent response and flushes
+ * the buffered content to the platform as a single message.
+ *
+ * Implementations handle platform-specific message creation/editing
+ * (e.g., Telegram message edits, SSE event writes).
+ */
 export interface ITextBuffer {
+  /** Appends a partial text chunk to the internal buffer. */
   append(text: string): void;
+  /** Flushes all buffered text to the platform (send or edit). */
   flush(): Promise<void>;
+  /** Discards any buffered text and releases resources. */
   destroy(): void;
 }
 
+/**
+ * Serializes async operations to respect platform rate limits and
+ * maintain message ordering within a session.
+ */
 export interface ISendQueue<T = unknown> {
+  /** Queues an async operation for sequential execution. */
   enqueue<R>(fn: () => Promise<R>): Promise<R>;
 }

--- a/src/core/agent-switch-handler.ts
+++ b/src/core/agent-switch-handler.ts
@@ -14,6 +14,7 @@ import { Hook, BusEvent, SessionEv } from "./events.js";
 
 const log = createChildLogger({ module: "agent-switch" });
 
+/** Dependencies injected from OpenACPCore to avoid circular imports. */
 export interface AgentSwitchDeps {
   sessionManager: SessionManager;
   agentManager: AgentManager;
@@ -27,11 +28,30 @@ export interface AgentSwitchDeps {
   getService: <T>(name: string) => T | undefined;
 }
 
+/**
+ * Coordinates the state transitions required when switching agents mid-session.
+ *
+ * Switching agents is a multi-step process with rollback support:
+ * 1. Run `agent:beforeSwitch` middleware (blocking — plugins can veto)
+ * 2. Determine whether to resume a previous agent session or spawn fresh
+ * 3. Disconnect all SessionBridges and clean up adapter state
+ * 4. Replace the agent instance on the session (with rollback on failure)
+ * 5. Reconnect all bridges to the new agent
+ * 6. Persist updated session record
+ * 7. Fire `agent:afterSwitch` middleware (non-blocking)
+ *
+ * A per-session lock prevents concurrent switches on the same session.
+ */
 export class AgentSwitchHandler {
+  /** Prevents concurrent switch operations on the same session */
   private switchingLocks = new Set<string>();
 
   constructor(private deps: AgentSwitchDeps) {}
 
+  /**
+   * Switch a session to a different agent. Returns whether the previous
+   * agent session was resumed or a new one was spawned.
+   */
   async switch(sessionId: string, toAgent: string): Promise<{ resumed: boolean }> {
     if (this.switchingLocks.has(sessionId)) {
       throw new Error('Switch already in progress');
@@ -64,7 +84,8 @@ export class AgentSwitchHandler {
     }, async (payload) => payload);
     if (middlewareChain && !result) throw new Error('Agent switch blocked by middleware');
 
-    // 2. Determine resume vs new
+    // 2. Determine resume vs new — if the agent was used before in this session
+    //    and supports resume, reconnect to its previous subprocess instead of spawning fresh
     const lastEntry = session.findLastSwitchEntry(toAgent);
     const caps = getAgentCapabilities(toAgent);
     const canResume = !!(lastEntry && caps.supportsResume);
@@ -105,7 +126,9 @@ export class AgentSwitchHandler {
 
     const fromAgentSessionId = session.agentSessionId;
 
-    // 4. Switch agent on session (with rollback on failure)
+    // 4. Switch agent on session (with rollback on failure).
+    //    switchAgent() replaces the session's agent instance atomically — if the
+    //    factory callback throws, the session state is unchanged.
     const fileService = this.deps.getService<import('../plugins/file-service/file-service.js').FileService>('file-service');
     const configAllowedPaths = configManager.get().workspace?.security?.allowedPaths ?? [];
     try {
@@ -122,6 +145,8 @@ export class AgentSwitchHandler {
           }
         }
 
+        // Fresh spawn: inject conversation history from the context service so the
+        // new agent has awareness of what was discussed with the previous agent
         const instance = await agentManager.spawn(toAgent, session.workingDirectory, configAllowedPaths);
         if (fileService) instance.addAllowedPath(fileService.baseDir);
         try {

--- a/src/core/agents/agent-catalog.ts
+++ b/src/core/agents/agent-catalog.ts
@@ -25,10 +25,23 @@ interface RegistryCache {
   data: { agents: RegistryAgent[] };
 }
 
+/**
+ * Central catalog of available and installed agents.
+ *
+ * Combines two data sources:
+ *  1. **Registry** — the remote ACP agent registry (CDN-hosted JSON), cached
+ *     locally with a 24-hour TTL and a bundled snapshot as fallback.
+ *  2. **Store** — locally installed agents persisted in `agents.json`.
+ *
+ * Provides discovery (list all agents), installation, uninstallation,
+ * and resolution (name → AgentDefinition for spawning).
+ */
 export class AgentCatalog {
   private store: AgentStore;
+  /** Agents available in the remote registry (cached in memory after load). */
   private registryAgents: RegistryAgent[] = [];
   private cachePath: string;
+  /** Directory where binary agent archives are extracted to. */
   private agentsDir: string | undefined;
 
   constructor(store: AgentStore, cachePath: string, agentsDir?: string) {
@@ -37,6 +50,12 @@ export class AgentCatalog {
     this.agentsDir = agentsDir;
   }
 
+  /**
+   * Load installed agents from disk and hydrate the registry from cache/snapshot.
+   *
+   * Also enriches installed agents with registry metadata — fixes agents that
+   * were migrated from older config formats with incomplete data.
+   */
   load(): void {
     this.store.load();
     this.loadRegistryFromCacheOrSnapshot();
@@ -45,6 +64,7 @@ export class AgentCatalog {
 
   // --- Registry ---
 
+  /** Fetch the latest agent registry from the CDN and update the local cache. */
   async fetchRegistry(): Promise<void> {
     try {
       log.info("Fetching agent registry from CDN...");
@@ -66,6 +86,7 @@ export class AgentCatalog {
     }
   }
 
+  /** Re-fetch registry only if the local cache has expired (24-hour TTL). */
   async refreshRegistryIfStale(): Promise<void> {
     if (this.isCacheStale()) {
       await this.fetchRegistry();
@@ -80,6 +101,7 @@ export class AgentCatalog {
     return this.registryAgents.find((a) => a.id === registryId);
   }
 
+  /** Find a registry agent by registry ID or by its short alias (e.g., "claude"). */
   findRegistryAgent(keyOrId: string): RegistryAgent | undefined {
     const byId = this.registryAgents.find((a) => a.id === keyOrId);
     if (byId) return byId;
@@ -102,6 +124,15 @@ export class AgentCatalog {
 
   // --- Discovery ---
 
+  /**
+   * Build the unified list of all agents (installed + registry-only).
+   *
+   * Installed agents appear first with their live availability status.
+   * Registry agents that aren't installed yet show whether a distribution
+   * exists for the current platform. Missing external dependencies
+   * (e.g., claude CLI) are surfaced as `missingDeps` for UI display
+   * but do NOT block installation.
+   */
   getAvailable(): AgentListItem[] {
     const installed = this.getInstalledEntries();
     const items: AgentListItem[] = [];
@@ -156,6 +187,7 @@ export class AgentCatalog {
     return items;
   }
 
+  /** Check if an agent can be installed on this system (platform + dependencies). */
   checkAvailability(keyOrId: string): AvailabilityResult {
     const agent = this.findRegistryAgent(keyOrId);
     if (!agent) return { available: false, reason: "Not found in the agent registry." };
@@ -170,6 +202,12 @@ export class AgentCatalog {
 
   // --- Install/Uninstall ---
 
+  /**
+   * Install an agent from the registry.
+   *
+   * Resolves the distribution (npx/uvx/binary), downloads binary archives
+   * if needed, and persists the agent definition in the store.
+   */
   async install(keyOrId: string, progress?: InstallProgress, force?: boolean): Promise<InstallResult> {
     const agent = this.findRegistryAgent(keyOrId);
     if (!agent) {
@@ -198,6 +236,7 @@ export class AgentCatalog {
     this.store.addAgent(key, data);
   }
 
+  /** Remove an installed agent and delete its binary directory if applicable. */
   async uninstall(key: string): Promise<{ ok: boolean; error?: string }> {
     if (this.store.hasAgent(key)) {
       await uninstallAgent(key, this.store);
@@ -208,6 +247,7 @@ export class AgentCatalog {
 
   // --- Resolution (for AgentManager) ---
 
+  /** Convert an installed agent's short key to an AgentDefinition for spawning. */
   resolve(key: string): AgentDefinition | undefined {
     const agent = this.store.getAgent(key);
     if (!agent) return undefined;

--- a/src/core/agents/agent-dependencies.ts
+++ b/src/core/agents/agent-dependencies.ts
@@ -1,19 +1,39 @@
+/**
+ * Agent dependency metadata, capabilities, and integration specs.
+ *
+ * This module contains static knowledge about each supported agent:
+ *  - **Dependencies** — external CLIs an agent requires (e.g., claude-acp needs the Claude CLI)
+ *  - **Setup info** — post-install instructions shown to the user
+ *  - **Capabilities** — whether an agent supports resume, and integration specs
+ *    for hooks/plugins that enable cross-agent coordination
+ *  - **Aliases** — maps registry IDs to short names (e.g., "claude-acp" → "claude")
+ */
+
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AvailabilityResult } from "../types.js";
 
+/** An external CLI binary that an agent requires to function. */
 export interface AgentDependency {
   command: string;
   label: string;
   installHint: string;
 }
 
+/** Post-install setup instructions displayed to the user after agent installation. */
 export interface AgentSetupInfo {
   setupSteps: string[];
   loginCommand?: string;
 }
 
+/**
+ * Integration spec for agents that support hooks-based coordination.
+ *
+ * Hooks let OpenACP inject behavior into the agent's lifecycle (e.g.,
+ * intercepting prompts for multi-agent handoff). The spec describes
+ * where the agent's settings and hooks directories live.
+ */
 export interface AgentHooksIntegrationSpec {
   strategy: "hooks";
   hookEvent: string;
@@ -29,6 +49,7 @@ export interface AgentHooksIntegrationSpec {
   workingDirVar?: string;
 }
 
+/** Integration spec for agents that support plugin-based coordination (e.g., opencode). */
 export interface AgentPluginIntegrationSpec {
   strategy: "plugin";
   pluginProvider: "opencode";
@@ -41,6 +62,7 @@ export interface AgentPluginIntegrationSpec {
 
 export type AgentIntegrationSpec = AgentHooksIntegrationSpec | AgentPluginIntegrationSpec;
 
+/** Static capability metadata for an agent (resume support, integration spec). */
 export interface AgentCapability {
   supportsResume: boolean;
   resumeCommand?: (sessionId: string) => string;
@@ -192,6 +214,7 @@ const AGENT_SETUP: Record<string, AgentSetupInfo> = {
   },
 };
 
+/** Get post-install setup instructions for an agent, if any. */
 export function getAgentSetup(registryId: string): AgentSetupInfo | undefined {
   return AGENT_SETUP[registryId];
 }
@@ -284,6 +307,7 @@ const AGENT_CAPABILITIES: Record<string, AgentCapability> = {
   },
 };
 
+/** Maps registry IDs to short user-facing names used as keys in agents.json. */
 export const REGISTRY_AGENT_ALIASES: Record<string, string> = {
   "claude-acp": "claude",
   "codex-acp": "codex",
@@ -296,24 +320,34 @@ export const REGISTRY_AGENT_ALIASES: Record<string, string> = {
   "qwen-code": "qwen",
 };
 
+/** Convert a registry ID to its short alias, or return the ID if no alias exists. */
 export function getAgentAlias(registryId: string): string {
   return REGISTRY_AGENT_ALIASES[registryId] ?? registryId;
 }
 
+/** Get the external CLI dependencies for an agent (empty if none required). */
 export function getAgentDependencies(registryId: string): AgentDependency[] {
   return AGENT_DEPENDENCIES[registryId] ?? [];
 }
 
+/** Look up static capabilities for an agent by its short name. */
 export function getAgentCapabilities(agentName: string): AgentCapability {
   return AGENT_CAPABILITIES[agentName] ?? { supportsResume: false };
 }
 
+/** List agent names that have a hooks or plugin integration spec defined. */
 export function listAgentsWithIntegration(): string[] {
   return Object.entries(AGENT_CAPABILITIES)
     .filter(([, cap]) => cap.integration != null)
     .map(([key]) => key);
 }
 
+/**
+ * Check if a command is available on the system.
+ *
+ * Checks PATH via `which` first, then walks up from cwd looking for
+ * the command in `node_modules/.bin/` directories.
+ */
 export function commandExists(cmd: string): boolean {
   try {
     execFileSync("which", [cmd], { stdio: "pipe" });
@@ -333,6 +367,7 @@ export function commandExists(cmd: string): boolean {
   return false;
 }
 
+/** Check if all external dependencies for an agent are installed on this system. */
 export function checkDependencies(registryId: string): AvailabilityResult {
   const deps = getAgentDependencies(registryId);
   if (deps.length === 0) return { available: true };
@@ -347,6 +382,7 @@ export function checkDependencies(registryId: string): AvailabilityResult {
   };
 }
 
+/** Check if a package runner (npx or uvx) is available on this system. */
 export function checkRuntimeAvailable(runtime: "npx" | "uvx"): boolean {
   return commandExists(runtime);
 }

--- a/src/core/agents/agent-installer.ts
+++ b/src/core/agents/agent-installer.ts
@@ -1,3 +1,15 @@
+/**
+ * Agent installation and uninstallation logic.
+ *
+ * Handles three distribution types:
+ *  - **npx** — Node package runner (no download, resolved on first use)
+ *  - **uvx** — Python package runner (no download, resolved on first use)
+ *  - **binary** — pre-built archive downloaded and extracted to `~/.openacp/agents/`
+ *
+ * Binary archives are validated before and after extraction to prevent
+ * path traversal attacks and symlink escapes.
+ */
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -13,6 +25,7 @@ const DEFAULT_AGENTS_DIR = path.join(os.homedir(), ".openacp", "agents");
 
 export const MAX_DOWNLOAD_SIZE = 500 * 1024 * 1024; // 500MB
 
+/** Verify SHA-256 checksum of a downloaded binary archive. */
 export function verifyChecksum(buffer: Buffer, expectedHash: string): void {
   const actualHash = crypto.createHash("sha256").update(buffer).digest("hex");
   if (actualHash !== expectedHash) {
@@ -22,6 +35,12 @@ export function verifyChecksum(buffer: Buffer, expectedHash: string): void {
   }
 }
 
+/**
+ * Validate archive entries before extraction to prevent path traversal attacks.
+ *
+ * Rejects entries containing `..` path segments or absolute paths that could
+ * write files outside the destination directory.
+ */
 export function validateArchiveContents(entries: string[], destDir: string): void {
   for (const entry of entries) {
     // Check for path traversal segments, not just substring — avoids false positives
@@ -39,6 +58,7 @@ export function validateArchiveContents(entries: string[], destDir: string): voi
 /** @deprecated Use validateArchiveContents instead */
 export const validateTarContents = validateArchiveContents;
 
+/** Safety check: refuse to delete paths outside the agents directory during uninstall. */
 export function validateUninstallPath(binaryPath: string, agentsDir: string): void {
   const realPath = path.resolve(binaryPath);
   const realAgentsDir = path.resolve(agentsDir);
@@ -47,6 +67,8 @@ export function validateUninstallPath(binaryPath: string, agentsDir: string): vo
   }
 }
 
+// Map Node's os.arch/platform values to the naming convention used by the
+// ACP agent registry's binary distribution targets.
 const ARCH_MAP: Record<string, string> = {
   arm64: "aarch64",
   x64: "x86_64",
@@ -58,6 +80,7 @@ const PLATFORM_MAP: Record<string, string> = {
   win32: "windows",
 };
 
+/** Build a platform-arch key (e.g., "darwin-aarch64") for binary distribution lookup. */
 export function getPlatformKey(): string {
   const platform = PLATFORM_MAP[process.platform] ?? process.platform;
   const arch = ARCH_MAP[process.arch] ?? process.arch;
@@ -69,6 +92,12 @@ export type ResolvedDistribution =
   | { type: "uvx"; package: string; args: string[]; env?: Record<string, string> }
   | { type: "binary"; archive: string; cmd: string; args: string[]; env?: Record<string, string> };
 
+/**
+ * Determine how to run an agent on this platform.
+ *
+ * Returns the distribution type (npx/uvx/binary) with all necessary
+ * metadata, or null if no distribution exists for the current platform.
+ */
 export function resolveDistribution(agent: RegistryAgent): ResolvedDistribution | null {
   const dist = agent.distribution;
 
@@ -87,6 +116,12 @@ export function resolveDistribution(agent: RegistryAgent): ResolvedDistribution 
   return null;
 }
 
+/**
+ * Build an InstalledAgent record from a resolved distribution.
+ *
+ * For npx/uvx agents, version pins are stripped from the package name so
+ * the runner always resolves to the latest version at runtime.
+ */
 export function buildInstalledAgent(
   registryId: string,
   name: string,
@@ -155,6 +190,17 @@ function stripPythonPackageVersion(pkg: string): string {
   return at === -1 ? pkg : pkg.slice(0, at);
 }
 
+/**
+ * Install an agent from the registry.
+ *
+ * Steps:
+ *  1. Resolve distribution type for the current platform
+ *  2. Check runtime availability (uvx/npx must exist)
+ *  3. Check external CLI dependencies (non-blocking — surfaced as setup steps)
+ *  4. Download and extract binary archives (binary type only)
+ *  5. Save to the agent store
+ *  6. Return setup instructions for post-install configuration
+ */
 export async function installAgent(
   agent: RegistryAgent,
   store: AgentStore,
@@ -245,6 +291,12 @@ async function downloadAndExtract(
   return destDir;
 }
 
+/**
+ * Read a fetch response body with download progress reporting and size limit enforcement.
+ *
+ * Streams chunks incrementally to avoid buffering the entire response
+ * in memory before checking the size.
+ */
 export async function readResponseWithProgress(
   response: Response,
   contentLength: number,
@@ -275,6 +327,11 @@ export async function readResponseWithProgress(
   return Buffer.concat(chunks);
 }
 
+/**
+ * Post-extraction safety check: verify all extracted files resolve within
+ * the destination directory. Catches symlink-based escapes that wouldn't
+ * be detected by pre-extraction path validation alone.
+ */
 function validateExtractedPaths(destDir: string): void {
   const realDest = fs.realpathSync(destDir);
   const entries = fs.readdirSync(destDir, { recursive: true, withFileTypes: true });
@@ -337,6 +394,7 @@ async function extractZip(buffer: Buffer, destDir: string): Promise<void> {
   validateExtractedPaths(destDir);
 }
 
+/** Remove an agent from the store and delete its binary directory if present. */
 export async function uninstallAgent(
   agentKey: string,
   store: AgentStore,

--- a/src/core/agents/agent-instance.ts
+++ b/src/core/agents/agent-instance.ts
@@ -1,3 +1,17 @@
+/**
+ * AgentInstance — the ACP Client implementation that manages an agent subprocess.
+ *
+ * This is the lowest-level boundary between OpenACP and an external AI agent.
+ * It spawns the agent as a child process, communicates over stdin/stdout using
+ * the Agent Client Protocol (newline-delimited JSON), and translates ACP events
+ * into the internal `AgentEvent` union consumed by Session and adapters.
+ *
+ * Lifecycle: spawn → ACP initialize → newSession/loadSession → prompt ↔ events → destroy
+ *
+ * Session wraps AgentInstance to add prompt queuing, auto-naming, and
+ * permission gating. This module should NOT be used directly by adapters.
+ */
+
 import { spawn, execFileSync, type ChildProcess } from "node:child_process";
 import { Transform } from "node:stream";
 import fs from "node:fs";
@@ -40,7 +54,13 @@ import { createChildLogger } from "../utils/log.js";
 import { Hook, SessionEv } from "../events.js";
 const log = createChildLogger({ module: "agent-instance" });
 
-/** Find the nearest ancestor directory containing package.json */
+/**
+ * Find the nearest ancestor directory containing package.json.
+ *
+ * Used by `resolveAgentCommand` to locate node_modules from the package's
+ * own install location, which differs between tsc output (`dist/core/`)
+ * and tsup bundles (`dist/`).
+ */
 function findPackageRoot(startDir: string): string {
   let dir = startDir;
   while (dir !== path.dirname(dir)) {
@@ -52,7 +72,21 @@ function findPackageRoot(startDir: string): string {
   return startDir;
 }
 
-/** Resolve an agent command to a directly executable form (avoids shell wrappers) */
+/**
+ * Resolve an agent command name to a directly executable form.
+ *
+ * Agent commands (e.g. "claude-agent-acp") are npm package names, not native
+ * binaries. This function locates the actual JS entry point and runs it via
+ * `node` directly, avoiding npm shell wrappers that break subprocess stdio
+ * piping (the ACP protocol relies on clean stdin/stdout streams).
+ *
+ * Resolution order:
+ *  1. node_modules/<package>/dist/index.js (direct entry point)
+ *  2. node_modules/.bin/<cmd> (parse shebang or shell wrapper to find JS target)
+ *  3. System PATH via `which`
+ *  4. Special handling for npx/uvx: derive from the running Node's bin directory
+ *  5. Fallback: use command as-is
+ */
 function resolveAgentCommand(cmd: string): { command: string; args: string[] } {
   // Directories to search for node_modules: cwd AND the package's own directory
   const searchRoots = [process.cwd()];
@@ -150,7 +184,9 @@ function resolveAgentCommand(cmd: string): { command: string; args: string[] } {
 
 // TerminalState has been extracted to TerminalManager
 
-// Local types for ACP session update shapes not fully typed by SDK
+// Local types for ACP session update shapes not fully typed by the SDK.
+// The SDK uses a generic `update` object; these interfaces provide type safety
+// for fields we access when converting ACP events to internal AgentEvent types.
 interface SdkToolCallFields {
   rawInput?: unknown;
   rawOutput?: unknown;
@@ -182,17 +218,35 @@ interface SdkReadTextFileParams {
   limit?: number;
 }
 
+/** Events emitted by AgentInstance — consumed by Session to relay to adapters. */
 export interface AgentInstanceEvents {
   agent_event: (event: AgentEvent) => void;
 }
 
+/**
+ * Manages an ACP agent subprocess and implements the ACP Client interface.
+ *
+ * Each AgentInstance owns exactly one child process. It handles:
+ * - Subprocess spawning with filtered environment and path guarding
+ * - ACP protocol handshake (initialize → newSession/loadSession)
+ * - Translating ACP session updates into internal AgentEvent types
+ * - File I/O and terminal operations requested by the agent
+ * - Permission request proxying (agent → Session → adapter → user → agent)
+ * - Graceful shutdown (SIGTERM with SIGKILL fallback)
+ *
+ * Session wraps this class to add prompt queuing and lifecycle management.
+ */
 export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
   private connection!: ClientSideConnection;
   private child!: ChildProcess;
   private stderrCapture!: StderrCapture;
+  /** Manages terminal subprocesses that agents can spawn for shell commands. */
   private terminalManager = new TerminalManager();
+  /** Shared across all instances — resolves MCP server configs for ACP sessions. */
   private static mcpManager = new McpManager();
+  /** Guards against emitting crash events during intentional shutdown. */
   private _destroying = false;
+  /** Restricts agent file I/O to the workspace directory and explicitly allowed paths. */
   private pathGuard!: PathGuard;
 
   sessionId!: string;
@@ -204,12 +258,18 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
   middlewareChain?: MiddlewareChain;
   debugTracer: DebugTracer | null = null;
 
-  /** Allow external callers (e.g. SessionFactory) to whitelist additional read paths */
+  /**
+   * Whitelist an additional filesystem path for agent read access.
+   *
+   * Called by SessionFactory to allow agents to read files outside the
+   * workspace (e.g., the file-service upload directory for attachments).
+   */
   addAllowedPath(p: string): void {
     this.pathGuard.addAllowedPath(p);
   }
 
-  // Callback — set by core when wiring events
+  // Callback — set by Session/Core when wiring events. Returns the selected
+  // permission option ID. Default no-op auto-selects the first option.
   onPermissionRequest: (request: PermissionRequest) => Promise<string> =
     async () => "";
 
@@ -218,6 +278,20 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     this.agentName = agentName;
   }
 
+  /**
+   * Spawn the agent child process and complete the ACP protocol handshake.
+   *
+   * Steps:
+   *  1. Resolve the agent command to a directly executable path
+   *  2. Create a PathGuard scoped to the working directory
+   *  3. Spawn the subprocess with a filtered environment (security: only whitelisted
+   *     env vars are passed to prevent leaking secrets like API keys)
+   *  4. Wire stdin/stdout through debug-tracing Transform streams
+   *  5. Convert Node streams → Web streams for the ACP SDK
+   *  6. Perform the ACP `initialize` handshake and negotiate capabilities
+   *
+   * Does NOT create a session — callers must follow up with newSession or loadSession.
+   */
   private static async spawnSubprocess(
     agentDef: AgentDefinition,
     workingDirectory: string,
@@ -264,11 +338,17 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
       instance.child.on("spawn", () => resolve());
     });
 
+    // Capture last 50 stderr lines for crash diagnostics — stderr is NOT part of
+    // the ACP protocol (which uses stdout), but agents log errors/warnings there.
     instance.stderrCapture = new StderrCapture(50);
     instance.child.stderr!.on("data", (chunk: Buffer) => {
       instance.stderrCapture.append(chunk.toString());
     });
 
+    // stdin/stdout pass-through transforms for ACP protocol tracing.
+    // When debugTracer is active, each ndjson message is logged with direction
+    // (send/recv) for protocol-level debugging. The transforms are transparent
+    // when tracing is off — they pass chunks through without modification.
     const stdinLogger = new Transform({
       transform(chunk, _enc, cb) {
         if (instance.debugTracer) {
@@ -299,15 +379,21 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     });
     instance.child.stdout!.pipe(stdoutLogger);
 
+    // Bridge Node streams → Web Streams API for the ACP SDK, which uses
+    // ReadableStream/WritableStream internally for ndjson parsing.
     const toAgent = nodeToWebWritable(stdinLogger);
     const fromAgent = nodeToWebReadable(stdoutLogger);
     const stream = ndJsonStream(toAgent, fromAgent);
 
+    // ClientSideConnection is the ACP SDK's client. It sends JSON-RPC requests
+    // and routes incoming notifications to the Client callbacks (createClient).
     instance.connection = new ClientSideConnection(
       (_agent: Agent): Client => instance.createClient(_agent),
       stream,
     );
 
+    // ACP handshake: negotiate protocol version and declare client capabilities.
+    // The agent responds with its own capabilities (image/audio support, etc.).
     const initResponse = await instance.connection.initialize({
       protocolVersion: PROTOCOL_VERSION,
       clientCapabilities: {
@@ -337,6 +423,13 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     return instance;
   }
 
+  /**
+   * Monitor the subprocess for unexpected exits and emit error events.
+   *
+   * Distinguishes intentional shutdown (SIGTERM/SIGINT during destroy) from
+   * crashes (non-zero exit code or unexpected signal). Crash events include
+   * captured stderr output for diagnostic context.
+   */
   private setupCrashDetection(): void {
     this.child.on("exit", (code, signal) => {
       if (this._destroying) return;
@@ -362,6 +455,18 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     });
   }
 
+  /**
+   * Spawn a new agent subprocess and create a fresh ACP session.
+   *
+   * This is the primary entry point for starting an agent. It spawns the
+   * subprocess, completes the ACP handshake, and calls `newSession` to
+   * initialize the agent's working context (cwd, MCP servers).
+   *
+   * @param agentDef - Agent definition (command, args, env) from the catalog
+   * @param workingDirectory - Workspace root the agent operates in
+   * @param mcpServers - Optional MCP server configs to extend agent capabilities
+   * @param allowedPaths - Extra filesystem paths the agent may access
+   */
   static async spawn(
     agentDef: AgentDefinition,
     workingDirectory: string,
@@ -405,6 +510,15 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     return instance;
   }
 
+  /**
+   * Spawn a new subprocess and restore an existing agent session.
+   *
+   * Tries loadSession first (preferred, stable API), falls back to the
+   * unstable resumeSession, and finally falls back to creating a brand-new
+   * session if resume fails entirely (e.g., agent lost its state).
+   *
+   * @param agentSessionId - The agent-side session ID to restore
+   */
   static async resume(
     agentDef: AgentDefinition,
     workingDirectory: string,
@@ -483,13 +597,27 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     return instance;
   }
 
-  // createClient — implemented in Task 6b
+  /**
+   * Build the ACP Client callback object.
+   *
+   * The ACP SDK invokes these callbacks when the agent sends notifications
+   * or requests. Each callback maps an ACP protocol message to either:
+   * - An internal AgentEvent (emitted for Session/adapters to consume)
+   * - A filesystem or terminal operation (executed on the agent's behalf)
+   * - A permission request (proxied to the user via the adapter)
+   */
   private createClient(_agent: Agent): Client {
     const self = this;
     const MAX_OUTPUT_BYTES = 1024 * 1024; // 1MB cap
 
     return {
       // ── Session updates ──────────────────────────────────────────────────
+      // The agent streams its response as a series of session update events.
+      // Each event type maps to an internal AgentEvent that Session relays
+      // to adapters for rendering (text chunks, tool calls, usage stats, etc.).
+      // Chunks are forwarded to Session individually as they arrive — no buffering
+      // happens at this layer. If buffering is needed (e.g., to avoid rate limits),
+      // it is the responsibility of the Session or adapter layer.
       async sessionUpdate(params) {
         const update = params.update;
         let event: AgentEvent | null = null;
@@ -640,6 +768,10 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
       },
 
       // ── Permission requests ──────────────────────────────────────────────
+      // The agent needs user approval before performing sensitive operations
+      // (e.g., file writes, shell commands). This proxies the request up
+      // through Session → PermissionGate → adapter → user, then returns
+      // the user's chosen option ID back to the agent.
       async requestPermission(params) {
         const permissionRequest: PermissionRequest = {
           id: params.toolCall.toolCallId,
@@ -659,6 +791,9 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
       },
 
       // ── File operations ──────────────────────────────────────────────────
+      // The agent reads/writes files through these callbacks rather than
+      // accessing the filesystem directly. This allows PathGuard to enforce
+      // workspace boundaries and middleware hooks to intercept I/O.
       async readTextFile(params) {
         const p = params as unknown as SdkReadTextFileParams;
         // Security: validate path against workspace boundary
@@ -700,6 +835,8 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
       },
 
       // ── Terminal operations (delegated to TerminalManager) ─────────────
+      // Agents can spawn shell commands via terminal operations. TerminalManager
+      // handles subprocess lifecycle, output capture, and byte-limit enforcement.
       async createTerminal(params) {
         return self.terminalManager.createTerminal(
           self.sessionId,
@@ -735,6 +872,13 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
 
   // ── New ACP methods ──────────────────────────────────────────────────
 
+  /**
+   * Update a session config option (mode, model, etc.) on the agent.
+   *
+   * Falls back to legacy `setSessionMode`/`unstable_setSessionModel` methods
+   * for agents that haven't adopted the unified `session/set_config_option`
+   * ACP method (detected via JSON-RPC -32601 "Method Not Found" error).
+   */
   async setConfigOption(
     configId: string,
     value: SetConfigOptionValue,
@@ -769,6 +913,7 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     }
   }
 
+  /** List the agent's known sessions, optionally filtered by working directory. */
   async listSessions(
     cwd?: string,
     cursor?: string,
@@ -779,6 +924,7 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     });
   }
 
+  /** Load an existing agent session by ID into this subprocess. */
   async loadSession(
     sessionId: string,
     cwd: string,
@@ -792,10 +938,12 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     });
   }
 
+  /** Trigger agent-managed authentication (e.g., OAuth flow). */
   async authenticate(methodId: string): Promise<void> {
     await this.connection.authenticate({ methodId });
   }
 
+  /** Fork an existing session, creating a new branch with shared history. */
   async forkSession(
     sessionId: string,
     cwd: string,
@@ -809,12 +957,27 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     });
   }
 
+  /** Close a session on the agent side (cleanup agent-internal state). */
   async closeSession(sessionId: string): Promise<void> {
     await this.connection.unstable_closeSession({ sessionId });
   }
 
   // ── Prompt & lifecycle ──────────────────────────────────────────────
 
+  /**
+   * Send a user prompt to the agent and wait for the complete response.
+   *
+   * Builds ACP content blocks from the text and any attachments (images
+   * are base64-encoded if the agent supports them, otherwise appended as
+   * file paths). The promise resolves when the agent finishes responding;
+   * streaming events arrive via the `agent_event` emitter during execution.
+   *
+   * Attachments that exceed size limits or use unsupported formats are
+   * skipped with a note appended to the prompt text.
+   *
+   * Call `cancel()` to interrupt a running prompt; the agent will stop and
+   * the promise resolves with partial results.
+   */
   async prompt(text: string, attachments?: Attachment[]): Promise<PromptResponse> {
     const contentBlocks: Array<Record<string, unknown>> = [{ type: "text", text }];
     const capabilities = this.promptCapabilities ?? {};
@@ -862,20 +1025,26 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
     });
   }
 
+  /** Cancel the currently running prompt. The agent should stop and return partial results. */
   async cancel(): Promise<void> {
     await this.connection.cancel({ sessionId: this.sessionId });
   }
 
+  /**
+   * Gracefully shut down the agent subprocess.
+   *
+   * Sends SIGTERM first, giving the agent up to 10 seconds to clean up.
+   * If the process hasn't exited by then, SIGKILL forces termination.
+   * The timer is unref'd so it doesn't keep the Node process alive
+   * during shutdown.
+   */
   async destroy(): Promise<void> {
     this._destroying = true;
 
-    // Cleanup terminals
     this.terminalManager.destroyAll();
 
-    // If process already exited, nothing to do
     if (this.child.exitCode !== null) return;
 
-    // Kill agent subprocess and wait for it to actually exit
     await new Promise<void>((resolve) => {
       // Register exit listener BEFORE sending signal to avoid race
       this.child.on("exit", () => {
@@ -886,7 +1055,8 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
       this.child.kill("SIGTERM");
 
       const forceKillTimer = setTimeout(() => {
-        // Use exitCode check — child.killed is true after ANY kill() call
+        // Use exitCode check — child.killed is true after ANY kill() call,
+        // even if the process hasn't actually exited yet
         if (this.child.exitCode === null) this.child.kill("SIGKILL");
         resolve();
       }, 10_000);

--- a/src/core/agents/agent-manager.ts
+++ b/src/core/agents/agent-manager.ts
@@ -2,9 +2,20 @@ import type { AgentDefinition } from "../types.js";
 import { AgentInstance } from "./agent-instance.js";
 import type { AgentCatalog } from "./agent-catalog.js";
 
+/**
+ * High-level facade for spawning and resuming agent instances.
+ *
+ * Resolves agent names to definitions via AgentCatalog, then delegates
+ * to AgentInstance for subprocess management. Used by SessionFactory
+ * to create the agent backing a session.
+ *
+ * Agent switching (swapping the agent mid-session) is coordinated at the
+ * Session layer — AgentManager only handles individual spawn/resume calls.
+ */
 export class AgentManager {
   constructor(private catalog: AgentCatalog) {}
 
+  /** Return definitions for all installed agents. */
   getAvailableAgents(): AgentDefinition[] {
     const installed = this.catalog.getInstalledEntries();
     return Object.entries(installed).map(([key, agent]) => ({
@@ -15,10 +26,16 @@ export class AgentManager {
     }));
   }
 
+  /** Look up a single agent definition by its short name (e.g., "claude", "gemini"). */
   getAgent(name: string): AgentDefinition | undefined {
     return this.catalog.resolve(name);
   }
 
+  /**
+   * Spawn a new agent subprocess with a fresh session.
+   *
+   * @throws If the agent is not installed — includes install instructions in the error message.
+   */
   async spawn(
     agentName: string,
     workingDirectory: string,
@@ -29,6 +46,11 @@ export class AgentManager {
     return AgentInstance.spawn(agentDef, workingDirectory, undefined, allowedPaths);
   }
 
+  /**
+   * Spawn a subprocess and resume an existing agent session.
+   *
+   * Falls back to a new session if the agent cannot restore the given session ID.
+   */
   async resume(
     agentName: string,
     workingDirectory: string,

--- a/src/core/agents/agent-registry.ts
+++ b/src/core/agents/agent-registry.ts
@@ -1,3 +1,3 @@
-// Re-export from new consolidated module for backward compatibility
+/** @deprecated Re-exports from agent-dependencies.ts for backward compatibility. */
 export { getAgentCapabilities } from "./agent-dependencies.js";
 export type { AgentCapability } from "./agent-dependencies.js";

--- a/src/core/agents/agent-store.ts
+++ b/src/core/agents/agent-store.ts
@@ -1,3 +1,12 @@
+/**
+ * Persistent storage for installed agent definitions.
+ *
+ * Agents are stored in `agents.json` (typically `~/.openacp/agents.json`).
+ * The file is validated with Zod on load; corrupted or invalid data is
+ * discarded gracefully with a warning. Writes use atomic rename to
+ * prevent partial writes from corrupting the file.
+ */
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";
@@ -26,6 +35,7 @@ const AgentStoreSchema = z.object({
 
 type AgentStoreData = z.infer<typeof AgentStoreSchema>;
 
+/** JSON-backed store for installed agent definitions (`agents.json`). */
 export class AgentStore {
   private data: AgentStoreData = { version: 1, installed: {} };
   readonly filePath: string;
@@ -34,6 +44,7 @@ export class AgentStore {
     this.filePath = filePath;
   }
 
+  /** Load and validate the store from disk. Starts fresh if file is missing or invalid. */
   load(): void {
     if (!fs.existsSync(this.filePath)) {
       this.data = { version: 1, installed: {} };
@@ -81,6 +92,11 @@ export class AgentStore {
     return key in this.data.installed;
   }
 
+  /**
+   * Persist the store to disk using atomic write (write to .tmp, then rename).
+   * File permissions are restricted to owner-only (0o600) since the store
+   * may contain agent binary paths and environment variables.
+   */
   private save(): void {
     fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
     const tmpPath = this.filePath + ".tmp";

--- a/src/core/assistant/assistant-manager.ts
+++ b/src/core/assistant/assistant-manager.ts
@@ -5,6 +5,7 @@ import { createChildLogger } from '../utils/log.js'
 
 const log = createChildLogger({ module: 'assistant-manager' })
 
+/** Subset of OpenACPCore methods needed by AssistantManager, avoiding a circular import. */
 interface AssistantManagerCore {
   createSession(params: {
     channelId: string
@@ -23,6 +24,19 @@ interface AssistantManagerCore {
   sessionStore: SessionStore | null
 }
 
+/**
+ * Manages the OpenACP built-in assistant session.
+ *
+ * The assistant is a special session (marked with `isAssistant: true`) that
+ * can answer questions about the running OpenACP system — sessions, agents,
+ * config, etc. Unlike user-created sessions, it is created and managed by
+ * core, and its system prompt is dynamically composed from registry sections
+ * that inject live system state.
+ *
+ * One assistant session exists per channel. The system prompt is built at
+ * spawn time and deferred — it's prepended to the first user message rather
+ * than sent immediately, so the agent receives it alongside real context.
+ */
 export class AssistantManager {
   private sessions = new Map<string, Session>()
   private pendingSystemPrompts = new Map<string, string>()
@@ -32,6 +46,13 @@ export class AssistantManager {
     private registry: AssistantRegistry,
   ) {}
 
+  /**
+   * Returns the assistant session for a channel, creating one if needed.
+   *
+   * If a persisted assistant session exists in the store, it is reused
+   * (same session ID) to preserve conversation history. The system prompt
+   * is always rebuilt fresh and deferred until the first user message.
+   */
   async getOrSpawn(channelId: string, threadId: string): Promise<Session> {
     const existing = this.core.sessionStore?.findAssistant(channelId)
     const session = await this.core.createSession({
@@ -45,6 +66,8 @@ export class AssistantManager {
     })
     this.sessions.set(channelId, session)
 
+    // Build the system prompt now but don't send it yet — it will be
+    // prepended to the first real user message via consumePendingSystemPrompt()
     const systemPrompt = this.registry.buildSystemPrompt(channelId)
     this.pendingSystemPrompts.set(channelId, systemPrompt)
     log.info(
@@ -55,6 +78,7 @@ export class AssistantManager {
     return session
   }
 
+  /** Returns the active assistant session for a channel, or null if none exists. */
   get(channelId: string): Session | null {
     return this.sessions.get(channelId) ?? null
   }
@@ -69,6 +93,7 @@ export class AssistantManager {
     return prompt
   }
 
+  /** Checks whether a given session ID belongs to the built-in assistant. */
   isAssistant(sessionId: string): boolean {
     for (const s of this.sessions.values()) {
       if (s.id === sessionId) return true

--- a/src/core/assistant/assistant-registry.ts
+++ b/src/core/assistant/assistant-registry.ts
@@ -3,28 +3,48 @@ import { ASSISTANT_PREAMBLE, buildAssistantGuidelines } from './prompt-constants
 
 const log = createChildLogger({ module: 'assistant-registry' })
 
+/** A CLI command the assistant can run, shown as a code block in the system prompt. */
 export interface AssistantCommand {
   command: string
   description: string
 }
 
+/**
+ * A section that injects live system state into the assistant's system prompt.
+ *
+ * Each section provides a `buildContext()` callback that is called at prompt
+ * composition time. Sections are sorted by priority (lower = earlier in prompt)
+ * so the most important context appears first.
+ */
 export interface AssistantSection {
   id: string
   title: string
+  /** Lower priority = appears earlier in the system prompt. */
   priority: number
+  /** Returns the section's context string, or null to skip this section entirely. */
   buildContext: () => string | null
   commands?: AssistantCommand[]
 }
 
+/**
+ * Registry that collects assistant prompt sections and composes them into
+ * a single system prompt.
+ *
+ * Core modules and plugins register sections (e.g. sessions, agents, config)
+ * that each contribute a fragment of live system state. At prompt build time,
+ * sections are sorted by priority, their `buildContext()` is called, and the
+ * results are assembled with the preamble and CLI guidelines.
+ */
 export class AssistantRegistry {
   private sections = new Map<string, AssistantSection>()
   private _instanceRoot: string = ''
 
-  /** Set the instance root path used in assistant guidelines */
+  /** Set the instance root path used in assistant guidelines. */
   setInstanceRoot(root: string): void {
     this._instanceRoot = root
   }
 
+  /** Register a prompt section. Overwrites any existing section with the same id. */
   register(section: AssistantSection): void {
     if (this.sections.has(section.id)) {
       log.warn({ id: section.id }, 'Assistant section overwritten')
@@ -32,10 +52,21 @@ export class AssistantRegistry {
     this.sections.set(section.id, section)
   }
 
+  /** Remove a previously registered section by id. */
   unregister(id: string): void {
     this.sections.delete(id)
   }
 
+  /**
+   * Compose the full system prompt from all registered sections.
+   *
+   * Sections are sorted by priority (ascending), each contributing a titled
+   * markdown block. If a section's `buildContext()` throws, it is skipped
+   * gracefully so one broken section doesn't break the entire prompt.
+   *
+   * If `channelId` is provided, a "Current Channel" block is injected at the
+   * top of the prompt so the assistant can adapt its behavior to the platform.
+   */
   buildSystemPrompt(channelId?: string): string {
     const sorted = [...this.sections.values()].sort((a, b) => a.priority - b.priority)
     const parts: string[] = [ASSISTANT_PREAMBLE]

--- a/src/core/assistant/prompt-constants.ts
+++ b/src/core/assistant/prompt-constants.ts
@@ -1,3 +1,7 @@
+/**
+ * Sets the assistant's persona and basic formatting rules.
+ * This is always the first block in the composed system prompt.
+ */
 export const ASSISTANT_PREAMBLE = `You are the OpenACP Assistant — a helpful guide for managing AI coding sessions.
 
 Respond in the same language the user uses.
@@ -17,6 +21,13 @@ export function resolveCliCommand(): string {
   return 'openacp'
 }
 
+/**
+ * Builds the CLI guidelines section of the assistant's system prompt.
+ *
+ * These guidelines teach the assistant how to invoke OpenACP CLI commands
+ * against the correct instance. The `--dir` flag is critical — without it,
+ * commands may target the wrong instance when multiple instances exist.
+ */
 export function buildAssistantGuidelines(instanceRoot: string): string {
   const cli = resolveCliCommand()
   const baseCmd = `${cli} --dir "${instanceRoot}"`

--- a/src/core/assistant/sections/agents.ts
+++ b/src/core/assistant/sections/agents.ts
@@ -1,5 +1,12 @@
 import type { AssistantSection } from '../assistant-registry.js'
 
+/**
+ * Creates the "Agent Management" section for the assistant's system prompt.
+ *
+ * Injects a live snapshot of installed agents, the default agent, and how
+ * many more are available in the ACP Registry — so the assistant can answer
+ * questions about agents and help users install new ones.
+ */
 export function createAgentsSection(core: {
   agentCatalog: { getInstalledEntries(): Record<string, { name: string }>; getAvailable(): Array<{ installed: boolean }> }
   configManager: { get(): { defaultAgent: string } }

--- a/src/core/assistant/sections/config.ts
+++ b/src/core/assistant/sections/config.ts
@@ -1,5 +1,11 @@
 import type { AssistantSection } from '../assistant-registry.js'
 
+/**
+ * Creates the "Configuration" section for the assistant's system prompt.
+ *
+ * Injects the workspace base path and speech-to-text availability, so the
+ * assistant knows the current environment and can guide config changes.
+ */
 export function createConfigSection(core: {
   configManager: { resolveWorkspace(): string }
   lifecycleManager?: { serviceRegistry: { get<T>(name: string): T | undefined } }

--- a/src/core/assistant/sections/remote.ts
+++ b/src/core/assistant/sections/remote.ts
@@ -1,5 +1,13 @@
 import type { AssistantSection } from '../assistant-registry.js'
 
+/**
+ * Creates the "Remote Access" section for the assistant's system prompt.
+ *
+ * Describes how to generate one-time remote access links so users can
+ * connect to this OpenACP instance from the app or a browser. The section
+ * is static (no live state) — it teaches the assistant about available
+ * roles, link expiry, and tunnel behavior.
+ */
 export function createRemoteSection(): AssistantSection {
   return {
     id: 'core:remote',

--- a/src/core/assistant/sections/sessions.ts
+++ b/src/core/assistant/sections/sessions.ts
@@ -1,5 +1,12 @@
 import type { AssistantSection } from '../assistant-registry.js'
 
+/**
+ * Creates the "Session Management" section for the assistant's system prompt.
+ *
+ * Injects live session counts (active vs total) and instructions for creating
+ * new sessions. This is the highest-priority section (priority 10) because
+ * session management is the assistant's primary purpose.
+ */
 export function createSessionsSection(core: { sessionManager: { listRecords(): Array<{ status: string }> } }): AssistantSection {
   return {
     id: 'core:sessions',

--- a/src/core/assistant/sections/system.ts
+++ b/src/core/assistant/sections/system.ts
@@ -1,5 +1,11 @@
 import type { AssistantSection } from '../assistant-registry.js'
 
+/**
+ * Creates the "System" section for the assistant's system prompt.
+ *
+ * Provides system-level commands (health check, restart, version) and
+ * instructs the assistant to always confirm before disruptive actions.
+ */
 export function createSystemSection(): AssistantSection {
   return {
     id: 'core:system',

--- a/src/core/channel.ts
+++ b/src/core/channel.ts
@@ -1,10 +1,18 @@
 import type { OutgoingMessage, PermissionRequest, NotificationMessage, AgentCommand } from './types.js'
 
+/**
+ * Configuration for an adapter channel (Telegram, Slack, etc.).
+ * Each adapter defines its own fields beyond `enabled`.
+ */
 export interface ChannelConfig {
   enabled: boolean
   [key: string]: unknown
 }
 
+/**
+ * Declares what a messaging platform supports. Core uses these to decide
+ * whether to attempt features like streaming, file uploads, or voice.
+ */
 export interface AdapterCapabilities {
   streaming: boolean
   richFormatting: boolean
@@ -14,6 +22,17 @@ export interface AdapterCapabilities {
   voice: boolean
 }
 
+/**
+ * Contract for a messaging platform adapter.
+ *
+ * A "channel" in OpenACP is identified by an adapter name (e.g. "telegram", "slack").
+ * Each session binds to a channel + thread ID — together they form a unique conversation
+ * location. The adapter is responsible for platform-specific I/O: sending messages,
+ * creating threads/topics, handling permission buttons, etc.
+ *
+ * Core calls adapter methods via SessionBridge (for agent events) or directly
+ * (for session lifecycle operations like thread creation and archiving).
+ */
 export interface IChannelAdapter {
   readonly name: string
   readonly capabilities: AdapterCapabilities
@@ -21,13 +40,14 @@ export interface IChannelAdapter {
   start(): Promise<void>
   stop(): Promise<void>
 
-  // Outgoing: core → channel
+  // --- Outgoing: core → platform ---
   sendMessage(sessionId: string, content: OutgoingMessage): Promise<void>
   sendPermissionRequest(sessionId: string, request: PermissionRequest): Promise<void>
   sendNotification(notification: NotificationMessage): Promise<void>
 
-  // Session lifecycle on channel side
-  createSessionThread(sessionId: string, name: string): Promise<string>  // returns threadId
+  // --- Session lifecycle on platform side ---
+  /** Create a thread/topic for a session. Returns the platform-specific thread ID. */
+  createSessionThread(sessionId: string, name: string): Promise<string>
   renameSessionThread(sessionId: string, newName: string): Promise<void>
   deleteSessionThread?(sessionId: string): Promise<void>
   archiveSessionTopic?(sessionId: string): Promise<void>
@@ -35,10 +55,10 @@ export interface IChannelAdapter {
   // TTS strip — optional, called after TTS audio is synthesized to remove [TTS] block from text
   stripTTSBlock?(sessionId: string): Promise<void>
 
-  // Skill commands — optional
+  // --- Skill commands — optional, for agents that expose interactive commands ---
   sendSkillCommands?(sessionId: string, commands: AgentCommand[]): Promise<void>
   cleanupSkillCommands?(sessionId: string): Promise<void>
-  /** Flush skill commands that were queued before threadId was available */
+  /** Flush skill commands that were queued before threadId was available. */
   flushPendingSkillCommands?(sessionId: string): Promise<void>
 
   // Agent switch cleanup — optional, called when switching agents to clear adapter-side per-session state
@@ -46,8 +66,14 @@ export interface IChannelAdapter {
 }
 
 /**
- * Base class providing default no-op implementations for optional methods.
- * Adapters can extend this or implement IChannelAdapter directly.
+ * Original base class for channel adapters. Provides default no-op implementations
+ * for optional IChannelAdapter methods so subclasses only need to implement the
+ * methods they care about.
+ *
+ * This class predates the adapter-primitives package. It has since been superseded
+ * by MessagingAdapter and StreamAdapter, which add structured send queuing, streaming
+ * support, and platform-specific rendering out of the box.
+ *
  * @deprecated Use MessagingAdapter or StreamAdapter instead. Kept for backward compat during migration.
  */
 export abstract class ChannelAdapter<TCore = unknown> implements IChannelAdapter {

--- a/src/core/command-registry.ts
+++ b/src/core/command-registry.ts
@@ -1,5 +1,9 @@
 import type { CommandDef, CommandArgs, CommandResponse } from './plugin/types.js'
 
+/**
+ * Internal representation of a registered command, extending CommandDef with
+ * a `scope` derived from the plugin name for namespace-qualified lookups.
+ */
 interface RegisteredCommand extends CommandDef {
   /** Scope extracted from pluginName, e.g. '@openacp/speech' → 'speech' */
   scope?: string
@@ -15,6 +19,11 @@ interface RegisteredCommand extends CommandDef {
  * - Adapter plugins (@openacp/telegram, @openacp/discord)
  *   registering a command that already exists → stored as an override
  *   keyed by `channelId:commandName`, used when channelId matches.
+ *
+ * Note: this registry only handles slash commands (e.g. /new, /session).
+ * Callback button routing (inline keyboard buttons) is handled separately
+ * at the adapter level using a `c/` prefix — it is not part of command dispatch
+ * and does not go through this registry.
  */
 export class CommandRegistry {
   /** Main registry: short names + qualified names → RegisteredCommand */
@@ -127,20 +136,25 @@ export class CommandRegistry {
   }
 
   /**
-   * Parse and execute a command string.
-   * @param commandString - Full command string, e.g. "/greet hello world"
-   * @param baseArgs - Base arguments (channelId, userId, etc.)
-   * @returns CommandResponse
+   * Parse and execute a command string (e.g. "/greet hello world").
+   *
+   * Resolution order:
+   * 1. Adapter-specific override (e.g. Telegram's version of /new)
+   * 2. Short name or qualified name in the main registry
+   *
+   * Strips Telegram-style bot mentions (e.g. "/help@MyBot" → "help").
+   * Returns `{ type: 'delegated' }` if the handler returns null/undefined
+   * (meaning it handled the response itself, e.g. via assistant).
    */
   async execute(commandString: string, baseArgs: CommandArgs): Promise<CommandResponse> {
-    // Parse command name and raw args
     const trimmed = commandString.trim()
     const spaceIdx = trimmed.indexOf(' ')
     const rawCmd = spaceIdx === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIdx)
+    // Strip bot mention suffix: "/help@MyBot" → "help"
     const cmdName = rawCmd.split("@")[0]
     const rawArgs = spaceIdx === -1 ? '' : trimmed.slice(spaceIdx + 1)
 
-    // Check for adapter-specific override first
+    // Adapter-specific overrides take precedence (e.g. Telegram's /new with topic creation)
     const overrideKey = `${baseArgs.channelId}:${cmdName}`
     const override = this.overrides.get(overrideKey)
 

--- a/src/core/commands/admin.ts
+++ b/src/core/commands/admin.ts
@@ -2,6 +2,12 @@ import type { CommandRegistry } from '../command-registry.js'
 import type { CommandResponse } from '../plugin/types.js'
 import type { OpenACPCore } from '../core.js'
 
+/**
+ * Register administrative commands: /restart, /update, /doctor, /integrate.
+ *
+ * These commands manage the server itself — restarting, updating, running
+ * diagnostics, and setting up new platform integrations.
+ */
 export function registerAdminCommands(registry: CommandRegistry, _core: unknown): void {
   const core = _core as OpenACPCore;
   registry.register({

--- a/src/core/commands/agents.ts
+++ b/src/core/commands/agents.ts
@@ -2,6 +2,13 @@ import type { CommandRegistry } from '../command-registry.js'
 import type { CommandResponse } from '../plugin/types.js'
 import type { OpenACPCore } from '../core.js'
 
+/**
+ * Register agent management commands: /agents and /install.
+ *
+ * /agents lists installed and available agents from the catalog.
+ * /install triggers agent installation, delegating to the assistant for guided flow
+ * or showing a CLI command as fallback.
+ */
 export function registerAgentCommands(registry: CommandRegistry, _core: unknown): void {
   const core = _core as OpenACPCore
 

--- a/src/core/commands/config.ts
+++ b/src/core/commands/config.ts
@@ -68,6 +68,14 @@ function getLabels(category: string, commandName: string): CategoryLabels {
 
 // ── Generic category command factory ─────────────────────────────────
 
+/**
+ * Register a command that reads/writes a session config option by category.
+ *
+ * Each agent exposes config options (mode, model, thought_level) as select menus.
+ * This factory creates a command that:
+ * - With no args: shows a menu of available values with the current one checked
+ * - With a value arg: validates and applies the new value via `session.setConfigOption`
+ */
 function registerCategoryCommand(
   registry: CommandRegistry,
   core: OpenACPCore,
@@ -142,6 +150,15 @@ function registerCategoryCommand(
 
 // ── /bypass_permissions command ───────────────────────────────────────────────
 
+/**
+ * Register /bypass_permissions — toggles auto-approval of permission requests.
+ *
+ * Two mechanisms are supported:
+ * 1. If the agent has a bypass value in its mode options (e.g. Claude Code's "dangermode"),
+ *    the command switches the agent mode via setConfigOption.
+ * 2. Otherwise, falls back to a client-side override on the Session that auto-approves
+ *    all permission requests before they reach the user.
+ */
 function registerDangerousCommand(registry: CommandRegistry, core: OpenACPCore): void {
   registry.register({
     name: 'bypass_permissions',
@@ -246,6 +263,12 @@ function registerDangerousCommand(registry: CommandRegistry, core: OpenACPCore):
 
 // ── Public registration ──────────────────────────────────────────────
 
+/**
+ * Register session configuration commands: /mode, /model, /thought, /bypass_permissions.
+ *
+ * These commands let users change agent behavior at runtime. Each maps to
+ * a config option category exposed by the agent via ACP config_option events.
+ */
 export function registerConfigCommands(registry: CommandRegistry, _core: unknown): void {
   const core = _core as OpenACPCore
   registerCategoryCommand(registry, core, 'mode', 'mode')

--- a/src/core/commands/help.ts
+++ b/src/core/commands/help.ts
@@ -1,6 +1,13 @@
 import type { CommandRegistry } from '../command-registry.js'
 import type { CommandResponse } from '../plugin/types.js'
 
+/**
+ * Register the /help command.
+ *
+ * With no arguments, auto-generates a command listing from the registry
+ * (grouped by system vs plugin). With a command name argument, shows
+ * detailed usage for that specific command.
+ */
 export function registerHelpCommand(registry: CommandRegistry, _core: unknown): void {
   registry.register({
     name: 'help',

--- a/src/core/commands/index.ts
+++ b/src/core/commands/index.ts
@@ -7,6 +7,12 @@ import { registerMenuCommand } from './menu.js'
 import { registerSwitchCommands } from './switch.js'
 import { registerConfigCommands } from './config.js'
 
+/**
+ * Register all built-in system commands with the command registry.
+ *
+ * Called once during startup (from main.ts). System commands always own the
+ * short name — plugin commands cannot override them, only add qualified alternatives.
+ */
 export function registerSystemCommands(registry: CommandRegistry, core: unknown): void {
   registerSessionCommands(registry, core)
   registerAgentCommands(registry, core)

--- a/src/core/commands/menu.ts
+++ b/src/core/commands/menu.ts
@@ -1,6 +1,12 @@
 import type { CommandRegistry } from '../command-registry.js'
 import type { CommandResponse } from '../plugin/types.js'
 
+/**
+ * Register the /menu command, which presents a static main menu of common actions.
+ *
+ * Adapters render this as an inline keyboard (Telegram) or interactive message (Slack).
+ * Each option maps to another command via the `c/` callback prefix routing.
+ */
 export function registerMenuCommand(registry: CommandRegistry, _core: unknown): void {
   registry.register({
     name: 'menu',

--- a/src/core/commands/session.ts
+++ b/src/core/commands/session.ts
@@ -2,6 +2,14 @@ import type { CommandRegistry } from '../command-registry.js'
 import type { CommandResponse } from '../plugin/types.js'
 import type { OpenACPCore } from '../core.js'
 
+/**
+ * Register session lifecycle commands: /new, /cancel, /status, /sessions,
+ * /newchat, /resume, /handoff, /fork, /archive, /close, /agentsessions.
+ *
+ * These commands manage the full session lifecycle — creating, inspecting,
+ * forking, archiving, and closing sessions. Most require a session context
+ * (i.e. being invoked inside a session topic/thread).
+ */
 export function registerSessionCommands(registry: CommandRegistry, _core: unknown): void {
   const core = _core as OpenACPCore;
   registry.register({

--- a/src/core/commands/switch.ts
+++ b/src/core/commands/switch.ts
@@ -2,6 +2,14 @@ import type { CommandRegistry } from '../command-registry.js'
 import type { CommandResponse } from '../plugin/types.js'
 import type { OpenACPCore } from '../core.js'
 
+/**
+ * Register the /switch command for hot-swapping agents mid-session.
+ *
+ * - `/switch` (no args): shows a menu of available agents (excluding current)
+ * - `/switch <agent>`: aborts any running prompt and delegates to AgentSwitchHandler
+ * - `/switch label on|off`: toggles agent attribution labels in conversation history
+ *   (used by the context plugin when building history for the new agent)
+ */
 export function registerSwitchCommands(registry: CommandRegistry, _core: unknown): void {
   const core = _core as OpenACPCore;
 

--- a/src/core/config/config-editor.ts
+++ b/src/core/config/config-editor.ts
@@ -1,3 +1,19 @@
+/**
+ * Interactive CLI config editor (`openacp config`).
+ *
+ * Provides a menu-driven interface for editing global config and per-plugin
+ * settings. Operates in two modes:
+ * - **file mode**: collects all changes in a `updates` object as the user
+ *   navigates menus, then flushes the batch to config.json on exit. This
+ *   accumulate-then-flush approach avoids partial writes if the user cancels
+ *   midway through editing multiple fields.
+ * - **api mode**: sends each section's changes to the running daemon via REST
+ *   API immediately, enabling hot-reload without restart.
+ *
+ * Global settings (logging, runMode, defaultAgent) are stored in config.json.
+ * Plugin-specific settings (bot tokens, ports) are stored in per-plugin
+ * settings files via SettingsManager.
+ */
 import * as path from 'node:path'
 import * as clack from '@clack/prompts'
 import type { Config, ConfigManager } from './config.js'
@@ -669,6 +685,13 @@ async function editProviderOptions(
 
 // --- Main Config Editor ---
 
+/**
+ * Launches the interactive config editor.
+ *
+ * In `file` mode, changes accumulate and are written to disk on exit.
+ * In `api` mode, each section's changes are sent to the running daemon
+ * via the REST API, enabling hot-reload without restart.
+ */
 export async function runConfigEditor(
   configManager: ConfigManager,
   mode: 'file' | 'api' = 'file',
@@ -742,6 +765,7 @@ export async function runConfigEditor(
   }
 }
 
+/** Sends config updates to a running daemon via the REST API, one field path at a time. */
 async function sendConfigViaApi(port: number, updates: ConfigUpdates): Promise<void> {
   const { apiCall: call } = await import('../../cli/api-client.js')
 
@@ -761,6 +785,7 @@ async function sendConfigViaApi(port: number, updates: ConfigUpdates): Promise<v
   }
 }
 
+/** Flattens a nested object into dot-path/value pairs for the config PATCH API. */
 function flattenToPaths(obj: Record<string, unknown>, prefix = ''): Array<{ path: string; value: unknown }> {
   const result: Array<{ path: string; value: unknown }> = []
   for (const [key, val] of Object.entries(obj)) {

--- a/src/core/config/config-migrations.ts
+++ b/src/core/config/config-migrations.ts
@@ -1,3 +1,14 @@
+/**
+ * Config migrations transform old config.json shapes to the current schema.
+ *
+ * Migrations run automatically during ConfigManager.load(), before Zod validation.
+ * Each migration mutates the raw JSON object in place and returns true if it
+ * made changes. They run sequentially in array order — new migrations should
+ * always be appended at the end.
+ *
+ * If any migration fires, the updated config is written back to disk immediately,
+ * so the file stays in sync with the in-memory representation.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -6,17 +17,26 @@ const log = createChildLogger({ module: "config-migrations" });
 
 type RawConfig = Record<string, unknown>;
 
+/** Context passed to migrations that need filesystem access (e.g. looking up the instance registry). */
 export interface MigrationContext {
   configDir: string;
 }
 
+/** A single config migration: a named transform applied to the raw config object. */
 export interface Migration {
   name: string;
+  /** Mutates `raw` in place. Returns `true` if the config was changed. */
   apply: (raw: RawConfig, ctx?: MigrationContext) => boolean;
 }
 
+/**
+ * Ordered list of config migrations. Each runs once — idempotent guards
+ * (checking if the field already exists) prevent re-application.
+ */
 export const migrations: Migration[] = [
   {
+    // v2025.x: instanceName was added to support multi-instance setups.
+    // Old configs lack this field — default to "Main" so the UI has a display name.
     name: "add-instance-name",
     apply(raw) {
       if (raw.instanceName) return false;
@@ -26,6 +46,8 @@ export const migrations: Migration[] = [
     },
   },
   {
+    // displayVerbosity was replaced by outputMode — remove the legacy key
+    // so it doesn't confuse Zod strict parsing or the config editor.
     name: "delete-display-verbosity",
     apply(raw) {
       if (!("displayVerbosity" in raw)) return false;
@@ -35,15 +57,18 @@ export const migrations: Migration[] = [
     },
   },
   {
+    // Instance IDs were originally only in instances.json (the global registry).
+    // This migration copies the ID into config.json so each instance is self-identifying
+    // without needing to cross-reference the registry.
     name: "add-instance-id",
     apply(raw, ctx) {
-      if (raw.id) return false; // already has id, skip
-      if (!ctx?.configDir) return false; // no context, can't look up
+      if (raw.id) return false;
+      if (!ctx?.configDir) return false;
 
-      // ctx.configDir === instanceRoot (config.json lives at instanceRoot/config.json)
       const instanceRoot = ctx.configDir;
 
       try {
+        // Look up this instance's ID from the global registry
         const registryPath = path.join(os.homedir(), ".openacp", "instances.json");
         const data = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
         const instances = data?.instances ?? {};
@@ -65,8 +90,12 @@ export const migrations: Migration[] = [
 ];
 
 /**
- * Apply all migrations to raw config (mutates in place).
- * Returns whether any changes were made.
+ * Applies all pending migrations to a raw config object (mutates in place).
+ *
+ * Called by ConfigManager.load() before Zod validation. Each migration is
+ * idempotent — safe to run on configs that have already been migrated.
+ *
+ * @returns Whether any migration made changes (caller should persist if true)
  */
 export function applyMigrations(
   raw: RawConfig,

--- a/src/core/config/config-registry.ts
+++ b/src/core/config/config-registry.ts
@@ -1,15 +1,41 @@
+/**
+ * Config registry — declarative metadata for config fields.
+ *
+ * Each registered field describes its UI type, whether it can be hot-reloaded,
+ * and whether it's safe to expose via the API. This drives:
+ * - The API server's PATCH /api/config endpoint (validates + applies changes)
+ * - Hot-reload: fields marked `hotReload: true` take effect immediately via
+ *   ConfigManager's `config:changed` event, without requiring a restart
+ * - Security: only `scope: "safe"` fields are exposed to the REST API
+ */
 import type { Config } from "./config.js";
 
+/**
+ * Metadata for a single config field, describing how it should be
+ * displayed, validated, and applied at runtime.
+ */
 export interface ConfigFieldDef {
+  /** Dot-path into the Config object (e.g. "logging.level"). */
   path: string;
+  /** Human-readable label for UI display. */
   displayName: string;
+  /** Grouping key for organizing fields in the editor (e.g. "agent", "logging"). */
   group: string;
+  /** UI control type — determines validation and rendering. */
   type: "toggle" | "select" | "number" | "string";
+  /** For "select" type: allowed values, either static or derived from current config. */
   options?: string[] | ((config: Config) => string[]);
+  /** "safe" fields can be exposed via the API; "sensitive" fields require direct file access. */
   scope: "safe" | "sensitive";
+  /** Whether changes to this field take effect without restarting the server. */
   hotReload: boolean;
 }
 
+/**
+ * Static registry of all config fields that support programmatic access.
+ * Fields not listed here can still exist in config.json but won't be
+ * editable via the API or shown in the config UI.
+ */
 export const CONFIG_REGISTRY: ConfigFieldDef[] = [
   {
     path: "defaultAgent",
@@ -17,7 +43,6 @@ export const CONFIG_REGISTRY: ConfigFieldDef[] = [
     group: "agent",
     type: "select",
     options: (config) => {
-      // Return the current default agent as an option
       // Full agent list is managed by AgentCatalog at runtime, not config registry
       const current = config.defaultAgent;
       return current ? [current] : [];
@@ -52,19 +77,23 @@ export const CONFIG_REGISTRY: ConfigFieldDef[] = [
   },
 ];
 
+/** Looks up a field definition by its dot-path. */
 export function getFieldDef(path: string): ConfigFieldDef | undefined {
   return CONFIG_REGISTRY.find((f) => f.path === path);
 }
 
+/** Returns only fields safe to expose via the REST API. */
 export function getSafeFields(): ConfigFieldDef[] {
   return CONFIG_REGISTRY.filter((f) => f.scope === "safe");
 }
 
+/** Checks whether a config field can be changed without restarting the server. */
 export function isHotReloadable(path: string): boolean {
   const def = getFieldDef(path);
   return def?.hotReload ?? false;
 }
 
+/** Resolves select options — evaluates the function form against the current config if needed. */
 export function resolveOptions(
   def: ConfigFieldDef,
   config: Config,
@@ -73,6 +102,7 @@ export function resolveOptions(
   return typeof def.options === "function" ? def.options(config) : def.options;
 }
 
+/** Traverses a config object by dot-path (e.g. "logging.level") and returns the value. */
 export function getConfigValue(config: Config, path: string): unknown {
   const parts = path.split(".");
   let current: unknown = config;
@@ -86,6 +116,7 @@ export function getConfigValue(config: Config, path: string): unknown {
   return current;
 }
 
+/** Thrown when a config field value fails type validation against its registry definition. */
 export class ConfigValidationError extends Error {
   constructor(message: string) {
     super(message);
@@ -93,6 +124,7 @@ export class ConfigValidationError extends Error {
   }
 }
 
+/** Validates that a value matches the expected type for a registry field. */
 function validateFieldValue(field: ConfigFieldDef, value: unknown): void {
   switch (field.type) {
     case "number":
@@ -119,6 +151,11 @@ function validateFieldValue(field: ConfigFieldDef, value: unknown): void {
   }
 }
 
+/**
+ * Validates and persists a config field value via the ConfigManager.
+ *
+ * @returns Whether the change requires a server restart to take effect
+ */
 export async function setFieldValueAsync(
   field: ConfigFieldDef,
   value: unknown,

--- a/src/core/config/config.ts
+++ b/src/core/config/config.ts
@@ -9,6 +9,7 @@ import { createChildLogger } from "../utils/log.js";
 import type { SettingsManager } from "../plugin/settings-manager.js";
 const log = createChildLogger({ module: "config" });
 
+/** Log rotation and verbosity settings. */
 const LoggingSchema = z
   .object({
     level: z
@@ -21,12 +22,28 @@ const LoggingSchema = z
   })
   .default({});
 
+/** Runtime logging configuration. Controls per-module log levels and output destinations. */
 export type LoggingConfig = z.infer<typeof LoggingSchema>;
 
+/**
+ * Zod schema for the global OpenACP config file (`~/.openacp/config.json`).
+ *
+ * Every field uses `.default()` or `.optional()` so that config files from older
+ * versions — which lack newly added fields — still pass validation without error.
+ * This is critical for backward compatibility: users should never have to manually
+ * edit their config after upgrading.
+ *
+ * Plugin-specific settings live separately in per-plugin settings files
+ * (`~/.openacp/plugins/<name>/settings.json`), not here. This schema only
+ * covers global, cross-cutting concerns.
+ */
 export const ConfigSchema = z.object({
-  id: z.string().optional(),             // instance UUID, written once at creation time
+  /** Instance UUID, written once at creation time. */
+  id: z.string().optional(),
   instanceName: z.string().optional(),
   defaultAgent: z.string(),
+
+  // --- Workspace security & path resolution ---
   workspace: z
     .object({
       allowExternalWorkspaces: z.boolean().default(true),
@@ -38,14 +55,22 @@ export const ConfigSchema = z.object({
         .default({}),
     })
     .default({}),
+
+  // --- Logging ---
   logging: LoggingSchema,
+
+  // --- Process lifecycle ---
   runMode: z.enum(["foreground", "daemon"]).default("foreground"),
   autoStart: z.boolean().default(false),
+
+  // --- Session persistence ---
   sessionStore: z
     .object({
       ttlDays: z.number().default(30),
     })
     .default({}),
+
+  // --- Installed integration tracking (e.g. plugins installed via CLI) ---
   integrations: z
     .record(
       z.string(),
@@ -55,14 +80,20 @@ export const ConfigSchema = z.object({
       }),
     )
     .default({}),
+
+  // --- Agent output verbosity control ---
   outputMode: z.enum(["low", "medium", "high"]).default("medium").optional(),
+
+  // --- Multi-agent switching behavior ---
   agentSwitch: z.object({
     labelHistory: z.boolean().default(true),
   }).default({}),
 });
 
+/** Validated config object used throughout the codebase. Always obtained via `ConfigManager.get()` to ensure it's up-to-date. */
 export type Config = z.infer<typeof ConfigSchema>;
 
+/** Expands a leading `~` to the user's home directory. Returns the path unchanged if no `~` prefix. */
 export function expandHome(p: string): string {
   if (p.startsWith("~")) {
     return path.join(os.homedir(), p.slice(1));
@@ -75,6 +106,13 @@ const DEFAULT_CONFIG = {
   sessionStore: { ttlDays: 30 },
 };
 
+/**
+ * Manages loading, validating, and persisting the global config file.
+ *
+ * The load cycle is: read JSON -> apply migrations -> apply env overrides -> validate with Zod.
+ * Emits `config:changed` events when individual fields are updated, enabling
+ * hot-reload for fields marked as `hotReload` in the config registry.
+ */
 export class ConfigManager extends EventEmitter {
   private config!: Config;
   private configPath: string;
@@ -85,12 +123,17 @@ export class ConfigManager extends EventEmitter {
       process.env.OPENACP_CONFIG_PATH || configPath || expandHome("~/.openacp/config.json");
   }
 
+  /**
+   * Loads config from disk through the full validation pipeline:
+   * 1. Create default config if missing (first run)
+   * 2. Apply migrations for older config formats
+   * 3. Apply environment variable overrides
+   * 4. Validate against Zod schema — exits on failure
+   */
   async load(): Promise<void> {
-    // 1. Ensure directory exists
     const dir = path.dirname(this.configPath);
     fs.mkdirSync(dir, { recursive: true });
 
-    // 2. If config file doesn't exist, create default
     if (!fs.existsSync(this.configPath)) {
       fs.writeFileSync(
         this.configPath,
@@ -103,19 +146,16 @@ export class ConfigManager extends EventEmitter {
       process.exit(1);
     }
 
-    // 3. Read and parse
     const raw = JSON.parse(fs.readFileSync(this.configPath, "utf-8"));
 
-    // 3.5. Auto-migrate config
+    // Auto-migrate before validation — transforms old config shapes to current schema
     const { changed: configUpdated } = applyMigrations(raw, undefined, { configDir: path.dirname(this.configPath) });
     if (configUpdated) {
       fs.writeFileSync(this.configPath, JSON.stringify(raw, null, 2));
     }
 
-    // 4. Apply env var overrides
     this.applyEnvOverrides(raw);
 
-    // 5. Validate with Zod
     const result = ConfigSchema.safeParse(raw);
     if (!result.success) {
       log.error("Config validation failed");
@@ -130,16 +170,23 @@ export class ConfigManager extends EventEmitter {
     this.config = result.data;
   }
 
+  /** Returns a deep clone of the current config to prevent external mutation. */
   get(): Config {
     return structuredClone(this.config);
   }
 
+  /**
+   * Merges partial updates into the config file using atomic write (write tmp + rename).
+   *
+   * Validates the merged result before writing. If `changePath` is provided,
+   * emits a `config:changed` event with old and new values for that path,
+   * enabling hot-reload without restart.
+   */
   async save(
     updates: Record<string, unknown>,
     changePath?: string,
   ): Promise<void> {
     const oldConfig = this.config ? structuredClone(this.config) : undefined;
-    // Read current file, merge updates
     const raw = JSON.parse(fs.readFileSync(this.configPath, "utf-8"));
     this.deepMerge(raw, updates);
     // Validate BEFORE writing to disk
@@ -148,11 +195,11 @@ export class ConfigManager extends EventEmitter {
       log.error({ errors: result.error.issues }, "Config validation failed, not saving");
       return;
     }
+    // Atomic write: tmp file + rename prevents corruption if process crashes mid-write
     const tmpPath = this.configPath + `.tmp.${randomBytes(4).toString('hex')}`;
     fs.writeFileSync(tmpPath, JSON.stringify(raw, null, 2), "utf-8");
     fs.renameSync(tmpPath, this.configPath);
     this.config = result.data;
-    // Emit change event if path provided
     if (changePath) {
       const { getConfigValue } = await import("./config-registry.js");
       const value = getConfigValue(this.config, changePath);
@@ -164,9 +211,12 @@ export class ConfigManager extends EventEmitter {
   }
 
   /**
-   * Set a single config value by dot-path (e.g. "logging.level").
-   * Builds the nested update object, validates, and saves.
-   * Throws if the path contains blocked keys or the value fails Zod validation.
+   * Convenience wrapper for updating a single deeply-nested config field
+   * without constructing the full update object manually.
+   *
+   * Accepts a dot-path (e.g. "logging.level") and builds the nested
+   * update object internally before delegating to `save()`.
+   * Throws if the path contains prototype-pollution keys.
    */
   async setPath(dotPath: string, value: unknown): Promise<void> {
     const BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
@@ -187,6 +237,13 @@ export class ConfigManager extends EventEmitter {
     await this.save(updates, dotPath);
   }
 
+  /**
+   * Resolves a workspace path from user input.
+   *
+   * Supports three forms: no input (returns base dir), absolute/tilde paths
+   * (validated against allowExternalWorkspaces), and named workspaces
+   * (alphanumeric subdirectories under the base).
+   */
   resolveWorkspace(input?: string): string {
     // configPath = /x/y/.openacp/config.json → workspace = /x/y/
     const workspaceBase = path.dirname(path.dirname(this.configPath));
@@ -230,20 +287,29 @@ export class ConfigManager extends EventEmitter {
     return namedPath;
   }
 
+  /** Checks whether the config file exists on disk. Wraps synchronous `fs.existsSync` behind an async interface for consistency with the rest of the ConfigManager API. */
   async exists(): Promise<boolean> {
     return fs.existsSync(this.configPath);
   }
 
+  /** Returns the resolved path to the config JSON file. */
   getConfigPath(): string {
     return this.configPath;
   }
 
+  /** Writes a complete config object to disk, creating the directory if needed. Used during initial setup. */
   async writeNew(config: Config): Promise<void> {
     const dir = path.dirname(this.configPath);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(this.configPath, JSON.stringify(config, null, 2));
   }
 
+  /**
+   * Applies `OPENACP_*` environment variables as overrides to per-plugin settings.
+   *
+   * This lets users configure plugin values (bot tokens, ports, etc.) via env vars
+   * without editing settings files — useful for Docker, CI, and headless setups.
+   */
   async applyEnvToPluginSettings(settingsManager: SettingsManager): Promise<void> {
     const pluginOverrides: Array<{
       envVar: string;
@@ -277,6 +343,7 @@ export class ConfigManager extends EventEmitter {
     }
   }
 
+  /** Applies env var overrides to the raw config object before Zod validation. */
   private applyEnvOverrides(raw: Record<string, unknown>): void {
     const overrides: [string, string[]][] = [
       ["OPENACP_DEFAULT_AGENT", ["defaultAgent"]],
@@ -312,10 +379,12 @@ export class ConfigManager extends EventEmitter {
     }
   }
 
+  /** Recursively merges source into target, skipping prototype-pollution keys. */
   private deepMerge(
     target: Record<string, unknown>,
     source: Record<string, unknown>,
   ): void {
+    // Prototype pollution guard — these keys must never be set via user input
     const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
     for (const key of Object.keys(source)) {
       if (DANGEROUS_KEYS.has(key)) continue;

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -334,7 +334,8 @@ export class OpenACPCore {
   /**
    * Archive a session: delete its adapter topic/thread and cancel the session.
    *
-   * Only sessions in terminal-ish states (active, cancelled, error) can be archived.
+   * Only sessions in archivable states (active, cancelled, error) can be archived —
+   * initializing and finished sessions are excluded.
    * The adapter handles platform-side cleanup (e.g. deleting a Telegram topic).
    */
   async archiveSession(sessionId: string): Promise<{ ok: true } | { ok: false; error: string }> {

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -35,6 +35,18 @@ import type { InstanceContext } from "./instance/instance-context.js";
 import { Hook, BusEvent, SessionEv } from "./events.js";
 const log = createChildLogger({ module: "core" });
 
+/**
+ * Top-level orchestrator that wires all OpenACP modules together.
+ *
+ * Responsibilities:
+ * - Registers messaging adapters (Telegram, Slack, SSE, etc.)
+ * - Routes incoming messages to the correct Session (by channel + thread)
+ * - Manages the full session lifecycle: creation, agent switch, archive, shutdown
+ * - Connects agent events to adapter callbacks via SessionBridge
+ * - Accesses plugin-provided services (security, notifications, speech, etc.)
+ *   through ServiceRegistry rather than direct references, since plugins
+ *   register their services asynchronously during boot
+ */
 export class OpenACPCore {
   configManager: ConfigManager;
   agentCatalog: AgentCatalog;
@@ -57,38 +69,57 @@ export class OpenACPCore {
   readonly assistantRegistry = new AssistantRegistry();
   assistantManager!: AssistantManager;
 
-  // --- Lazy getters: resolve from ServiceRegistry (populated by plugins during boot) ---
+  // Services (security, notifications, speech, etc.) are provided by plugins that
+  // register during boot. Core accesses them lazily via ServiceRegistry so it doesn't
+  // need compile-time dependencies on plugin implementations.
 
+  /** @throws if the service hasn't been registered by its plugin yet */
   private getService<T>(name: string): T {
     const svc = this.lifecycleManager.serviceRegistry.get<T>(name);
     if (!svc) throw new Error(`Service '${name}' not registered — is the ${name} plugin loaded?`);
     return svc;
   }
 
+  /** Access control and rate-limiting guard (provided by security plugin). */
   get securityGuard(): SecurityGuard {
     return this.getService<SecurityGuard>('security');
   }
 
+  /** Cross-session notification delivery (provided by notifications plugin). */
   get notificationManager(): NotificationManager {
     return this.getService<NotificationManager>('notifications');
   }
 
+  /** File I/O service for agent attachment storage (provided by file-service plugin). */
   get fileService(): FileServiceInterface {
     return this.getService<FileServiceInterface>('file-service');
   }
 
+  /** Text-to-speech / speech-to-text engine (provided by speech plugin). */
   get speechService(): SpeechService {
     return this.getService<SpeechService>('speech');
   }
 
+  /** Conversation history builder for context injection (provided by context plugin). */
   get contextManager(): ContextManager {
     return this.getService<ContextManager>('context');
   }
 
+  /** Per-plugin persistent settings (e.g. API keys). */
   get settingsManager(): SettingsManager | undefined {
     return this.lifecycleManager.settingsManager;
   }
 
+  /**
+   * Bootstrap all core subsystems. The boot order matters:
+   * 1. AgentCatalog + AgentManager (agent definitions)
+   * 2. SessionStore + SessionManager (session persistence and lookup)
+   * 3. EventBus (inter-module communication)
+   * 4. SessionFactory (session creation pipeline)
+   * 5. LifecycleManager (plugin infrastructure)
+   * 6. Wire middleware chain into factory + manager
+   * 7. AgentSwitchHandler, config listeners, menu/assistant registries
+   */
   constructor(configManager: ConfigManager, ctx: InstanceContext) {
     this.configManager = configManager;
     this.instanceContext = ctx;
@@ -225,19 +256,31 @@ export class OpenACPCore {
     this.lifecycleManager.serviceRegistry.register('assistant-registry', this.assistantRegistry, 'core');
   }
 
+  /** Optional tunnel for generating public URLs (code viewer links, etc.). */
   get tunnelService(): TunnelService | undefined {
     return this._tunnelService;
   }
 
+  /** Propagate tunnel service to MessageTransformer so it can generate viewer links. */
   set tunnelService(service: TunnelService | undefined) {
     this._tunnelService = service;
     this.messageTransformer.tunnelService = service;
   }
 
+  /**
+   * Register a messaging adapter (e.g. Telegram, Slack, SSE).
+   *
+   * Adapters must be registered before `start()`. The adapter name serves as its
+   * channel ID throughout the system — used in session records, bridge keys, and routing.
+   */
   registerAdapter(name: string, adapter: IChannelAdapter): void {
     this.adapters.set(name, adapter);
   }
 
+  /**
+   * Start all registered adapters. Adapters that fail are logged but do not
+   * prevent others from starting. Throws only if ALL adapters fail.
+   */
   async start(): Promise<void> {
     this.agentCatalog.refreshRegistryIfStale().catch((err) => {
       log.warn({ err }, "Background registry refresh failed");
@@ -258,6 +301,10 @@ export class OpenACPCore {
     }
   }
 
+  /**
+   * Graceful shutdown: notify users, persist session state, stop adapters.
+   * Agent subprocesses are not explicitly killed — they exit with the parent process.
+   */
   async stop(): Promise<void> {
     // 1. Notify users (best effort — service may not be available)
     try {
@@ -284,6 +331,12 @@ export class OpenACPCore {
 
   // --- Archive ---
 
+  /**
+   * Archive a session: delete its adapter topic/thread and cancel the session.
+   *
+   * Only sessions in terminal-ish states (active, cancelled, error) can be archived.
+   * The adapter handles platform-side cleanup (e.g. deleting a Telegram topic).
+   */
   async archiveSession(sessionId: string): Promise<{ ok: true } | { ok: false; error: string }> {
     const session = this.sessionManager.getSession(sessionId);
     if (!session) return { ok: false, error: "Session not found (must be in memory)" };
@@ -314,6 +367,18 @@ export class OpenACPCore {
 
   // --- Message Routing ---
 
+  /**
+   * Route an incoming platform message to the appropriate session.
+   *
+   * Flow:
+   * 1. Run `message:incoming` middleware (plugins can modify or block)
+   * 2. SecurityGuard checks user access and per-user session limits
+   * 3. Find session by channel+thread (in-memory lookup, then lazy resume from disk)
+   * 4. For assistant sessions, prepend any deferred system prompt
+   * 5. Emit `message:queued` for SSE clients, then enqueue the prompt on the session
+   *
+   * If no session is found, the user is told to start one with /new.
+   */
   async handleMessage(message: IncomingMessage): Promise<void> {
     log.debug(
       {
@@ -383,13 +448,17 @@ export class OpenACPCore {
       }
     }
 
-    // Emit message:queued immediately (before awaiting the queue) so SSE clients see the
-    // incoming message right away, not after the AI finishes processing.
+    // Emit message:queued immediately (before awaiting the queue) so SSE clients
+    // see the incoming message right away, not after the AI finishes processing.
+
+    // Merge sourceAdapterId into routing so middleware hooks (e.g. history recorder)
+    // can identify the originating adapter even when the message is processed by a
+    // different adapter (e.g. an API-sourced message routed through a Telegram session).
     const sourceAdapterId = message.routing?.sourceAdapterId ?? message.channelId;
-    // Merge sourceAdapterId into routing so middleware (e.g. history recorder) receives it
     const routing = sourceAdapterId !== message.routing?.sourceAdapterId
       ? { ...message.routing, sourceAdapterId }
       : message.routing;
+    // Skip queue event for SSE/API sources — they already have the message
     if (sourceAdapterId && sourceAdapterId !== 'sse' && sourceAdapterId !== 'api') {
       const turnId = nanoid(8);
       this.eventBus.emit(BusEvent.MESSAGE_QUEUED, {
@@ -410,6 +479,17 @@ export class OpenACPCore {
 
   // --- Unified Session Creation Pipeline ---
 
+  /**
+   * Create (or resume) a session with full wiring: agent, adapter thread, bridge, persistence.
+   *
+   * This is the single entry point for session creation. The pipeline:
+   * 1. SessionFactory spawns/resumes the agent process
+   * 2. Adapter creates a thread/topic if requested
+   * 3. Initial session record is persisted (so lazy resume can find it by threadId)
+   * 4. SessionBridge connects agent events to the adapter
+   * 5. For headless sessions (no adapter), fallback event handlers are wired inline
+   * 6. Side effects (usage tracking, tunnel cleanup) are attached
+   */
   async createSession(params: {
     channelId: string;
     agentName: string;
@@ -580,6 +660,7 @@ export class OpenACPCore {
     return session;
   }
 
+  /** Convenience wrapper: create a new session with default agent/workspace resolution. */
   async handleNewSession(
     channelId: string,
     agentName?: string,
@@ -589,6 +670,12 @@ export class OpenACPCore {
     return this.sessionFactory.handleNewSession(channelId, agentName, workspacePath, options);
   }
 
+  /**
+   * Adopt an externally-started agent session (e.g. from a CLI `openacp adopt` command).
+   *
+   * Validates that the agent supports resume, checks session limits, avoids duplicates,
+   * then creates a full session via the unified pipeline with resume semantics.
+   */
   async adoptSession(
     agentName: string,
     agentSessionId: string,
@@ -632,7 +719,9 @@ export class OpenACPCore {
       };
     }
 
-    // 3. Check session limit (default 20; security plugin may override via plugin settings)
+    // 3. Hard cap for the adoptSession path (CLI-initiated session adoption).
+    // This is separate from the per-user limits enforced by securityGuard.checkAccess
+    // during handleMessage. The security plugin cannot override this value.
     const maxSessions = 20;
     if (this.sessionManager.listSessions().length >= maxSessions) {
       return {
@@ -730,10 +819,12 @@ export class OpenACPCore {
     };
   }
 
+  /** Start a new chat within the same agent and workspace as the current session's thread. */
   async handleNewChat(channelId: string, currentThreadId: string): Promise<Session | null> {
     return this.sessionFactory.handleNewChat(channelId, currentThreadId);
   }
 
+  /** Create a session and inject conversation context from a prior session or repo. */
   async createSessionWithContext(params: {
     channelId: string;
     agentName: string;
@@ -748,18 +839,27 @@ export class OpenACPCore {
 
   // --- Agent Switch ---
 
+  /** Switch a session's active agent. Delegates to AgentSwitchHandler for state coordination. */
   async switchSessionAgent(sessionId: string, toAgent: string): Promise<{ resumed: boolean }> {
     return this.agentSwitchHandler.switch(sessionId, toAgent);
   }
 
+  /** Find a session by channel+thread, resuming from disk if not in memory. */
   async getOrResumeSession(channelId: string, threadId: string): Promise<Session | null> {
     return this.sessionFactory.getOrResume(channelId, threadId);
   }
 
+  /** Find a session by ID, resuming from disk if not in memory. */
   async getOrResumeSessionById(sessionId: string): Promise<Session | null> {
     return this.sessionFactory.getOrResumeById(sessionId);
   }
 
+  /**
+   * Attach an additional adapter to an existing session (multi-adapter support).
+   *
+   * Creates a thread on the target adapter and connects a SessionBridge so the
+   * session's agent events are forwarded to both the primary and attached adapters.
+   */
   async attachAdapter(sessionId: string, adapterId: string): Promise<{ threadId: string }> {
     const session = this.sessionManager.getSession(sessionId);
     if (!session) throw new Error(`Session ${sessionId} not found`);
@@ -794,6 +894,10 @@ export class OpenACPCore {
     return { threadId };
   }
 
+  /**
+   * Detach a secondary adapter from a session. The primary adapter (channelId) cannot
+   * be detached. Disconnects the bridge and cleans up thread mappings.
+   */
   async detachAdapter(sessionId: string, adapterId: string): Promise<void> {
     const session = this.sessionManager.getSession(sessionId);
     if (!session) throw new Error(`Session ${sessionId} not found`);
@@ -836,6 +940,7 @@ export class OpenACPCore {
     });
   }
 
+  /** Build the platforms map (adapter → thread/topic IDs) for persistence. */
   private buildPlatformsFromSession(session: Session): Record<string, Record<string, unknown>> {
     const platforms: Record<string, Record<string, unknown>> = {};
     for (const [adapterId, threadId] of session.threadIds) {
@@ -872,8 +977,13 @@ export class OpenACPCore {
     bridge.connect();
   }
 
-  /** Create a SessionBridge for the given session and adapter.
-   *  Disconnects any existing bridge for the same adapter+session first. */
+  /**
+   * Create a SessionBridge for the given session and adapter.
+   *
+   * The bridge subscribes to Session events (agent output, status changes, naming)
+   * and forwards them to the adapter for platform delivery. Disconnects any existing
+   * bridge for the same adapter+session first to avoid duplicate event handlers.
+   */
   createBridge(session: Session, adapter: IChannelAdapter, adapterId?: string): SessionBridge {
     const id = adapterId ?? adapter.name;
     const key = this.bridgeKey(id, session.id);

--- a/src/core/doctor/checks/agents.ts
+++ b/src/core/doctor/checks/agents.ts
@@ -1,14 +1,21 @@
+/**
+ * Doctor check: Agents — verifies configured agents are installed and
+ * their commands are accessible via PATH or local node_modules/.bin.
+ * Missing the default agent is a "fail"; missing optional agents are "warn".
+ */
+
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { DoctorCheck, CheckResult } from "../types.js";
 
+/** Checks PATH first, then walks up the directory tree looking for node_modules/.bin. */
 function commandExists(cmd: string): boolean {
   try {
     execFileSync("which", [cmd], { stdio: "pipe" });
     return true;
   } catch {
-    // not in PATH
+    // not in PATH — fall through to node_modules check
   }
   let dir = process.cwd();
   while (true) {

--- a/src/core/doctor/checks/config.ts
+++ b/src/core/doctor/checks/config.ts
@@ -1,3 +1,11 @@
+/**
+ * Doctor check: Config — validates config.json exists, is parseable JSON,
+ * passes Zod schema validation, and has no pending migrations.
+ *
+ * Pending migrations are auto-fixable (safe). This check runs first (order 1)
+ * because most other checks depend on a valid config.
+ */
+
 import * as fs from "node:fs";
 import { ConfigSchema } from "../../config/config.js";
 import { applyMigrations } from "../../config/config-migrations.js";

--- a/src/core/doctor/checks/daemon.ts
+++ b/src/core/doctor/checks/daemon.ts
@@ -1,7 +1,13 @@
+/**
+ * Doctor check: Daemon — verifies daemon process state, PID file validity,
+ * and API port availability. Stale PID files are auto-fixable.
+ */
+
 import * as fs from "node:fs";
 import * as net from "node:net";
 import type { DoctorCheck, CheckResult } from "../types.js";
 
+/** Sends signal 0 to check if a process exists without killing it. */
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -11,6 +17,7 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+/** Attempts to bind the port — if binding fails, the port is in use. */
 function checkPortInUse(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer();

--- a/src/core/doctor/checks/plugins.ts
+++ b/src/core/doctor/checks/plugins.ts
@@ -1,3 +1,10 @@
+/**
+ * Doctor check: Plugins — verifies the plugins directory exists and its
+ * package.json is valid. Missing directory or package.json are auto-fixable.
+ * Corrupt package.json is a risky fix (requires user confirmation since
+ * resetting it loses the dependency list).
+ */
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { DoctorCheck, CheckResult } from "../types.js";

--- a/src/core/doctor/checks/storage.ts
+++ b/src/core/doctor/checks/storage.ts
@@ -1,3 +1,9 @@
+/**
+ * Doctor check: Storage — verifies the data directory (.openacp/), session
+ * store, and log directory exist and are writable. Corrupt sessions.json
+ * is a risky fix (resetting it drops session history).
+ */
+
 import * as fs from "node:fs";
 import type { DoctorCheck, CheckResult } from "../types.js";
 

--- a/src/core/doctor/checks/telegram.ts
+++ b/src/core/doctor/checks/telegram.ts
@@ -1,6 +1,19 @@
+/**
+ * Doctor check: Telegram — validates bot token, chat ID, and bot permissions.
+ *
+ * Performs live API calls to verify:
+ *   1. Bot token format matches Telegram's pattern
+ *   2. Bot token is accepted by the Telegram API (getMe)
+ *   3. Chat ID points to a valid supergroup with topics enabled
+ *   4. Bot has administrator privileges in the group
+ *
+ * Skipped if Telegram is not configured (no bot token or chat ID in settings).
+ */
+
 import * as path from "node:path";
 import type { DoctorCheck, CheckResult } from "../types.js";
 
+/** Telegram bot tokens follow the pattern: <bot_id>:<alphanumeric_secret> */
 const BOT_TOKEN_REGEX = /^\d+:[A-Za-z0-9_-]{35,}$/;
 
 export const telegramCheck: DoctorCheck = {

--- a/src/core/doctor/checks/tunnel.ts
+++ b/src/core/doctor/checks/tunnel.ts
@@ -1,3 +1,9 @@
+/**
+ * Doctor check: Tunnel — verifies tunnel provider binary availability and
+ * port configuration when tunneling is enabled. Currently supports Cloudflare
+ * tunnel (cloudflared). Missing binary is auto-fixable via download.
+ */
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";

--- a/src/core/doctor/checks/workspace.ts
+++ b/src/core/doctor/checks/workspace.ts
@@ -1,3 +1,8 @@
+/**
+ * Doctor check: Workspace — verifies the workspace directory (parent of
+ * .openacp/) exists and is writable. A missing workspace is auto-fixable.
+ */
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { DoctorCheck, CheckResult } from "../types.js";

--- a/src/core/doctor/index.ts
+++ b/src/core/doctor/index.ts
@@ -12,6 +12,7 @@ import { pluginsCheck } from "./checks/plugins.js";
 import { daemonCheck } from "./checks/daemon.js";
 import { tunnelCheck } from "./checks/tunnel.js";
 
+/** All registered checks, sorted by order before execution. */
 const ALL_CHECKS: DoctorCheck[] = [
   configCheck,
   agentsCheck,
@@ -23,8 +24,16 @@ const ALL_CHECKS: DoctorCheck[] = [
   tunnelCheck,
 ];
 
+/** Per-check timeout — prevents a single hanging check from blocking the entire run. */
 const CHECK_TIMEOUT_MS = 10_000;
 
+/**
+ * Orchestrates diagnostic checks for an OpenACP installation.
+ *
+ * Runs all registered checks in order, collects results, and automatically
+ * applies safe fixes (unless in dry-run mode). Risky fixes are collected
+ * as `pendingFixes` for the CLI to present interactively.
+ */
 export class DoctorEngine {
   private dryRun: boolean;
   private dataDir: string;
@@ -34,6 +43,12 @@ export class DoctorEngine {
     this.dataDir = options!.dataDir!;
   }
 
+  /**
+   * Executes all checks and returns an aggregated report.
+   *
+   * Safe fixes are applied inline (mutating CheckResult.message to show "Fixed").
+   * Risky fixes are deferred to `report.pendingFixes` for user confirmation.
+   */
   async runAll(): Promise<DoctorReport> {
     const ctx = await this.buildContext();
     const checks = [...ALL_CHECKS].sort((a, b) => a.order - b.order);
@@ -89,6 +104,7 @@ export class DoctorEngine {
     return { categories, summary, pendingFixes };
   }
 
+  /** Constructs the shared context used by all checks — loads config if available. */
   private async buildContext(): Promise<DoctorContext> {
     const dataDir = this.dataDir;
     const configPath = process.env.OPENACP_CONFIG_PATH || path.join(dataDir, "config.json");

--- a/src/core/doctor/types.ts
+++ b/src/core/doctor/types.ts
@@ -1,7 +1,26 @@
+/**
+ * Type definitions for the doctor diagnostic system.
+ *
+ * The doctor runs a collection of checks, each producing CheckResults
+ * with a severity level. The CLI renders these results and optionally
+ * applies automatic fixes:
+ *
+ * - **pass** — check succeeded, shown as green checkmark
+ * - **warn** — non-critical issue, shown as yellow warning
+ * - **fail** — critical issue that will prevent OpenACP from working
+ *
+ * Fixable results include a `fix()` function with a risk level:
+ * - **safe** — auto-applied without prompting (e.g. creating missing dirs)
+ * - **risky** — requires user confirmation (e.g. resetting corrupted data)
+ */
+
 import type { Config } from "../config/config.js";
 
+/** Shared context passed to all doctor checks, built once per run. */
 export interface DoctorContext {
+  /** Parsed and validated config, or null if config couldn't be loaded. */
   config: Config | null;
+  /** Raw parsed JSON before Zod validation — available even if validation fails. */
   rawConfig: unknown;
   configPath: string;
   dataDir: string;
@@ -12,36 +31,49 @@ export interface DoctorContext {
   logsDir: string;
 }
 
+/** Result of a single diagnostic check within a category. */
 export interface CheckResult {
   status: "pass" | "warn" | "fail";
   message: string;
+  /** Whether this result has an associated automatic fix. */
   fixable?: boolean;
+  /** "safe" fixes are applied automatically; "risky" fixes require user confirmation. */
   fixRisk?: "safe" | "risky";
   fix?: () => Promise<FixResult>;
 }
 
+/** Outcome of applying a fix. */
 export interface FixResult {
   success: boolean;
   message: string;
 }
 
+/**
+ * A named diagnostic check that produces one or more results.
+ * Checks are sorted by `order` before execution.
+ */
 export interface DoctorCheck {
   name: string;
+  /** Lower order runs first. Config (1) must run before checks that depend on it. */
   order: number;
   run(ctx: DoctorContext): Promise<CheckResult[]>;
 }
 
+/** Aggregated report returned by DoctorEngine.runAll(). */
 export interface DoctorReport {
   categories: CategoryResult[];
   summary: { passed: number; warnings: number; failed: number; fixed: number };
+  /** Risky fixes that were deferred for user confirmation. */
   pendingFixes: PendingFix[];
 }
 
+/** All results for a single check category (e.g. "Config", "Agents"). */
 export interface CategoryResult {
   name: string;
   results: CheckResult[];
 }
 
+/** A risky fix deferred for interactive user confirmation. */
 export interface PendingFix {
   category: string;
   message: string;

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -1,6 +1,13 @@
 import { TypedEmitter } from "./utils/typed-emitter.js";
 import type { AgentEvent, PermissionRequest, SessionStatus, UsageRecordEvent } from "./types.js";
 
+/**
+ * Event map for the global EventBus.
+ *
+ * Defines all cross-cutting events that flow between core, plugins, and adapters.
+ * Plugins subscribe via `eventBus.on(...)` without needing direct references
+ * to the components that emit these events.
+ */
 export interface EventBusEvents {
   "session:created": (data: {
     sessionId: string;
@@ -89,4 +96,12 @@ export interface EventBusEvents {
   }) => void;
 }
 
+/**
+ * Global event bus for cross-cutting communication.
+ *
+ * Decouples plugins from direct session/core references — plugins and adapters
+ * subscribe to bus events without knowing which component emits them. The core
+ * and sessions emit events here; plugins consume them for features like usage
+ * tracking, notifications, and UI updates.
+ */
 export class EventBus extends TypedEmitter<EventBusEvents> {}

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -16,7 +16,14 @@ import type { SessionEvents } from './sessions/session.js';
 
 /**
  * Names for all middleware pipeline hooks.
- * Used with middlewareChain.execute(Hook.X, ...) and ctx.registerMiddleware(Hook.X, ...).
+ *
+ * Each hook is an intercept point in the request/event pipeline. Middleware
+ * registered on a hook can inspect, modify, or block the payload before it
+ * proceeds. "Read-only, fire-and-forget" hooks run after the fact and cannot
+ * block.
+ *
+ * Used with `middlewareChain.execute(Hook.X, ...)` and
+ * `ctx.registerMiddleware(Hook.X, ...)`.
  */
 export const Hook = {
   // --- Message flow ---
@@ -82,45 +89,72 @@ export type HookName = typeof Hook[keyof typeof Hook];
 
 /**
  * Names for all EventBus events.
- * Used with eventBus.emit(BusEvent.X, ...) and eventBus.on(BusEvent.X, ...).
- * Type-checked against EventBusEvents interface.
+ *
+ * EventBus is the global pub/sub bus for cross-cutting concerns — plugins
+ * subscribe to these events without needing direct references to sessions
+ * or adapters. Type-checked against the EventBusEvents interface.
+ *
+ * Used with `eventBus.emit(BusEvent.X, ...)` and `eventBus.on(BusEvent.X, ...)`.
  */
 export const BusEvent = {
   // --- Session lifecycle ---
+  /** Fired when a new session is created and ready. */
   SESSION_CREATED: 'session:created',
+  /** Fired when session metadata changes (status, name, overrides). */
   SESSION_UPDATED: 'session:updated',
+  /** Fired when a session record is deleted from the store. */
   SESSION_DELETED: 'session:deleted',
+  /** Fired when a session ends (agent finished or error). */
   SESSION_ENDED: 'session:ended',
+  /** Fired when a session receives its auto-generated name. */
   SESSION_NAMED: 'session:named',
+  /** Fired after a new session thread is created and bridge connected. */
   SESSION_THREAD_READY: 'session:threadReady',
+  /** Fired when an agent's config options change (adapters update control UIs). */
   SESSION_CONFIG_CHANGED: 'session:configChanged',
+  /** Fired during agent switch lifecycle (starting/succeeded/failed). */
   SESSION_AGENT_SWITCH: 'session:agentSwitch',
 
   // --- Agent ---
+  /** Fired for every agent event (text, tool_call, usage, etc.). */
   AGENT_EVENT: 'agent:event',
+  /** Fired when a prompt is sent to the agent. */
   AGENT_PROMPT: 'agent:prompt',
 
   // --- Permissions ---
+  /** Fired when the agent requests user permission (blocks until resolved). */
   PERMISSION_REQUEST: 'permission:request',
+  /** Fired after a permission request is resolved (approved or denied). */
   PERMISSION_RESOLVED: 'permission:resolved',
 
   // --- Message visibility ---
+  /** Fired when a user message is queued (for cross-adapter input visibility). */
   MESSAGE_QUEUED: 'message:queued',
+  /** Fired when a queued message starts processing. */
   MESSAGE_PROCESSING: 'message:processing',
 
   // --- System lifecycle ---
+  /** Fired after kernel (core + plugin infrastructure) has booted. */
   KERNEL_BOOTED: 'kernel:booted',
+  /** Fired when the system is fully ready (all adapters connected). */
   SYSTEM_READY: 'system:ready',
+  /** Fired during graceful shutdown. */
   SYSTEM_SHUTDOWN: 'system:shutdown',
+  /** Fired when all system commands are registered and available. */
   SYSTEM_COMMANDS_READY: 'system:commands-ready',
 
   // --- Plugin lifecycle ---
+  /** Fired when a plugin loads successfully. */
   PLUGIN_LOADED: 'plugin:loaded',
+  /** Fired when a plugin fails to load. */
   PLUGIN_FAILED: 'plugin:failed',
+  /** Fired when a plugin is disabled (e.g., missing config). */
   PLUGIN_DISABLED: 'plugin:disabled',
+  /** Fired when a plugin is unloaded during shutdown. */
   PLUGIN_UNLOADED: 'plugin:unloaded',
 
   // --- Usage ---
+  /** Fired when a token usage record is captured (consumed by usage plugin). */
   USAGE_RECORDED: 'usage:recorded',
 } as const satisfies Record<string, keyof EventBusEvents>;
 
@@ -132,17 +166,29 @@ export type BusEventName = typeof BusEvent[keyof typeof BusEvent];
 
 /**
  * Names for all Session TypedEmitter events.
- * Used with session.on(SessionEv.X, ...) and session.emit(SessionEv.X, ...).
- * Type-checked against SessionEvents interface.
+ *
+ * These are per-session events emitted by the Session instance itself.
+ * SessionBridge subscribes to these to relay agent output to adapters.
+ *
+ * Used with `session.on(SessionEv.X, ...)` and `session.emit(SessionEv.X, ...)`.
+ * Type-checked against the SessionEvents interface.
  */
 export const SessionEv = {
+  /** Agent produced an event (text, tool_call, etc.) during a turn. */
   AGENT_EVENT: 'agent_event',
+  /** Agent is requesting user permission — blocks until resolved. */
   PERMISSION_REQUEST: 'permission_request',
+  /** Session ended (agent finished, cancelled, or errored). */
   SESSION_END: 'session_end',
+  /** Session status changed (e.g., initializing → active). */
   STATUS_CHANGE: 'status_change',
+  /** Session received an auto-generated name from the first response. */
   NAMED: 'named',
+  /** An unrecoverable error occurred in the session. */
   ERROR: 'error',
+  /** The session's prompt count changed (used for UI counters). */
   PROMPT_COUNT_CHANGED: 'prompt_count_changed',
+  /** A new prompt turn started (provides TurnContext for middleware). */
   TURN_STARTED: 'turn_started',
 } as const satisfies Record<string, keyof SessionEvents>;
 

--- a/src/core/instance/instance-context.ts
+++ b/src/core/instance/instance-context.ts
@@ -2,25 +2,42 @@ import path from 'node:path'
 import fs from 'node:fs'
 import os from 'node:os'
 
+/**
+ * Describes a single OpenACP instance and all its filesystem paths.
+ *
+ * An "instance" is one running OpenACP server process, identified by a
+ * unique ID. Multiple instances can run on the same machine with different
+ * configs, ports, and data directories. The instance root is typically
+ * `<workspace>/.openacp/`.
+ */
 export interface InstanceContext {
+  /** Unique identifier for this instance (UUID). */
   id: string
+  /** Absolute path to the instance root directory (e.g. `~/my-project/.openacp/`). */
   root: string
+  /** Pre-resolved paths to all instance files and directories. */
   paths: {
     config: string
     sessions: string
     agents: string
+    /** Shared across all instances — lives under ~/.openacp/cache/. */
     registryCache: string
     plugins: string
     pluginsData: string
     pluginRegistry: string
     logs: string
+    /** PID file written by the daemon process to track the running server. */
     pid: string
+    /** Marker file that indicates the daemon was intentionally started. */
     running: string
+    /** Written at startup with the API server's port number. */
     apiPort: string
     apiSecret: string
+    /** Shared across all instances — lives under ~/.openacp/bin/. */
     bin: string
     cache: string
     tunnels: string
+    /** Shared across all instances — lives under ~/.openacp/agents/. */
     agentsDir: string
   }
 }
@@ -30,6 +47,12 @@ export interface CreateInstanceContextOpts {
   root: string
 }
 
+/**
+ * Creates an InstanceContext with all filesystem paths pre-resolved.
+ *
+ * Some paths (registryCache, bin, agentsDir) point to the global root
+ * (`~/.openacp/`) because they are shared across all instances.
+ */
 export function createInstanceContext(opts: CreateInstanceContextOpts): InstanceContext {
   const { id, root } = opts
   const globalRoot = getGlobalRoot()
@@ -56,6 +79,7 @@ export function createInstanceContext(opts: CreateInstanceContextOpts): Instance
   }
 }
 
+/** Converts a display name to a URL/filesystem-safe slug (lowercase, hyphens only). */
 export function generateSlug(name: string): string {
   const slug = name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
   return slug || 'openacp'
@@ -67,11 +91,28 @@ function expandHome(p: string): string {
 }
 
 export interface ResolveOpts {
+  /** Explicit directory flag (`--dir`). */
   dir?: string
+  /** Use CWD as instance root (`--local`). */
   local?: boolean
   cwd?: string
 }
 
+/**
+ * Resolves the instance root directory using a priority chain:
+ *
+ * 1. `--dir` flag (explicit)
+ * 2. `--local` flag (CWD)
+ * 3. CWD contains `.openacp/config.json`
+ * 4. Walk up parent directories (stop at $HOME, skip ~/.openacp)
+ * 5. Home directory fallback: `~/openacp-workspace/.openacp/`
+ * 6. `OPENACP_INSTANCE_ROOT` env var
+ *
+ * Returns null if no instance root is found via any of the above steps.
+ *
+ * `~/.openacp` is always skipped because it's the shared global store
+ * (registry, cache, bin), not an instance directory.
+ */
 export function resolveInstanceRoot(opts: ResolveOpts): string | null {
   const cwd = opts.cwd ?? process.cwd()
   const home = os.homedir()
@@ -118,6 +159,7 @@ export function resolveInstanceRoot(opts: ResolveOpts): string | null {
   return null
 }
 
+/** Returns the global shared root (`~/.openacp/`) used for cross-instance resources. */
 export function getGlobalRoot(): string {
   return path.join(os.homedir(), '.openacp')
 }
@@ -149,6 +191,7 @@ export async function resolveRunningInstance(cwd: string): Promise<string | null
   return null
 }
 
+/** Checks if an instance is running by reading its api.port file and hitting the health endpoint. */
 async function isInstanceRunning(instanceRoot: string): Promise<boolean> {
   const portFile = path.join(instanceRoot, 'api.port')
   try {

--- a/src/core/instance/instance-copy.ts
+++ b/src/core/instance/instance-copy.ts
@@ -3,10 +3,24 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 export interface CopyOptions {
+  /**
+   * Per-plugin allowlist of settings keys to copy.
+   * Keys: plugin name (e.g. "@openacp/telegram"), values: settings keys to inherit.
+   * Only listed keys are copied — secrets and instance-specific settings are excluded.
+   */
   inheritableKeys?: Record<string, string[]>
   onProgress?: (step: string, status: 'start' | 'done') => void
 }
 
+/**
+ * Copies an instance's configuration and installed plugins to a new directory.
+ *
+ * Used by `openacp instances create --from <id>` to fork an existing instance.
+ * The copy strips instance-specific fields (id, instanceName, workspace.baseDir)
+ * and plugin-owned config sections (security, tunnel, api, etc.) that now live
+ * in per-plugin settings.json files. Plugin settings are selectively copied
+ * based on `inheritableKeys` to avoid leaking secrets.
+ */
 export async function copyInstance(src: string, dst: string, opts: CopyOptions): Promise<void> {
   const { inheritableKeys = {}, onProgress } = opts
   fs.mkdirSync(dst, { recursive: true })
@@ -92,6 +106,10 @@ export async function copyInstance(src: string, dst: string, opts: CopyOptions):
   }
 }
 
+/**
+ * Copies only the allowed keys from each plugin's settings.json.
+ * This prevents secrets (tokens, API keys) from leaking into the new instance.
+ */
 function copyPluginSettings(srcData: string, dstData: string, inheritableKeys: Record<string, string[]>): void {
   walkPluginDirs(srcData, (pluginName, settingsPath) => {
     const allowedKeys = inheritableKeys[pluginName]
@@ -112,6 +130,7 @@ function copyPluginSettings(srcData: string, dstData: string, inheritableKeys: R
   })
 }
 
+/** Walks plugin data directories, handling both scoped (@org/plugin) and unscoped names. */
 function walkPluginDirs(base: string, cb: (pluginName: string, settingsPath: string) => void): void {
   if (!fs.existsSync(base)) return
   for (const entry of fs.readdirSync(base, { withFileTypes: true })) {

--- a/src/core/instance/instance-discovery.ts
+++ b/src/core/instance/instance-discovery.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+/** A running OpenACP instance discovered via the instance registry. */
 export interface DiscoveredInstance {
   id: string;
   root: string;
@@ -9,6 +10,17 @@ export interface DiscoveredInstance {
   running: boolean;
 }
 
+/**
+ * Discovers all currently running OpenACP instances on this machine.
+ *
+ * Reads the instance registry file, then for each registered instance:
+ * 1. Reads its `api.port` file to find the API server port
+ * 2. Sends a health check request to verify the process is alive
+ * 3. Reads `config.json` for the display name (falls back to instance ID)
+ *
+ * Instances that cannot be probed for any reason (missing port file, not responding)
+ * are silently skipped.
+ */
 export async function discoverRunningInstances(registryPath: string): Promise<DiscoveredInstance[]> {
   let registry: { version: number; instances: Record<string, { id: string; root: string }> };
   try {
@@ -47,6 +59,7 @@ export async function discoverRunningInstances(registryPath: string): Promise<Di
   return discovered;
 }
 
+/** Probes the local API server with a 3-second timeout to check if it's alive. */
 async function checkHealth(port: number): Promise<boolean> {
   try {
     const controller = new AbortController();

--- a/src/core/instance/instance-registry.ts
+++ b/src/core/instance/instance-registry.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 
+/** An entry in the instance registry mapping an instance ID to its root directory. */
 export interface InstanceRegistryEntry {
   id: string
   root: string
@@ -12,11 +13,22 @@ interface RegistryData {
   instances: Record<string, InstanceRegistryEntry>
 }
 
+/**
+ * File-based registry that tracks all known OpenACP instances on this machine.
+ *
+ * Stored at `~/.openacp/instances.json`. Each entry maps an instance ID to
+ * its root directory. The registry is the source for instance discovery,
+ * listing, and ID resolution.
+ *
+ * `config.json` inside each instance is the source of truth for the ID.
+ * If the registry disagrees with config.json, the registry is updated to match.
+ */
 export class InstanceRegistry {
   private data: RegistryData = { version: 1, instances: {} }
 
   constructor(private registryPath: string) {}
 
+  /** Load the registry from disk. If the file is missing or corrupt, starts fresh. */
   load(): void {
     try {
       const raw = fs.readFileSync(this.registryPath, 'utf-8')
@@ -47,32 +59,39 @@ export class InstanceRegistry {
     }
   }
 
+  /** Persist the registry to disk, creating parent directories if needed. */
   save(): void {
     const dir = path.dirname(this.registryPath)
     fs.mkdirSync(dir, { recursive: true })
     fs.writeFileSync(this.registryPath, JSON.stringify(this.data, null, 2))
   }
 
+  /** Add or update an instance entry in the registry. Does not persist — call save() after. */
   register(id: string, root: string): void {
     this.data.instances[id] = { id, root }
   }
 
+  /** Remove an instance entry. Does not persist — call save() after. */
   remove(id: string): void {
     delete this.data.instances[id]
   }
 
+  /** Look up an instance by its ID. */
   get(id: string): InstanceRegistryEntry | undefined {
     return this.data.instances[id]
   }
 
+  /** Look up an instance by its root directory path. */
   getByRoot(root: string): InstanceRegistryEntry | undefined {
     return Object.values(this.data.instances).find((e) => e.root === root)
   }
 
+  /** Returns all registered instances. */
   list(): InstanceRegistryEntry[] {
     return Object.values(this.data.instances)
   }
 
+  /** Returns `baseId` if available, otherwise appends `-2`, `-3`, etc. until unique. */
   uniqueId(baseId: string): string {
     if (!this.data.instances[baseId]) return baseId
     let n = 2

--- a/src/core/instance/migration.ts
+++ b/src/core/instance/migration.ts
@@ -6,9 +6,21 @@ import { getGlobalRoot } from './instance-context.js'
 import { InstanceRegistry } from './instance-registry.js'
 
 /**
- * Migrate a legacy global instance from ~/.openacp/ to <workspace>/.openacp/.
- * Called once on first CLI invocation after upgrade.
- * Returns the new instance root if migration happened, null otherwise.
+ * Migrates a legacy global instance from `~/.openacp/` to `<workspace>/.openacp/`.
+ *
+ * Early OpenACP versions stored instance data directly in `~/.openacp/`, mixing
+ * instance-specific files (config, sessions, plugins) with shared resources
+ * (registry cache, agent binaries). This migration separates them:
+ *
+ * - Instance files move to `<workspace>/.openacp/` (workspace from config, or
+ *   `~/openacp-workspace/` as default)
+ * - Shared resources stay in `~/.openacp/`
+ * - The instance registry is updated to point to the new location
+ * - `workspace.baseDir` is stripped from the migrated config (no longer needed
+ *   since the instance root is now inside the workspace itself)
+ *
+ * Called once on first CLI invocation after upgrade. Safe to call multiple times
+ * — returns null if no migration is needed.
  */
 export async function migrateGlobalInstance(): Promise<string | null> {
   const globalRoot = getGlobalRoot()
@@ -67,7 +79,8 @@ export async function migrateGlobalInstance(): Promise<string | null> {
     }
   }
 
-  // Move instance-specific cache (not registry-cache which stays shared)
+  // Move instance-specific cache entries but leave registry-cache.json in place —
+  // it's a shared resource used by all instances for agent registry lookups
   const srcCache = path.join(globalRoot, 'cache')
   const dstCache = path.join(targetRoot, 'cache')
   if (fs.existsSync(srcCache)) {

--- a/src/core/menu-registry.ts
+++ b/src/core/menu-registry.ts
@@ -5,22 +5,32 @@ const log = createChildLogger({ module: 'menu-registry' })
 
 export { type MenuItem }
 
+/**
+ * Registry for interactive menu items displayed to users (e.g. Telegram inline keyboards).
+ *
+ * Core registers default items (new session, agents, help, etc.) during construction.
+ * Plugins can add their own items. Items are sorted by priority (lower = higher position)
+ * and filtered by an optional `visible()` predicate at render time.
+ */
 export class MenuRegistry {
   private items = new Map<string, MenuItem>()
 
+  /** Register or replace a menu item by its unique ID. */
   register(item: MenuItem): void {
     this.items.set(item.id, item)
   }
 
+  /** Remove a menu item by ID. */
   unregister(id: string): void {
     this.items.delete(id)
   }
 
+  /** Look up a single menu item by ID. */
   getItem(id: string): MenuItem | undefined {
     return this.items.get(id)
   }
 
-  /** Get all visible items sorted by priority */
+  /** Get all visible items sorted by priority (lower number = shown first). */
   getItems(): MenuItem[] {
     return [...this.items.values()]
       .filter((item) => {

--- a/src/core/menu/core-items.ts
+++ b/src/core/menu/core-items.ts
@@ -1,5 +1,13 @@
 import type { MenuRegistry } from '../menu-registry.js'
 
+/**
+ * Register the default menu items that appear in the interactive menu.
+ *
+ * Items are grouped by function (session, info, config, system, help) and
+ * sorted by priority (lower = higher position). Each item maps to either
+ * a command (`/sessions`), a delegate prompt (assistant-guided new session),
+ * or a callback data string (settings panel).
+ */
 export function registerCoreMenuItems(registry: MenuRegistry): void {
   registry.register({
     id: 'core:new',

--- a/src/core/message-transformer.ts
+++ b/src/core/message-transformer.ts
@@ -134,6 +134,18 @@ function extractDiffStatsFromToolPayload(
   return null;
 }
 
+/**
+ * Transforms AgentEvents into OutgoingMessages suitable for adapter delivery.
+ *
+ * Handles two key concerns beyond simple type mapping:
+ * 1. **Tool input caching** — `tool_call` events carry `rawInput`, but subsequent
+ *    `tool_update` events for the same tool often omit it. The transformer caches
+ *    rawInput so updates can inherit it for viewer link generation.
+ * 2. **Viewer link enrichment** — when a tunnel service is available, tool events
+ *    for file reads/edits are enriched with public URLs to the code viewer and diff viewer.
+ *    Intermediate updates (with raw content) are preferred over completion events
+ *    (which have formatted content with line numbers).
+ */
 export class MessageTransformer {
   tunnelService?: TunnelServiceInterface;
   /** Cache rawInput from tool_call so it's available in tool_update (which often lacks it) */
@@ -145,6 +157,12 @@ export class MessageTransformer {
     this.tunnelService = tunnelService;
   }
 
+  /**
+   * Convert an agent event to an outgoing message for adapter delivery.
+   *
+   * For tool events, enriches the metadata with diff stats and viewer links
+   * when a tunnel service is available.
+   */
   transform(
     event: AgentEvent,
     sessionContext?: { id: string; workingDirectory: string },

--- a/src/core/plugin/dev-loader.ts
+++ b/src/core/plugin/dev-loader.ts
@@ -2,8 +2,17 @@ import fs from 'node:fs'
 import path from 'node:path'
 import type { OpenACPPlugin } from './types.js'
 
+/** Monotonic counter appended to import URLs to bust Node's ESM module cache on reload. */
 let loadCounter = 0
 
+/**
+ * Loads a plugin from a local directory path instead of npm.
+ *
+ * Used by `openacp dev --plugin <path>` for plugin development.
+ * Expects the plugin to be pre-built (dist/index.js must exist).
+ * Supports hot-reload by appending a cache-busting query string to the
+ * import URL — Node.js caches ESM modules by URL, so unique URLs force re-import.
+ */
 export class DevPluginLoader {
   private pluginPath: string
 
@@ -11,6 +20,10 @@ export class DevPluginLoader {
     this.pluginPath = path.resolve(pluginPath)
   }
 
+  /**
+   * Import the plugin's default export from dist/index.js.
+   * Each call uses a unique URL query to bypass Node's ESM cache.
+   */
   async load(): Promise<OpenACPPlugin> {
     const distIndex = path.join(this.pluginPath, 'dist', 'index.js')
     const srcIndex = path.join(this.pluginPath, 'src', 'index.ts')
@@ -37,10 +50,12 @@ export class DevPluginLoader {
     return plugin
   }
 
+  /** Returns the resolved absolute path to the plugin's root directory. */
   getPluginPath(): string {
     return this.pluginPath
   }
 
+  /** Returns the path to the plugin's dist directory. */
   getDistPath(): string {
     return path.join(this.pluginPath, 'dist')
   }

--- a/src/core/plugin/error-tracker.ts
+++ b/src/core/plugin/error-tracker.ts
@@ -1,20 +1,38 @@
+/** Configuration for the sliding-window error budget. */
 export interface ErrorBudgetConfig {
-  maxErrors: number   // default 10
-  windowMs: number    // default 3600000 (1 hour)
+  /** Maximum errors allowed within the window before disabling the plugin. Default: 10. */
+  maxErrors: number
+  /** Sliding window duration in milliseconds. Default: 3600000 (1 hour). */
+  windowMs: number
 }
 
+/**
+ * Circuit breaker for misbehaving plugins.
+ *
+ * Tracks errors per plugin within a sliding time window. When a plugin exceeds
+ * its error budget (default: 10 errors in 1 hour), it is auto-disabled —
+ * its middleware handlers are skipped by MiddlewareChain. This prevents a
+ * single broken plugin from degrading the entire system.
+ *
+ * Essential plugins can be marked exempt via `setExempt()`.
+ */
 export class ErrorTracker {
   private errors = new Map<string, { count: number; windowStart: number }>()
   private disabled = new Set<string>()
   private exempt = new Set<string>()
   private config: ErrorBudgetConfig
 
+  /** Callback fired when a plugin is auto-disabled due to error budget exhaustion. */
   onDisabled?: (pluginName: string, reason: string) => void
 
   constructor(config?: Partial<ErrorBudgetConfig>) {
     this.config = { maxErrors: config?.maxErrors ?? 10, windowMs: config?.windowMs ?? 3600000 }
   }
 
+  /**
+   * Record an error for a plugin. If the error budget is exceeded,
+   * the plugin is disabled and the `onDisabled` callback fires.
+   */
   increment(pluginName: string): void {
     if (this.exempt.has(pluginName)) return
 
@@ -35,15 +53,18 @@ export class ErrorTracker {
     }
   }
 
+  /** Check if a plugin has been disabled due to errors. */
   isDisabled(pluginName: string): boolean {
     return this.disabled.has(pluginName)
   }
 
+  /** Re-enable a plugin and clear its error history. */
   reset(pluginName: string): void {
     this.disabled.delete(pluginName)
     this.errors.delete(pluginName)
   }
 
+  /** Mark a plugin as exempt from circuit-breaking (e.g., essential plugins). */
   setExempt(pluginName: string): void {
     this.exempt.add(pluginName)
   }

--- a/src/core/plugin/install-context.ts
+++ b/src/core/plugin/install-context.ts
@@ -4,13 +4,23 @@ import type { SettingsManager } from './settings-manager.js'
 import { createTerminalIO } from './terminal-io.js'
 import { log as rootLog } from '../utils/log.js'
 
+/** Options for creating an InstallContext. */
 export interface CreateInstallContextOpts {
   pluginName: string
   settingsManager: SettingsManager
+  /** Base path for plugin data (typically ~/.openacp/plugins/) */
   basePath: string
   instanceRoot?: string
 }
 
+/**
+ * Factory for InstallContext — the limited context available to plugin
+ * install/uninstall/configure hooks.
+ *
+ * Unlike PluginContext (runtime), InstallContext provides terminal I/O for
+ * interactive setup and settings access, but no services, events, or middleware.
+ * This keeps install-time logic decoupled from the running system.
+ */
 export function createInstallContext(opts: CreateInstallContextOpts): InstallContext {
   const { pluginName, settingsManager, basePath, instanceRoot } = opts
   const dataDir = path.join(basePath, pluginName, 'data')

--- a/src/core/plugin/lifecycle-manager.ts
+++ b/src/core/plugin/lifecycle-manager.ts
@@ -8,9 +8,10 @@ import type { SettingsManager } from './settings-manager.js'
 import type { PluginRegistry } from './plugin-registry.js'
 import { BusEvent } from '../events.js'
 
-const SETUP_TIMEOUT_MS = 30_000
-const TEARDOWN_TIMEOUT_MS = 10_000
+const SETUP_TIMEOUT_MS = 30_000   // plugin.setup() must complete within 30s
+const TEARDOWN_TIMEOUT_MS = 10_000 // plugin.teardown() must complete within 10s
 
+/** Wraps a promise with a timeout; rejects if the promise doesn't settle in `ms` milliseconds. */
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`Timeout: ${label} exceeded ${ms}ms`)), ms)
@@ -21,6 +22,11 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   })
 }
 
+/**
+ * Extracts a plugin's config from the global ConfigManager.
+ * Tries the new `plugins.builtin['<name>'].config` format first,
+ * then falls back to legacy config paths for backward compatibility.
+ */
 function resolvePluginConfig(pluginName: string, configManager: unknown): Record<string, unknown> {
   try {
     const allConfig = (configManager as any)?.get?.() ?? {}
@@ -55,6 +61,7 @@ function resolvePluginConfig(pluginName: string, configManager: unknown): Record
   return {}
 }
 
+/** Options for constructing a LifecycleManager. All fields are optional with sensible defaults. */
 export interface LifecycleManagerOpts {
   serviceRegistry?: ServiceRegistry
   middlewareChain?: MiddlewareChain
@@ -75,6 +82,21 @@ export interface LifecycleManagerOpts {
   instanceRoot?: string
 }
 
+/**
+ * Orchestrates plugin boot, teardown, and hot-reload.
+ *
+ * Boot sequence:
+ * 1. Topological sort by `pluginDependencies` — ensures a plugin's deps are ready first
+ * 2. Version migration if registry version != plugin version
+ * 3. Settings validation against Zod schema
+ * 4. Create scoped PluginContext, call `plugin.setup(ctx)` with timeout
+ *
+ * Error isolation: if a plugin's setup() fails, it is marked as failed and skipped.
+ * Any plugin that depends on a failed plugin is also skipped (cascade failure).
+ * Other independent plugins continue booting normally.
+ *
+ * Shutdown calls teardown() in reverse boot order — dependencies are torn down last.
+ */
 export class LifecycleManager {
   readonly serviceRegistry: ServiceRegistry
   readonly middlewareChain: MiddlewareChain
@@ -95,14 +117,17 @@ export class LifecycleManager {
   private _loaded = new Set<string>()
   private _failed = new Set<string>()
 
+  /** Names of plugins that successfully completed setup(). */
   get loadedPlugins(): string[] {
     return [...this._loaded]
   }
 
+  /** Names of plugins whose setup() threw an error. These plugins are skipped but don't crash the system. */
   get failedPlugins(): string[] {
     return [...this._failed]
   }
 
+  /** The PluginRegistry tracking installed and enabled plugin state. */
   get registry(): PluginRegistry | undefined {
     return this.pluginRegistry
   }
@@ -143,6 +168,12 @@ export class LifecycleManager {
     return this.log ?? { trace() {}, debug() {}, info() {}, warn() {}, error() {}, fatal() {}, child() { return this } } as Logger
   }
 
+  /**
+   * Boot a set of plugins in dependency order.
+   *
+   * Can be called multiple times (e.g., core plugins first, then dev plugins later).
+   * Already-loaded plugins are included in dependency resolution but not re-booted.
+   */
   async boot(plugins: OpenACPPlugin[]): Promise<void> {
     // Resolve load order via topological sort.
     // resolveLoadOrder will skip plugins whose dependencies are missing entirely
@@ -279,6 +310,11 @@ export class LifecycleManager {
     }
   }
 
+  /**
+   * Unload a single plugin: call teardown(), clean up its context
+   * (listeners, middleware, services), and remove from tracked state.
+   * Used for hot-reload: unload → rebuild → re-boot.
+   */
   async unloadPlugin(name: string): Promise<void> {
     if (!this._loaded.has(name)) return
 
@@ -305,6 +341,10 @@ export class LifecycleManager {
     this.eventBus?.emit(BusEvent.PLUGIN_UNLOADED, { name })
   }
 
+  /**
+   * Gracefully shut down all loaded plugins.
+   * Teardown runs in reverse boot order so that dependencies outlive their dependents.
+   */
   async shutdown(): Promise<void> {
     // Teardown in reverse load order
     const reversed = [...this.loadOrder].reverse()

--- a/src/core/plugin/middleware-chain.ts
+++ b/src/core/plugin/middleware-chain.ts
@@ -1,5 +1,6 @@
 import type { ErrorTracker } from './error-tracker.js'
 
+/** Per-handler timeout — prevents a single middleware from blocking the entire chain. */
 const MIDDLEWARE_TIMEOUT_MS = 5000
 
 type HandlerEntry = {
@@ -8,11 +9,23 @@ type HandlerEntry = {
   handler: Function
 }
 
+/**
+ * Manages ordered middleware chains for each hook point.
+ *
+ * Execution model:
+ * - Handlers run in priority order (lower number = earlier). Default priority: 100.
+ * - Each handler receives the current payload and a `next()` function.
+ * - Calling `next()` passes control to the next handler in the chain.
+ * - Returning `null` short-circuits: the operation is blocked and no further handlers run.
+ * - If a handler throws or times out, it is skipped and the error is tracked.
+ *   After enough errors (see ErrorTracker), the plugin's middleware is auto-disabled.
+ */
 export class MiddlewareChain {
   private chains = new Map<string, Array<HandlerEntry>>()
   private errorHandler?: (pluginName: string, error: Error) => void
   private errorTracker?: ErrorTracker
 
+  /** Register a middleware handler for a hook. Handlers are kept sorted by priority. */
   add(
     hook: string,
     pluginName: string,
@@ -32,6 +45,15 @@ export class MiddlewareChain {
     }
   }
 
+  /**
+   * Execute the middleware chain for a hook, ending with the core handler.
+   *
+   * The chain is built recursively: each handler calls `next()` to invoke the
+   * next handler, with the core handler at the end. If no middleware is registered,
+   * the core handler runs directly.
+   *
+   * @returns The final payload, or `null` if any handler short-circuited.
+   */
   async execute<T>(
     hook: string,
     payload: T,
@@ -45,7 +67,8 @@ export class MiddlewareChain {
     // Handlers are pre-sorted by priority at registration time
     const sorted = handlers
 
-    // Build the chain
+    // Build the chain as a recursive series of `next()` closures.
+    // cachedResult prevents double-execution if a handler calls next() more than once.
     let cachedResult: { value: T | null } | undefined = undefined
 
     const buildNext = (index: number, currentPayload: T): (() => Promise<T | null>) => {
@@ -129,6 +152,7 @@ export class MiddlewareChain {
     return start()
   }
 
+  /** Remove all middleware handlers registered by a specific plugin. */
   removeAll(pluginName: string): void {
     for (const [hook, handlers] of this.chains.entries()) {
       const filtered = handlers.filter((h) => h.pluginName !== pluginName)
@@ -140,10 +164,12 @@ export class MiddlewareChain {
     }
   }
 
+  /** Set a callback for middleware errors (e.g., logging). */
   setErrorHandler(fn: (pluginName: string, error: Error) => void): void {
     this.errorHandler = fn
   }
 
+  /** Attach an ErrorTracker for circuit-breaking misbehaving plugins. */
   setErrorTracker(tracker: ErrorTracker): void {
     this.errorTracker = tracker
   }

--- a/src/core/plugin/plugin-context.ts
+++ b/src/core/plugin/plugin-context.ts
@@ -19,6 +19,7 @@ import { MiddlewareChain } from './middleware-chain.js'
 import { ErrorTracker } from './error-tracker.js'
 import { PluginStorageImpl } from './plugin-storage.js'
 
+/** Internal options for creating a PluginContext. Passed from LifecycleManager. */
 interface CreatePluginContextOpts {
   pluginName: string
   pluginConfig: Record<string, unknown>
@@ -39,12 +40,21 @@ interface CreatePluginContextOpts {
   instanceRoot?: string
 }
 
+/** Gate that throws if the plugin's declared permissions don't include the required one. */
 function requirePermission(permissions: PluginPermission[], required: PluginPermission, action: string): void {
   if (!permissions.includes(required)) {
     throw new Error(`Plugin does not have '${required}' permission required for ${action}`)
   }
 }
 
+/**
+ * Factory that creates a scoped, permission-gated PluginContext for a single plugin.
+ *
+ * Every call to a context method checks the plugin's declared permissions first.
+ * The returned object also includes a `cleanup()` method used by LifecycleManager
+ * to remove all registrations (listeners, middleware, services, commands) when
+ * the plugin is unloaded — ensuring no dangling references.
+ */
 export function createPluginContext(opts: CreatePluginContextOpts): PluginContext & { cleanup(): void } {
   const {
     pluginName,
@@ -60,7 +70,8 @@ export function createPluginContext(opts: CreatePluginContextOpts): PluginContex
   } = opts
   const instanceRoot = opts.instanceRoot!
 
-  // Track registered items for cleanup
+  // Track all registrations so cleanup() can remove them on plugin unload.
+  // Without this, unloaded plugins would leave orphaned listeners and middleware.
   const registeredListeners: Array<{ event: string; handler: (...args: unknown[]) => void }> = []
   const registeredCommands: CommandDef[] = []
   const registeredMenuItemIds: string[] = []
@@ -82,7 +93,8 @@ export function createPluginContext(opts: CreatePluginContextOpts): PluginContex
 
   const storageImpl = new PluginStorageImpl(storagePath)
 
-  // Create permission-guarded storage proxy
+  // Wrap storage operations with permission checks — plugins without
+  // storage:read or storage:write permissions cannot access the filesystem.
   const storage: PluginStorage = {
     async get<T>(key: string): Promise<T | undefined> {
       requirePermission(permissions, 'storage:read', 'storage.get')
@@ -168,6 +180,7 @@ export function createPluginContext(opts: CreatePluginContextOpts): PluginContex
       requirePermission(permissions, 'commands:register', 'registerMenuItem()')
       const menuRegistry = serviceRegistry.get('menu-registry') as MenuRegistry | undefined
       if (!menuRegistry) return
+      // Namespace menu item IDs with plugin name to prevent collisions
       const qualifiedId = `${pluginName}:${item.id}`
       menuRegistry.register({ ...item, id: qualifiedId })
       registeredMenuItemIds.push(qualifiedId)
@@ -184,6 +197,7 @@ export function createPluginContext(opts: CreatePluginContextOpts): PluginContex
       requirePermission(permissions, 'commands:register', 'registerAssistantSection()')
       const assistantRegistry = serviceRegistry.get('assistant-registry') as AssistantRegistry | undefined
       if (!assistantRegistry) return
+      // Namespace section IDs with plugin name to prevent collisions
       const qualifiedId = `${pluginName}:${section.id}`
       assistantRegistry.register({ ...section, id: qualifiedId })
       registeredAssistantSectionIds.push(qualifiedId)
@@ -227,6 +241,11 @@ export function createPluginContext(opts: CreatePluginContextOpts): PluginContex
 
     instanceRoot,
 
+    /**
+     * Called by LifecycleManager during plugin teardown.
+     * Unregisters all event handlers, middleware, commands, and services
+     * registered by this plugin, preventing leaks across reloads.
+     */
     cleanup(): void {
       // Remove all event listeners registered by this plugin
       for (const { event, handler } of registeredListeners) {

--- a/src/core/plugin/plugin-field-registry.ts
+++ b/src/core/plugin/plugin-field-registry.ts
@@ -2,19 +2,26 @@ import type { FieldDef } from './types.js'
 
 /**
  * Central registry for plugin-declared editable fields.
- * Registered as service 'field-registry' in main.ts.
+ *
+ * Plugins call `ctx.registerEditableFields()` during setup to declare which
+ * settings keys are exposed via the API/UI for dynamic configuration.
+ * The API server reads from this registry to render settings forms and
+ * validate updates. Registered as service 'field-registry' in main.ts.
  */
 export class PluginFieldRegistry {
   private fields = new Map<string, FieldDef[]>()
 
+  /** Register (or replace) the editable fields for a plugin. */
   register(pluginName: string, fields: FieldDef[]): void {
     this.fields.set(pluginName, fields)
   }
 
+  /** Get the editable fields for a specific plugin. */
   getForPlugin(pluginName: string): FieldDef[] {
     return this.fields.get(pluginName) ?? []
   }
 
+  /** Get all fields grouped by plugin name. */
   getAll(): Map<string, FieldDef[]> {
     return new Map(this.fields)
   }

--- a/src/core/plugin/plugin-installer.ts
+++ b/src/core/plugin/plugin-installer.ts
@@ -8,7 +8,11 @@ const execFileAsync = promisify(execFile)
 
 /**
  * Import a package resolved from a specific directory (not the project root).
- * Reads the package's package.json to find the ESM entry point, then imports by file path.
+ *
+ * We can't use bare `import('packageName')` because Node resolves from the
+ * project root's node_modules. Plugins are installed to a separate directory
+ * (~/.openacp/plugins/node_modules), so we manually resolve the ESM entry point
+ * from the package's package.json and import by absolute file:// URL.
  */
 export async function importFromDir(packageName: string, dir: string): Promise<any> {
   const pkgDir = path.join(dir, 'node_modules', ...packageName.split('/'))
@@ -46,8 +50,11 @@ export async function importFromDir(packageName: string, dir: string): Promise<a
 const VALID_NPM_NAME = /^(@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*(@[\w.^~>=<|-]+)?$/i;
 
 /**
- * Install an npm package to the plugins directory and return the loaded module.
- * Tries to import first; if not installed, runs npm install asynchronously.
+ * Install an npm package to the isolated plugins directory and return the loaded module.
+ *
+ * Plugins are installed to `~/.openacp/plugins/` (separate from the project's node_modules)
+ * to avoid version conflicts with core dependencies. Uses `--ignore-scripts` for security.
+ * Tries to import first (already installed case) before running npm install.
  */
 export async function installNpmPlugin(packageName: string, pluginsDir?: string): Promise<any> {
   if (!VALID_NPM_NAME.test(packageName)) {

--- a/src/core/plugin/plugin-loader.ts
+++ b/src/core/plugin/plugin-loader.ts
@@ -3,10 +3,15 @@ import { readFileSync } from 'node:fs'
 import type { OpenACPPlugin } from './types.js'
 
 /**
- * Resolve plugin load order via topological sort.
- * - Handles `overrides` field: overridden plugins are removed before sorting.
- * - Detects circular dependencies and throws.
- * - Missing dependencies: skip plugin + all dependents (cascade).
+ * Resolve plugin load order via topological sort (DFS-based).
+ *
+ * Plugins must boot in dependency order so that services and middleware from
+ * dependencies are available when a plugin's setup() runs. This function:
+ *
+ * 1. Removes overridden plugins (a plugin with `overrides: 'X'` replaces X)
+ * 2. Cascade-skips plugins whose required dependencies are missing
+ * 3. Detects circular dependencies (throws)
+ * 4. Returns plugins in safe boot order (dependencies before dependents)
  */
 export function resolveLoadOrder(plugins: OpenACPPlugin[]): OpenACPPlugin[] {
   // Phase 1: Apply overrides — remove overridden plugins

--- a/src/core/plugin/plugin-registry.ts
+++ b/src/core/plugin/plugin-registry.ts
@@ -1,10 +1,17 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+/**
+ * Persisted metadata about an installed plugin.
+ *
+ * This is the registry's view of a plugin — install state, version, source.
+ * Distinct from `OpenACPPlugin` which is the runtime instance with setup/teardown hooks.
+ */
 export interface PluginEntry {
   version: string
   installedAt: string
   updatedAt: string
+  /** How the plugin was installed: bundled with core, from npm, or from a local path */
   source: 'builtin' | 'npm' | 'local'
   enabled: boolean
   settingsPath: string
@@ -17,28 +24,40 @@ interface RegistryData {
   installed: Record<string, PluginEntry>
 }
 
+/**
+ * Tracks which plugins are installed, their versions, and enabled state.
+ * Persisted as JSON at `~/.openacp/plugins/registry.json`.
+ *
+ * Used by LifecycleManager to detect version changes (triggering migration)
+ * and to skip disabled plugins at boot time.
+ */
 export class PluginRegistry {
   private data: RegistryData = { installed: {} }
 
   constructor(private registryPath: string) {}
 
+  /** Return all installed plugins as a Map. */
   list(): Map<string, PluginEntry> {
     return new Map(Object.entries(this.data.installed))
   }
 
+  /** Look up a plugin by name. Returns undefined if not installed. */
   get(name: string): PluginEntry | undefined {
     return this.data.installed[name]
   }
 
+  /** Record a newly installed plugin. Timestamps are set automatically. */
   register(name: string, entry: RegisterInput): void {
     const now = new Date().toISOString()
     this.data.installed[name] = { ...entry, installedAt: now, updatedAt: now }
   }
 
+  /** Remove a plugin from the registry. */
   remove(name: string): void {
     delete this.data.installed[name]
   }
 
+  /** Enable or disable a plugin. Disabled plugins are skipped at boot. */
   setEnabled(name: string, enabled: boolean): void {
     const entry = this.data.installed[name]
     if (!entry) return
@@ -46,6 +65,7 @@ export class PluginRegistry {
     entry.updatedAt = new Date().toISOString()
   }
 
+  /** Update the stored version (called after successful migration). */
   updateVersion(name: string, version: string): void {
     const entry = this.data.installed[name]
     if (!entry) return
@@ -53,14 +73,17 @@ export class PluginRegistry {
     entry.updatedAt = new Date().toISOString()
   }
 
+  /** Return only enabled plugins. */
   listEnabled(): Map<string, PluginEntry> {
     return new Map(Object.entries(this.data.installed).filter(([, e]) => e.enabled))
   }
 
+  /** Filter plugins by installation source. */
   listBySource(source: PluginEntry['source']): Map<string, PluginEntry> {
     return new Map(Object.entries(this.data.installed).filter(([, e]) => e.source === source))
   }
 
+  /** Load registry data from disk. Silently starts empty if file doesn't exist. */
   async load(): Promise<void> {
     try {
       const content = fs.readFileSync(this.registryPath, 'utf-8')
@@ -73,6 +96,7 @@ export class PluginRegistry {
     }
   }
 
+  /** Persist registry data to disk. */
   async save(): Promise<void> {
     const dir = path.dirname(this.registryPath)
     fs.mkdirSync(dir, { recursive: true })

--- a/src/core/plugin/plugin-storage.ts
+++ b/src/core/plugin/plugin-storage.ts
@@ -2,9 +2,19 @@ import fs from 'node:fs'
 import path from 'node:path'
 import type { PluginStorage } from './types.js'
 
+/**
+ * File-backed key-value store for a single plugin.
+ *
+ * Data is stored at `~/.openacp/plugins/<name>/kv.json`. Each plugin gets its
+ * own instance, providing namespace isolation.
+ *
+ * Write operations are serialized through a promise chain (`writeChain`) to
+ * prevent concurrent writes from corrupting the JSON file.
+ */
 export class PluginStorageImpl implements PluginStorage {
   private readonly kvPath: string
   private readonly dataDir: string
+  /** Serializes writes to prevent concurrent file corruption */
   private writeChain: Promise<void> = Promise.resolve()
 
   constructor(baseDir: string) {
@@ -53,6 +63,7 @@ export class PluginStorageImpl implements PluginStorage {
     return Object.keys(this.readKv())
   }
 
+  /** Returns the plugin's data directory, creating it lazily on first access. */
   getDataDir(): string {
     fs.mkdirSync(this.dataDir, { recursive: true })
     return this.dataDir

--- a/src/core/plugin/registry-client.ts
+++ b/src/core/plugin/registry-client.ts
@@ -1,6 +1,9 @@
+/** URL of the public OpenACP plugin registry (hosted on GitHub). */
 const REGISTRY_URL = 'https://raw.githubusercontent.com/Open-ACP/plugin-registry/main/registry.json'
-const CACHE_TTL = 60 * 1000  // 1 minute
+/** Registry data is cached for 1 minute to reduce network requests during repeated lookups. */
+const CACHE_TTL = 60 * 1000
 
+/** Metadata for a plugin listed in the public OpenACP plugin registry. */
 export interface RegistryPlugin {
   name: string
   displayName?: string
@@ -18,6 +21,7 @@ export interface RegistryPlugin {
   featured: boolean
 }
 
+/** The full registry manifest, fetched as a single JSON file. */
 export interface Registry {
   version: number
   generatedAt: string
@@ -26,6 +30,13 @@ export interface Registry {
   categories: Array<{ id: string; name: string; icon: string }>
 }
 
+/**
+ * Client for the public OpenACP plugin registry.
+ *
+ * The registry is a static JSON file on GitHub — no API server needed.
+ * Results are cached in memory for 1 minute to avoid redundant fetches
+ * during CLI operations like search + install.
+ */
 export class RegistryClient {
   private cache: { data: Registry; fetchedAt: number } | null = null
   private registryUrl: string
@@ -34,6 +45,7 @@ export class RegistryClient {
     this.registryUrl = registryUrl ?? REGISTRY_URL
   }
 
+  /** Fetch the registry, returning cached data if still fresh. */
   async getRegistry(): Promise<Registry> {
     if (this.cache && Date.now() - this.cache.fetchedAt < CACHE_TTL) {
       return this.cache.data
@@ -45,6 +57,7 @@ export class RegistryClient {
     return data
   }
 
+  /** Search plugins by name, description, or tags (case-insensitive substring match). */
   async search(query: string): Promise<RegistryPlugin[]> {
     const registry = await this.getRegistry()
     const q = query.toLowerCase()
@@ -54,12 +67,14 @@ export class RegistryClient {
     })
   }
 
+  /** Resolve a registry plugin name to its npm package name. Returns null if not found. */
   async resolve(name: string): Promise<string | null> {
     const registry = await this.getRegistry()
     const plugin = registry.plugins.find(p => p.name === name)
     return plugin?.npm ?? null
   }
 
+  /** Force next getRegistry() call to refetch from network. */
   clearCache(): void {
     this.cache = null
   }

--- a/src/core/plugin/service-registry.ts
+++ b/src/core/plugin/service-registry.ts
@@ -1,6 +1,20 @@
+/**
+ * Central service discovery for the plugin system.
+ *
+ * Plugins register service implementations by string key (e.g., 'security', 'speech').
+ * Core and other plugins retrieve them via typed accessors:
+ *   `registry.get<SecurityService>('security')`
+ *
+ * Each service key is unique — registering a duplicate throws unless `registerOverride` is used.
+ * Services are tracked by the owning plugin name so they can be bulk-removed on plugin unload.
+ */
 export class ServiceRegistry {
   private services = new Map<string, { implementation: unknown; pluginName: string }>()
 
+  /**
+   * Register a service. Throws if the service name is already taken.
+   * Use `registerOverride` to intentionally replace an existing service.
+   */
   register<T>(name: string, implementation: T, pluginName: string): void {
     if (this.services.has(name)) {
       const existing = this.services.get(name)!
@@ -9,26 +23,32 @@ export class ServiceRegistry {
     this.services.set(name, { implementation, pluginName })
   }
 
+  /** Register a service, replacing any existing registration (used by override plugins). */
   registerOverride<T>(name: string, implementation: T, pluginName: string): void {
     this.services.set(name, { implementation, pluginName })
   }
 
+  /** Retrieve a service by name. Returns undefined if not registered. */
   get<T>(name: string): T | undefined {
     return this.services.get(name)?.implementation as T | undefined
   }
 
+  /** Check whether a service is registered. */
   has(name: string): boolean {
     return this.services.has(name)
   }
 
+  /** List all registered services with their owning plugin names. */
   list(): Array<{ name: string; pluginName: string }> {
     return [...this.services.entries()].map(([name, { pluginName }]) => ({ name, pluginName }))
   }
 
+  /** Remove a single service by name. */
   unregister(name: string): void {
     this.services.delete(name)
   }
 
+  /** Remove all services owned by a specific plugin (called during plugin unload). */
   unregisterByPlugin(pluginName: string): void {
     for (const [name, entry] of this.services) {
       if (entry.pluginName === pluginName) {

--- a/src/core/plugin/settings-manager.ts
+++ b/src/core/plugin/settings-manager.ts
@@ -3,23 +3,35 @@ import path from 'node:path'
 import type { SettingsAPI } from './types.js'
 import type { ZodSchema } from 'zod'
 
+/** Result of validating plugin settings against a Zod schema. */
 export interface ValidationResult {
   valid: boolean
   errors?: string[]
 }
 
+/**
+ * Manages per-plugin settings files.
+ *
+ * Each plugin's settings are stored at `<basePath>/<pluginName>/settings.json`.
+ * The basePath is typically `~/.openacp/plugins/`.
+ * Settings are distinct from plugin storage (kv.json) — settings are user-facing
+ * configuration, while storage is internal plugin state.
+ */
 export class SettingsManager {
   constructor(private basePath: string) {}
 
+  /** Returns the base path for all plugin settings directories. */
   getBasePath(): string {
     return this.basePath
   }
 
+  /** Create a SettingsAPI instance scoped to a specific plugin. */
   createAPI(pluginName: string): SettingsAPI {
     const settingsPath = this.getSettingsPath(pluginName)
     return new SettingsAPIImpl(settingsPath)
   }
 
+  /** Load a plugin's settings from disk. Returns empty object if file doesn't exist. */
   async loadSettings(pluginName: string): Promise<Record<string, unknown>> {
     const settingsPath = this.getSettingsPath(pluginName)
     try {
@@ -30,6 +42,7 @@ export class SettingsManager {
     }
   }
 
+  /** Validate settings against a Zod schema. Returns valid if no schema is provided. */
   validateSettings(
     _pluginName: string,
     settings: unknown,
@@ -47,6 +60,7 @@ export class SettingsManager {
     }
   }
 
+  /** Resolve the absolute path to a plugin's settings.json file. */
   getSettingsPath(pluginName: string): string {
     return path.join(this.basePath, pluginName, 'settings.json')
   }
@@ -55,6 +69,7 @@ export class SettingsManager {
     return this.loadSettings(pluginName)
   }
 
+  /** Merge updates into existing settings (shallow merge). */
   async updatePluginSettings(pluginName: string, updates: Record<string, unknown>): Promise<void> {
     const api = this.createAPI(pluginName)
     const current = await api.getAll()
@@ -62,6 +77,11 @@ export class SettingsManager {
   }
 }
 
+/**
+ * File-backed implementation of SettingsAPI for a single plugin.
+ * Reads/writes JSON synchronously with an in-memory cache to avoid
+ * redundant disk reads within the same lifecycle.
+ */
 class SettingsAPIImpl implements SettingsAPI {
   private cache: Record<string, unknown> | null = null
 

--- a/src/core/plugin/terminal-io.ts
+++ b/src/core/plugin/terminal-io.ts
@@ -1,6 +1,9 @@
 import * as clack from '@clack/prompts'
 import type { TerminalIO } from './types.js'
 
+// @clack/prompts returns a symbol when the user cancels (Ctrl+C).
+// We convert that to an Error so callers can handle cancellation uniformly.
+
 function isCancel(value: unknown): value is symbol {
   return typeof value === 'symbol'
 }
@@ -12,6 +15,13 @@ function guardCancel<T>(value: T | symbol): T {
   return value as T
 }
 
+/**
+ * Create a TerminalIO implementation backed by @clack/prompts.
+ *
+ * Used during plugin install/configure flows — these are CLI-only operations
+ * that require interactive terminal access. Not available during normal
+ * runtime (headless server mode).
+ */
 export function createTerminalIO(): TerminalIO {
   return {
     async text(opts) {

--- a/src/core/plugin/types.ts
+++ b/src/core/plugin/types.ts
@@ -11,24 +11,47 @@ import type {
 } from '../types.js'
 import type { IChannelAdapter } from '../channel.js'
 
-// Re-export IChannelAdapter for plugin authors
+/** Re-export IChannelAdapter for plugin authors */
 export type { IChannelAdapter }
 
 // ============================================================
 // Section 2: Plugin Interface
 // ============================================================
 
+/**
+ * Permission tokens that gate access to PluginContext capabilities.
+ * Declared in a plugin's `permissions` array; enforced at runtime by PluginContext.
+ */
 export type PluginPermission =
+  /** Subscribe to EventBus events */
   | 'events:read'
+  /** Emit custom events on the EventBus */
   | 'events:emit'
+  /** Register services in the ServiceRegistry */
   | 'services:register'
+  /** Look up and consume services from the ServiceRegistry */
   | 'services:use'
+  /** Register middleware handlers on hook points */
   | 'middleware:register'
+  /** Register slash commands, menu items, assistant sections, and editable fields */
   | 'commands:register'
+  /** Read from plugin-scoped storage */
   | 'storage:read'
+  /** Write to plugin-scoped storage */
   | 'storage:write'
+  /** Direct access to OpenACPCore internals (sessions, config, eventBus) */
   | 'kernel:access'
 
+/**
+ * The runtime plugin instance — the object a plugin module default-exports.
+ *
+ * This is distinct from `PluginEntry` (the registry's persisted metadata about
+ * an installed plugin). `OpenACPPlugin` defines behavior (setup/teardown hooks),
+ * while `PluginEntry` tracks install state (version, source, enabled flag).
+ *
+ * Lifecycle: LifecycleManager topo-sorts plugins by `pluginDependencies`,
+ * then calls `setup()` on each in order, passing a scoped `PluginContext`.
+ */
 export interface OpenACPPlugin {
   /** Unique identifier, e.g., '@openacp/security' */
   name: string
@@ -42,17 +65,26 @@ export interface OpenACPPlugin {
   optionalPluginDependencies?: Record<string, string>
   /** Override a built-in plugin (replaces it entirely) */
   overrides?: string
-  /** Required permissions — PluginContext enforces these */
+  /** Required permissions — PluginContext enforces these at runtime */
   permissions?: PluginPermission[]
-  /** Called during startup in dependency order */
+  /** Called during startup in dependency order. 30s timeout. */
   setup(ctx: PluginContext): Promise<void>
-  /** Called during shutdown in reverse order. 10s timeout. */
+  /** Called during shutdown in reverse dependency order. 10s timeout. */
   teardown?(): Promise<void>
+  /** Called once when the plugin is first installed via CLI */
   install?(ctx: InstallContext): Promise<void>
+  /** Called when the plugin is removed via CLI. `purge` deletes data too. */
   uninstall?(ctx: InstallContext, opts: { purge: boolean }): Promise<void>
+  /** Interactive configuration via CLI (post-install) */
   configure?(ctx: InstallContext): Promise<void>
+  /**
+   * Called at boot when the registry's stored version differs from the plugin's
+   * current version. Returns new settings to persist, or void to keep existing.
+   */
   migrate?(ctx: MigrateContext, oldSettings: unknown, oldVersion: string): Promise<unknown>
+  /** Zod schema to validate settings before setup(). Validation failure skips the plugin. */
   settingsSchema?: import('zod').ZodSchema
+  /** If true, the plugin is critical to core operation (informational flag) */
   essential?: boolean
   /** Settings keys that can be copied when creating a new instance from this one */
   inheritableKeys?: string[]
@@ -62,16 +94,25 @@ export interface OpenACPPlugin {
 // Section 3: PluginContext, PluginStorage, CommandDef
 // ============================================================
 
+/**
+ * Per-plugin key-value storage backed by a JSON file on disk.
+ * Each plugin gets an isolated namespace at `~/.openacp/plugins/<name>/kv.json`.
+ */
 export interface PluginStorage {
   get<T>(key: string): Promise<T | undefined>
   set<T>(key: string, value: T): Promise<void>
   delete(key: string): Promise<void>
   list(): Promise<string[]>
+  /** Returns the plugin's dedicated data directory, creating it if needed */
   getDataDir(): string
 }
 
 // ─── Settings API (per-plugin settings.json) ───
 
+/**
+ * Typed API for reading and writing a plugin's settings.json file.
+ * Backed by SettingsManager; available in InstallContext and MigrateContext.
+ */
 export interface SettingsAPI {
   get<T = unknown>(key: string): Promise<T | undefined>
   set<T = unknown>(key: string, value: T): Promise<void>
@@ -101,6 +142,11 @@ export interface FieldDef {
 
 // ─── Terminal I/O (interactive CLI for plugins) ───
 
+/**
+ * Interactive CLI primitives for plugin install/configure flows.
+ * Wraps @clack/prompts — only available during CLI operations (install, configure),
+ * NOT during normal runtime. Plugins use this in their `install()` and `configure()` hooks.
+ */
 export interface TerminalIO {
   text(opts: {
     message: string
@@ -150,6 +196,11 @@ export interface TerminalIO {
 
 // ─── Install Context (for install/configure/uninstall) ───
 
+/**
+ * Context provided to plugin install/uninstall/configure hooks.
+ * Unlike PluginContext (runtime), InstallContext provides terminal I/O
+ * for interactive setup but no access to services, middleware, or events.
+ */
 export interface InstallContext {
   pluginName: string
   terminal: TerminalIO
@@ -162,6 +213,10 @@ export interface InstallContext {
 
 // ─── Migrate Context (for boot-time migration) ───
 
+/**
+ * Context provided to the `migrate()` hook at boot time when the plugin's
+ * current version differs from the version stored in the registry.
+ */
 export interface MigrateContext {
   pluginName: string
   settings: SettingsAPI
@@ -170,13 +225,19 @@ export interface MigrateContext {
 
 // ─── Command Response Types ───
 
+/**
+ * Possible response shapes from a command handler.
+ * Adapters render each type per-platform (e.g., Telegram inline keyboards for menus).
+ */
 export type CommandResponse =
   | { type: 'text'; text: string }
   | { type: 'menu'; title: string; options: MenuOption[] }
   | { type: 'list'; title: string; items: ListItem[] }
   | { type: 'confirm'; question: string; onYes: string; onNo: string }
   | { type: 'error'; message: string }
+  /** Command handled successfully but produces no visible output */
   | { type: 'silent' }
+  /** Command delegates further processing to another system (e.g., agent prompt) */
   | { type: 'delegated' }
 
 // ─── Menu Types ───
@@ -237,7 +298,7 @@ export interface CommandDef {
 }
 
 // Forward declarations for kernel types used in PluginContext.
-// These are structural types to avoid circular imports.
+// Structural (index-signature) types to avoid circular imports with core modules.
 export interface SessionManager {
   [key: string]: unknown
 }
@@ -261,6 +322,7 @@ export interface CoreAccess {
   adapters: Map<string, IChannelAdapter>
 }
 
+/** Pino-compatible logger interface used throughout the plugin system. */
 export interface Logger {
   trace(msg: string, ...args: unknown[]): void
   debug(msg: string, ...args: unknown[]): void
@@ -268,9 +330,21 @@ export interface Logger {
   warn(msg: string, ...args: unknown[]): void
   error(msg: string, ...args: unknown[]): void
   fatal(msg: string, ...args: unknown[]): void
+  /** Create a child logger with additional context bindings (e.g., `{ plugin: name }`) */
   child(bindings: Record<string, unknown>): Logger
 }
 
+/**
+ * Scoped API surface given to each plugin during setup().
+ *
+ * Each plugin receives its own PluginContext instance with permission-gated
+ * access. This provides isolation: storage is namespaced per-plugin, logs are
+ * prefixed with the plugin name, and only declared permissions are allowed.
+ *
+ * Tier 1 (Events) — subscribe/emit on the shared EventBus.
+ * Tier 2 (Actions) — register services, middleware, commands.
+ * Tier 3 (Kernel)  — direct access to core internals (requires kernel:access).
+ */
 export interface PluginContext {
   // === Identity ===
   pluginName: string
@@ -279,6 +353,13 @@ export interface PluginContext {
   // === Tier 1 — Events ===
   /** Subscribe to events. Auto-cleaned on teardown. Requires 'events:read'. */
   on(event: string, handler: (...args: unknown[]) => void): void
+  /**
+   * Unsubscribes a previously registered event handler.
+   *
+   * Called automatically for all listeners registered via `on()` during plugin teardown.
+   * Use manually only when conditional unsubscription is needed before teardown.
+   * Requires 'events:read' permission.
+   */
   off(event: string, handler: (...args: unknown[]) => void): void
   /** Emit custom events. Event names MUST be prefixed with plugin name. Requires 'events:emit'. */
   emit(event: string, payload: unknown): void
@@ -319,8 +400,11 @@ export interface PluginContext {
   sendMessage(sessionId: string, content: OutgoingMessage): Promise<void>
 
   // === Tier 3 — Kernel access (requires 'kernel:access') ===
+  /** Direct access to SessionManager. Requires 'kernel:access'. */
   sessions: SessionManager
+  /** Direct access to ConfigManager. Requires 'kernel:access'. */
   config: ConfigManager
+  /** Direct access to EventBus. Requires 'kernel:access'. */
   eventBus: EventBus
   /** Direct access to OpenACPCore instance. Requires 'kernel:access'. */
   core: unknown
@@ -336,6 +420,14 @@ export interface PluginContext {
 // Section 4: Middleware System
 // ============================================================
 
+/**
+ * Maps each middleware hook name to its payload type.
+ *
+ * Middleware handlers receive the payload, can modify it, and call `next()` to pass
+ * it down the chain. Returning `null` short-circuits the chain (blocks the operation).
+ * There are 19 hook points covering message flow, agent lifecycle, file system,
+ * terminal, permissions, sessions, config changes, and agent switching.
+ */
 export interface MiddlewarePayloadMap {
   // === Message flow ===
   'message:incoming': {
@@ -463,8 +555,15 @@ export interface MiddlewarePayloadMap {
   }
 }
 
+/** Union of all valid middleware hook names */
 export type MiddlewareHook = keyof MiddlewarePayloadMap
 
+/**
+ * Middleware handler signature. Receives the current payload and a `next` function.
+ * - Call `next()` to continue the chain (optionally with a modified payload).
+ * - Return the (possibly modified) payload to pass it upstream.
+ * - Return `null` to short-circuit — the operation is blocked entirely.
+ */
 export type MiddlewareFn<T> = (payload: T, next: () => Promise<T>) => Promise<T | null>
 
 export interface MiddlewareOptions<T> {
@@ -478,6 +577,11 @@ export interface MiddlewareOptions<T> {
 // Section 8: Plugin Events
 // ============================================================
 
+/**
+ * Well-known events emitted on the EventBus.
+ * Plugins can subscribe via `ctx.on(event, handler)`.
+ * Custom plugin events use the `pluginName:eventName` convention.
+ */
 export interface PluginEventMap {
   // System lifecycle
   'kernel:booted': Record<string, never>
@@ -512,6 +616,10 @@ export interface PluginEventMap {
 // ============================================================
 // Section 6: Service Contract Interfaces
 // ============================================================
+
+// These interfaces define the typed contracts for services registered in
+// the ServiceRegistry. Plugins register implementations; core and other
+// plugins retrieve them via `serviceRegistry.get<T>(name)`.
 
 export interface SecurityService {
   checkAccess(userId: string): Promise<{ allowed: boolean; reason?: string }>

--- a/src/core/security/env-filter.ts
+++ b/src/core/security/env-filter.ts
@@ -1,12 +1,25 @@
+/**
+ * Allowlisted environment variable patterns for agent subprocesses.
+ *
+ * Agent processes inherit a filtered subset of the parent environment.
+ * This prevents agents from accessing secrets (API keys, tokens, cloud
+ * credentials) that happen to be in the OpenACP process environment.
+ *
+ * Only shell basics (PATH, HOME, SHELL), locale settings, git/SSH config,
+ * and terminal rendering vars are passed through. Patterns ending with "*"
+ * match any variable starting with that prefix (e.g. "GIT_*" matches "GIT_AUTHOR_NAME").
+ */
 export const DEFAULT_ENV_WHITELIST = [
+  // Shell basics — agents need these to resolve commands and write temp files
   "PATH", "HOME", "SHELL", "LANG", "LC_*", "TERM", "USER", "LOGNAME",
   "TMPDIR", "XDG_*", "NODE_ENV", "EDITOR",
-  // Git
+  // Git — agents need git config and SSH access for code operations
   "GIT_*", "SSH_AUTH_SOCK", "SSH_AGENT_PID",
-  // Terminal rendering
+  // Terminal rendering — ensures correct color output in agent responses
   "COLORTERM", "FORCE_COLOR", "NO_COLOR", "TERM_PROGRAM", "HOSTNAME",
 ];
 
+/** Supports exact match and trailing wildcard (e.g. "GIT_*" matches "GIT_AUTHOR_NAME"). */
 function matchesPattern(key: string, pattern: string): boolean {
   if (pattern.endsWith("*")) {
     return key.startsWith(pattern.slice(0, -1));
@@ -14,6 +27,17 @@ function matchesPattern(key: string, pattern: string): boolean {
   return key === pattern;
 }
 
+/**
+ * Filters environment variables for an agent subprocess.
+ *
+ * Only variables matching the whitelist patterns are passed through.
+ * Agent-specific env vars (from agent config) are merged on top,
+ * allowing agents to override allowlisted values.
+ *
+ * @param processEnv - The parent process environment (typically `process.env`)
+ * @param agentEnv - Additional env vars defined in the agent's configuration
+ * @param whitelist - Custom whitelist patterns (defaults to DEFAULT_ENV_WHITELIST)
+ */
 export function filterEnv(
   processEnv: Record<string, string | undefined>,
   agentEnv?: Record<string, string>,

--- a/src/core/security/path-guard.ts
+++ b/src/core/security/path-guard.ts
@@ -1,26 +1,61 @@
+/**
+ * PathGuard — filesystem access control for agent subprocesses.
+ *
+ * Agents run with the user's filesystem permissions but should NOT access:
+ *   - Files outside the workspace directory (prevents system-wide reads/writes)
+ *   - Sensitive files within the workspace (env files, keys, credentials)
+ *   - The .openacp/ directory itself (contains bot tokens and API keys)
+ *
+ * The guard uses a deny-by-default approach: paths must be within the cwd
+ * or explicitly allowlisted, AND must not match any deny pattern. Deny
+ * patterns use .gitignore syntax via the `ignore` library.
+ *
+ * Used by AgentInstance when processing file read/write tool calls from agents.
+ */
+
 import fs from "node:fs";
 import path from "node:path";
 import ignore, { type Ignore } from "ignore";
 
+/**
+ * Default deny patterns for sensitive files that agents must never access.
+ * Uses .gitignore-style glob syntax.
+ */
 const DEFAULT_DENY_PATTERNS = [
+  // Environment files — contain API keys, database URLs, etc.
   ".env",
   ".env.*",
+  // Cryptographic keys
   "*.key",
   "*.pem",
+  // SSH and cloud credentials
   ".ssh/",
   ".aws/",
+  // OpenACP workspace — contains bot tokens and secrets
   ".openacp/",
+  // Generic credential/secret files
   "**/credentials*",
   "**/secrets*",
   "**/*.secret",
 ];
 
+/** Configuration for PathGuard's access control rules. */
 export interface PathGuardOptions {
+  /** Workspace root — files must be within this directory (or allowedPaths). */
   cwd: string;
+  /** Additional paths allowed outside cwd (e.g. file-service upload dir). */
   allowedPaths: string[];
+  /** Additional deny patterns (merged with DEFAULT_DENY_PATTERNS). */
   ignorePatterns: string[];
 }
 
+/**
+ * Enforces path restrictions on agent file operations.
+ *
+ * Validates that a target path is within the workspace boundary and does
+ * not match any deny pattern. Resolves symlinks to prevent traversal attacks
+ * (e.g. symlink pointing outside the workspace).
+ */
 export class PathGuard {
   private readonly cwd: string;
   private readonly allowedPaths: string[];
@@ -47,6 +82,20 @@ export class PathGuard {
     }
   }
 
+  /**
+   * Checks whether an agent is allowed to access the given path.
+   *
+   * Validation order:
+   *   1. Write to .openacpignore is always blocked (prevents agents from weakening their own restrictions)
+   *   2. Path must be within cwd or an explicitly allowlisted path
+   *   3. If within cwd but not allowlisted, path must not match any deny pattern
+   *
+   * @param targetPath - The path the agent is attempting to access.
+   * @param operation - The operation type. Write operations are subject to stricter
+   *   restrictions than reads — specifically, writing to `.openacpignore` is blocked
+   *   (to prevent agents from weakening their own restrictions), while reading it is allowed.
+   * @returns `{ allowed: true }` or `{ allowed: false, reason: "..." }`
+   */
   validatePath(
     targetPath: string,
     operation: "read" | "write",
@@ -97,6 +146,7 @@ export class PathGuard {
     return { allowed: true, reason: "" };
   }
 
+  /** Adds an additional allowed path at runtime (e.g. for file-service uploads). */
   addAllowedPath(p: string): void {
     try {
       this.allowedPaths.push(fs.realpathSync(path.resolve(p)));
@@ -105,6 +155,10 @@ export class PathGuard {
     }
   }
 
+  /**
+   * Loads additional deny patterns from .openacpignore in the workspace root.
+   * Follows .gitignore syntax — blank lines and lines starting with # are skipped.
+   */
   static loadIgnoreFile(cwd: string): string[] {
     const ignorePath = path.join(cwd, ".openacpignore");
     try {

--- a/src/core/security/sanitize-html.ts
+++ b/src/core/security/sanitize-html.ts
@@ -1,5 +1,16 @@
+/**
+ * HTML sanitization for agent output sent to Telegram.
+ *
+ * Telegram's HTML mode renders a subset of tags for message formatting.
+ * Agent responses can contain arbitrary HTML from markdown conversion,
+ * which may include script tags, event handlers, or malformed markup
+ * that would break Telegram's parser. This module strips everything
+ * except safe formatting and structural tags.
+ */
+
 import sanitizeHtmlLib from "sanitize-html";
 
+/** Tags allowed through sanitization — matches Telegram's supported subset plus safe structural elements. */
 const ALLOWED_TAGS = [
   "b",
   "i",
@@ -39,13 +50,23 @@ const ALLOWED_TAGS = [
 
 const SANITIZE_OPTIONS: sanitizeHtmlLib.IOptions = {
   allowedTags: ALLOWED_TAGS,
+  // Only href on anchors — no onclick, style, or other attributes
   allowedAttributes: {
     a: ["href"],
   },
+  // Restrict link schemes to prevent javascript: or data: URI injection
   allowedSchemes: ["http", "https", "mailto"],
+  // Discard disallowed tags entirely rather than escaping them
   disallowedTagsMode: "discard",
 };
 
+/**
+ * Strips unsafe HTML tags and attributes from agent output.
+ *
+ * Used by the Telegram adapter before sending messages in HTML parse mode.
+ * Retains formatting tags (bold, italic, code, links) while removing
+ * everything else to prevent markup injection or parser breakage.
+ */
 export function sanitizeHtml(html: string): string {
   return sanitizeHtmlLib(html, SANITIZE_OPTIONS);
 }

--- a/src/core/sessions/permission-gate.ts
+++ b/src/core/sessions/permission-gate.ts
@@ -3,7 +3,20 @@ import type { PermissionRequest } from "../types.js";
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
 /**
- * Encapsulates pending permission state with a typed Promise API.
+ * Blocks the prompt pipeline until the user approves or denies a permission request.
+ *
+ * When an agent requests permission (e.g., to run a shell command), AgentInstance
+ * calls its `onPermissionRequest` callback. SessionBridge handles this by calling
+ * `setPending()`, which returns a promise that blocks the ACP prompt/response cycle
+ * until `resolve()` or `reject()` is called. If the user doesn't respond within
+ * the timeout, the request is automatically rejected.
+ *
+ * Only one permission request can be pending at a time — setting a new one
+ * supersedes (rejects) the previous.
+ *
+ * When `bypassPermissions` is enabled on the session, SessionBridge short-circuits
+ * this gate entirely: `setPending()` is never called, and permissions are auto-approved
+ * upstream before the request reaches this class.
  */
 export class PermissionGate {
   private request?: PermissionRequest;
@@ -17,6 +30,10 @@ export class PermissionGate {
     this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
+  /**
+   * Register a new permission request and return a promise that resolves with the
+   * chosen option ID when the user responds, or rejects on timeout / supersession.
+   */
   setPending(request: PermissionRequest): Promise<string> {
     // Reject any existing pending promise so callers don't hang forever
     if (!this.settled && this.rejectFn) {
@@ -33,12 +50,14 @@ export class PermissionGate {
       this.timeoutTimer = setTimeout(() => {
         this.reject("Permission request timed out (no response received)");
       }, this.timeoutMs);
+      // unref() prevents the timeout from keeping the process alive during shutdown
       if (typeof this.timeoutTimer === 'object' && 'unref' in this.timeoutTimer) {
         (this.timeoutTimer as NodeJS.Timeout).unref();
       }
     });
   }
 
+  /** Approve the pending request with the given option ID. No-op if already settled. */
   resolve(optionId: string): void {
     if (this.settled || !this.resolveFn) return;
     this.settled = true;
@@ -47,6 +66,7 @@ export class PermissionGate {
     this.cleanup();
   }
 
+  /** Deny the pending request. No-op if already settled. */
   reject(reason?: string): void {
     if (this.settled || !this.rejectFn) return;
     this.settled = true;

--- a/src/core/sessions/prompt-queue.ts
+++ b/src/core/sessions/prompt-queue.ts
@@ -3,6 +3,11 @@ import type { TurnRouting } from './turn-context.js'
 
 /**
  * Serial prompt queue — ensures prompts are processed one at a time.
+ *
+ * Agents are stateful (each prompt builds on prior context), so concurrent
+ * prompts would corrupt the conversation. This queue guarantees that only
+ * one prompt is processed at a time; additional prompts are buffered and
+ * drained sequentially after the current one completes.
  */
 export class PromptQueue {
   private queue: Array<{ text: string; attachments?: Attachment[]; routing?: TurnRouting; turnId?: string; resolve: () => void }> = []
@@ -16,6 +21,11 @@ export class PromptQueue {
     private onError?: (err: unknown) => void,
   ) {}
 
+  /**
+   * Add a prompt to the queue. If no prompt is currently processing, it runs
+   * immediately. Otherwise, it's buffered and the returned promise resolves
+   * only after the prompt finishes processing.
+   */
   async enqueue(text: string, attachments?: Attachment[], routing?: TurnRouting, turnId?: string): Promise<void> {
     if (this.processing) {
       return new Promise<void>((resolve) => {
@@ -25,6 +35,7 @@ export class PromptQueue {
     await this.process(text, attachments, routing, turnId)
   }
 
+  /** Run a single prompt through the processor, then drain the next queued item. */
   private async process(text: string, attachments?: Attachment[], routing?: TurnRouting, turnId?: string): Promise<void> {
     this.processing = true
     this.abortController = new AbortController()
@@ -52,6 +63,7 @@ export class PromptQueue {
     }
   }
 
+  /** Dequeue and process the next pending prompt, if any. Called after each prompt completes. */
   private drainNext(): void {
     const next = this.queue.shift()
     if (next) {
@@ -59,6 +71,10 @@ export class PromptQueue {
     }
   }
 
+  /**
+   * Abort the in-flight prompt and discard all queued prompts.
+   * Pending promises are resolved (not rejected) so callers don't see unhandled rejections.
+   */
   clear(): void {
     // Abort the currently running prompt so the queue can drain
     if (this.abortController) {

--- a/src/core/sessions/session-bridge.ts
+++ b/src/core/sessions/session-bridge.ts
@@ -15,6 +15,7 @@ import { Hook, BusEvent, SessionEv } from "../events.js";
 
 const log = createChildLogger({ module: "session-bridge" });
 
+/** Services required by SessionBridge for message transformation, persistence, and middleware. */
 export interface BridgeDeps {
   messageTransformer: MessageTransformer;
   notificationManager: NotificationManager;
@@ -24,6 +25,18 @@ export interface BridgeDeps {
   middlewareChain?: MiddlewareChain;
 }
 
+/**
+ * Connects a Session to a channel adapter, forwarding agent events to the adapter's
+ * stream interface and wiring up permission handling, lifecycle persistence, and middleware.
+ *
+ * Each adapter attached to a session gets its own bridge. The bridge subscribes to
+ * Session events (agent_event, permission_request, status_change, etc.) and translates
+ * them into adapter-specific calls (sendMessage, sendPermissionRequest, renameSessionThread).
+ *
+ * Multi-adapter routing: when a TurnContext is active, turn events (text, tool_call, etc.)
+ * are forwarded only to the adapter that originated the prompt. System events (commands_update,
+ * session_end, etc.) are always broadcast to all bridges.
+ */
 export class SessionBridge {
   private connected = false;
   private cleanupFns: Array<() => void> = [];
@@ -71,7 +84,10 @@ export class SessionBridge {
     }
   }
 
-  /** Determine if this bridge should forward the given event based on turn routing. */
+  /**
+   * Determine if this bridge should forward the given event based on turn routing.
+   * System events are always forwarded; turn events are routed only to the target adapter.
+   */
   shouldForward(event: AgentEvent): boolean {
     // System events → always forward to all bridges
     if (isSystemEvent(event)) return true;
@@ -90,6 +106,13 @@ export class SessionBridge {
     return this.adapterId === target;
   }
 
+  /**
+   * Subscribe to session events and start forwarding them to the adapter.
+   *
+   * Wires: agent events → adapter dispatch, permission UI, lifecycle persistence
+   * (status changes, naming, prompt count), and EventBus notifications.
+   * Also replays any commands or config options that arrived before the bridge connected.
+   */
   connect(): void {
     if (this.connected) return;
     this.connected = true;
@@ -203,6 +226,7 @@ export class SessionBridge {
     }
   }
 
+  /** Unsubscribe all session event listeners and clean up adapter state. */
   disconnect(): void {
     if (!this.connected) return;
     this.connected = false;

--- a/src/core/sessions/session-factory.ts
+++ b/src/core/sessions/session-factory.ts
@@ -18,6 +18,7 @@ import { Hook, BusEvent, SessionEv } from "../events.js";
 
 const log = createChildLogger({ module: "session-factory" });
 
+/** Parameters for creating a new session — used by SessionFactory.create() and Core.createFullSession(). */
 export interface SessionCreateParams {
   channelId: string;
   agentName: string;
@@ -34,6 +35,14 @@ export interface SideEffectDeps {
   tunnelService?: TunnelService;
 }
 
+/**
+ * Constructs new Sessions with the right agent, working directory, and initial state.
+ *
+ * Handles agent spawning (or resuming from a previous ACP session), middleware integration,
+ * ACP state hydration, and side-effect wiring (usage tracking, tunnel cleanup).
+ * Also provides lazy resume: when a message arrives for a stored (not live) session,
+ * the factory transparently resumes it by re-spawning the agent with the stored session ID.
+ */
 export class SessionFactory {
   middlewareChain?: MiddlewareChain;
   private resumeLocks: Map<string, Promise<Session | null>> = new Map();
@@ -69,6 +78,10 @@ export class SessionFactory {
       : this.speechServiceAccessor;
   }
 
+  /**
+   * Create a new Session: spawn agent → create Session instance → hydrate ACP state → register.
+   * Runs session:beforeCreate middleware (which can modify params or block creation).
+   */
   async create(params: SessionCreateParams): Promise<Session> {
     // Hook: session:beforeCreate — modifiable, can block
     let createParams = params;
@@ -290,6 +303,11 @@ export class SessionFactory {
     return resumePromise;
   }
 
+  /**
+   * Attempt to resume a session from disk when a message arrives on a thread with
+   * no live session. Deduplicates concurrent resume attempts for the same thread
+   * via resumeLocks to avoid spawning multiple agents.
+   */
   private async lazyResume(channelId: string, threadId: string): Promise<Session | null> {
     const store = this.sessionStore;
     if (!store || !this.createFullSession) return null;
@@ -413,6 +431,7 @@ export class SessionFactory {
     return resumePromise;
   }
 
+  /** Create a brand-new session, resolving agent name and workspace from config if not provided. */
   async handleNewSession(
     channelId: string,
     agentName?: string,
@@ -472,6 +491,7 @@ export class SessionFactory {
     );
   }
 
+  /** Create a session and inject conversation context from a ContextProvider (e.g., history from a previous session). */
   async createSessionWithContext(params: {
     channelId: string;
     agentName: string;
@@ -511,6 +531,7 @@ export class SessionFactory {
     return { session, contextResult };
   }
 
+  /** Wire session-level side effects: usage tracking (via EventBus) and tunnel cleanup on session end. */
   wireSideEffects(session: Session, deps: SideEffectDeps): void {
     // Wire usage tracking via event bus (consumed by usage plugin)
     session.on(SessionEv.AGENT_EVENT, (event: AgentEvent) => {

--- a/src/core/sessions/session-manager.ts
+++ b/src/core/sessions/session-manager.ts
@@ -6,6 +6,7 @@ import type { MiddlewareChain } from "../plugin/middleware-chain.js";
 import type { SessionStatus, ConfigOption, AgentCapabilities } from "../types.js";
 import { Hook, BusEvent } from "../events.js";
 
+/** Flattened view of a session for API consumers — merges live state with stored record. */
 export interface SessionSummary {
   id: string;
   agent: string;
@@ -23,12 +24,24 @@ export interface SessionSummary {
   isLive: boolean;
 }
 
+/**
+ * Registry for live Session instances. Provides lookup by session ID, channel+thread,
+ * or agent session ID. Coordinates session lifecycle: creation, cancellation, persistence,
+ * and graceful shutdown.
+ *
+ * Live sessions are kept in an in-memory Map. The optional SessionStore handles
+ * disk persistence — the manager delegates save/patch/remove operations to the store.
+ */
 export class SessionManager {
   private sessions: Map<string, Session> = new Map();
   private store: SessionStore | null;
   private eventBus?: EventBus;
   middlewareChain?: MiddlewareChain;
 
+  /**
+   * Inject the EventBus after construction. Deferred because EventBus is created
+   * after SessionManager during bootstrap, so it cannot be passed to the constructor.
+   */
   setEventBus(eventBus: EventBus): void {
     this.eventBus = eventBus;
   }
@@ -37,6 +50,7 @@ export class SessionManager {
     this.store = store;
   }
 
+  /** Create a new session by spawning an agent and persisting the initial record. */
   async createSession(
     channelId: string,
     agentName: string,
@@ -72,10 +86,12 @@ export class SessionManager {
     return session;
   }
 
+  /** Look up a live session by its OpenACP session ID. */
   getSession(sessionId: string): Session | undefined {
     return this.sessions.get(sessionId);
   }
 
+  /** Look up a live session by adapter channel and thread ID (checks per-adapter threadIds map first, then legacy fields). */
   getSessionByThread(channelId: string, threadId: string): Session | undefined {
     for (const session of this.sessions.values()) {
       // New: check per-adapter threadIds map
@@ -89,6 +105,7 @@ export class SessionManager {
     return undefined;
   }
 
+  /** Look up a live session by the agent's internal session ID (assigned by the ACP subprocess). */
   getSessionByAgentSessionId(agentSessionId: string): Session | undefined {
     for (const session of this.sessions.values()) {
       if (session.agentSessionId === agentSessionId) {
@@ -98,12 +115,14 @@ export class SessionManager {
     return undefined;
   }
 
+  /** Look up the persisted SessionRecord by the agent's internal session ID. */
   getRecordByAgentSessionId(
     agentSessionId: string,
   ): import("../types.js").SessionRecord | undefined {
     return this.store?.findByAgentSessionId(agentSessionId);
   }
 
+  /** Look up the persisted SessionRecord by channel and thread ID. */
   getRecordByThread(
     channelId: string,
     threadId: string,
@@ -114,10 +133,16 @@ export class SessionManager {
     );
   }
 
+  /** Register a session that was created externally (e.g. restored from store on startup). */
   registerSession(session: Session): void {
     this.sessions.set(session.id, session);
   }
 
+  /**
+   * Merge a partial update into the stored SessionRecord. If no record exists yet and
+   * the patch includes `sessionId`, it is treated as an initial save.
+   * Pass `{ immediate: true }` to flush the store to disk synchronously.
+   */
   async patchRecord(
     sessionId: string,
     patch: Partial<import("../types.js").SessionRecord>,
@@ -136,12 +161,14 @@ export class SessionManager {
     }
   }
 
+  /** Retrieve the persisted SessionRecord for a given session ID. Returns undefined if no store or record not found. */
   getSessionRecord(
     sessionId: string,
   ): import("../types.js").SessionRecord | undefined {
     return this.store?.get(sessionId);
   }
 
+  /** Cancel a session: abort in-flight prompt, transition to cancelled, destroy agent, and persist. */
   async cancelSession(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId);
     if (session) {
@@ -166,12 +193,17 @@ export class SessionManager {
     }
   }
 
+  /** List live (in-memory) sessions, optionally filtered by channel. Excludes assistant sessions. */
   listSessions(channelId?: string): Session[] {
     const all = Array.from(this.sessions.values()).filter(s => !s.isAssistant);
     if (channelId) return all.filter((s) => s.channelId === channelId);
     return all;
   }
 
+  /**
+   * List all sessions (live + stored) as SessionSummary. Live sessions take precedence
+   * over stored records — their real-time state (queueDepth, promptRunning) is used.
+   */
   listAllSessions(channelId?: string): SessionSummary[] {
     if (this.store) {
       let records = this.store.list().filter(r => !r.isAssistant);
@@ -236,6 +268,7 @@ export class SessionManager {
     }));
   }
 
+  /** List all stored SessionRecords, optionally filtered by status. Excludes assistant sessions. */
   listRecords(filter?: {
     statuses?: string[];
   }): import("../types.js").SessionRecord[] {
@@ -247,6 +280,7 @@ export class SessionManager {
     return records;
   }
 
+  /** Remove a session's stored record and emit a SESSION_DELETED event. */
   async removeRecord(sessionId: string): Promise<void> {
     if (!this.store) return;
     await this.store.remove(sessionId);

--- a/src/core/sessions/session-store.ts
+++ b/src/core/sessions/session-store.ts
@@ -5,6 +5,7 @@ import { createChildLogger } from "../utils/log.js";
 
 const log = createChildLogger({ module: "session-store" });
 
+/** Persistence interface for session records. Implementations handle serialization format and storage. */
 export interface SessionStore {
   save(record: SessionRecord): Promise<void>;
   /** Immediately flush pending writes to disk (no debounce). */
@@ -20,13 +21,22 @@ export interface SessionStore {
   remove(sessionId: string): Promise<void>;
 }
 
+/** On-disk JSON format: versioned envelope wrapping a session ID → record map. */
 interface StoreFile {
   version: number;
   sessions: Record<string, SessionRecord>;
 }
 
+/** Writes are debounced to avoid excessive disk I/O during rapid state changes. */
 const DEBOUNCE_MS = 2000;
 
+/**
+ * JSON file-backed session store.
+ *
+ * Reads the entire store into memory on startup, applies all mutations in-memory,
+ * and debounces writes to disk. Expired records (past ttlDays) are cleaned up
+ * periodically. On shutdown, pending writes are flushed synchronously.
+ */
 export class JsonFileSessionStore implements SessionStore {
   private records: Map<string, SessionRecord> = new Map();
   private filePath: string;
@@ -80,6 +90,11 @@ export class JsonFileSessionStore implements SessionStore {
     return undefined;
   }
 
+  /**
+   * Find a session by its ACP agent session ID.
+   * Checks current, original, and historical agent session IDs (from agent switches)
+   * since the agent session ID changes on each switch.
+   */
   findByAgentSessionId(agentSessionId: string): SessionRecord | undefined {
     for (const record of this.records.values()) {
       if (
@@ -88,7 +103,6 @@ export class JsonFileSessionStore implements SessionStore {
       ) {
         return record;
       }
-      // Also search switch history
       if (record.agentSwitchHistory?.some((e) => e.agentSessionId === agentSessionId)) {
         return record;
       }
@@ -134,6 +148,7 @@ export class JsonFileSessionStore implements SessionStore {
     fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
   }
 
+  /** Clean up timers and process listeners. Call on shutdown to prevent leaks. */
   destroy(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     if (this.cleanupInterval) clearInterval(this.cleanupInterval);
@@ -170,7 +185,11 @@ export class JsonFileSessionStore implements SessionStore {
     }
   }
 
-  /** Migrate old SessionRecord format to new multi-adapter format. */
+  /**
+   * Migrate old SessionRecord format to new multi-adapter format.
+   * Converts single-adapter `platform` field to per-adapter `platforms` map,
+   * and initializes `attachedAdapters` for records created before multi-adapter support.
+   */
   private migrateRecord(record: SessionRecord): SessionRecord {
     // Migrate platform → platforms
     if (!record.platforms && record.platform && typeof record.platform === "object") {
@@ -186,6 +205,7 @@ export class JsonFileSessionStore implements SessionStore {
     return record;
   }
 
+  /** Remove expired session records (past TTL). Active and assistant sessions are preserved. */
   private cleanup(): void {
     const cutoff = Date.now() - this.ttlDays * 24 * 60 * 60 * 1000;
     let removed = 0;

--- a/src/core/sessions/session.ts
+++ b/src/core/sessions/session.ts
@@ -206,7 +206,7 @@ export class Session extends TypedEmitter<SessionEvents> {
     this.emit(SessionEv.SESSION_END, reason ?? "completed");
   }
 
-  /** Transition to cancelled — from active only (terminal session cancel) */
+  /** Transition to cancelled — from active or error (terminal session cancel) */
   markCancelled(): void {
     this.transition("cancelled");
   }
@@ -509,7 +509,9 @@ export class Session extends TypedEmitter<SessionEvents> {
     }
   }
 
-  // NOTE: This injects a summary prompt into the agent's conversation history.
+  // Sends a special prompt to the agent to generate a short session title.
+  // The session emitter is paused (excluding non-agent_event emissions) so the naming
+  // prompt's output is intercepted by a capture handler instead of being forwarded to adapters.
   private async autoName(): Promise<void> {
     let title = "";
 

--- a/src/core/sessions/session.ts
+++ b/src/core/sessions/session.ts
@@ -13,13 +13,26 @@ import { createTurnContext, type TurnContext } from "./turn-context.js";
 import { Hook, SessionEv } from "../events.js";
 const moduleLog = createChildLogger({ module: "session" });
 
-// TTS constants
+// TTS injection pattern: we append TTS_PROMPT_INSTRUCTION to the user's prompt so the
+// agent includes a [TTS]...[/TTS] block in its response. After the response completes,
+// we extract that block via TTS_BLOCK_REGEX and synthesize speech from it. The TTS block
+// is then stripped from the text shown to the user (via tts_strip event).
 export const TTS_PROMPT_INSTRUCTION = `\n\nAdditionally, include a [TTS]...[/TTS] block with a spoken-friendly summary of your response. Focus on key information, decisions the user needs to make, or actions required. The agent decides what to say and how long. Respond in the same language the user is using. This instruction applies to this message only.`;
 export const TTS_BLOCK_REGEX = /\[TTS\]([\s\S]*?)\[\/TTS\]/;
 export const TTS_MAX_LENGTH = 5000;
 export const TTS_TIMEOUT_MS = 30_000;
 
-// Valid state transitions: from → Set<to>
+// Session state machine — valid transitions: from → Set<to>
+//
+//   initializing → active (first prompt received)
+//                → error  (agent spawn failed)
+//   active       → error     (unrecoverable prompt failure)
+//                → finished  (agent signaled session_end)
+//                → cancelled (user cancelled the session)
+//   error        → active    (retry: user sends a new prompt)
+//                → cancelled (user gives up)
+//   cancelled    → active    (resume: user sends a new prompt)
+//   finished     → (terminal — no further transitions)
 const VALID_TRANSITIONS: Record<SessionStatus, Set<SessionStatus>> = {
   initializing: new Set(["active", "error"]),
   active: new Set(["error", "finished", "cancelled"]),
@@ -28,6 +41,7 @@ const VALID_TRANSITIONS: Record<SessionStatus, Set<SessionStatus>> = {
   finished: new Set(),
 };
 
+/** Events emitted by a Session instance — SessionBridge subscribes to relay them to adapters. */
 export interface SessionEvents {
   agent_event: (event: AgentEvent) => void;
   permission_request: (request: PermissionRequest) => void;
@@ -39,6 +53,17 @@ export interface SessionEvents {
   turn_started: (ctx: TurnContext) => void;
 }
 
+/**
+ * Manages a single conversation between a user and an AI agent.
+ *
+ * Wraps an AgentInstance with serial prompt queuing (via PromptQueue), permission
+ * gating (via PermissionGate), TTS/STT integration, auto-naming, and a state
+ * machine tracking the session lifecycle. SessionBridge subscribes to this
+ * emitter to forward agent output to channel adapters.
+ *
+ * A session can be attached to multiple adapters simultaneously (e.g., Telegram
+ * and SSE). The `threadIds` map tracks which thread each adapter uses.
+ */
 export class Session extends TypedEmitter<SessionEvents> {
   id: string;
   channelId: string;
@@ -55,6 +80,8 @@ export class Session extends TypedEmitter<SessionEvents> {
   workingDirectory: string;
   private _agentInstance!: AgentInstance;
   get agentInstance(): AgentInstance { return this._agentInstance; }
+  /** Setting agentInstance wires the agent→session event relay and commands buffer.
+   *  This happens both at construction and on agent switch (switchAgent). */
   set agentInstance(agent: AgentInstance) {
     this._agentInstance = agent;
     this.wireAgentRelay();
@@ -202,18 +229,21 @@ export class Session extends TypedEmitter<SessionEvents> {
     return this.queue.pending;
   }
 
+  /** Whether a prompt is currently being processed by the agent */
   get promptRunning(): boolean {
     return this.queue.isProcessing;
   }
 
   // --- Context Injection ---
 
+  /** Store context markdown to be prepended to the next prompt (used for session resume with history). */
   setContext(markdown: string): void {
     this.pendingContext = markdown;
   }
 
   // --- Voice Mode ---
 
+  /** Set TTS mode: "off" = disabled, "next" = one-shot (auto-resets after prompt), "on" = persistent. */
   setVoiceMode(mode: "off" | "next" | "on"): void {
     this.voiceMode = mode;
     this.log.info({ voiceMode: mode }, "TTS mode changed");
@@ -221,6 +251,13 @@ export class Session extends TypedEmitter<SessionEvents> {
 
   // --- Public API ---
 
+  /**
+   * Enqueue a user prompt for serial processing.
+   *
+   * Runs the prompt through agent:beforePrompt middleware (which can modify or block),
+   * then adds it to the PromptQueue. Returns a turnId that callers can use to correlate
+   * queued/processing events before the prompt actually runs.
+   */
   async enqueuePrompt(text: string, attachments?: Attachment[], routing?: TurnRouting, externalTurnId?: string): Promise<string> {
     // Use pre-generated turnId if provided (so callers can emit events before awaiting the queue)
     const turnId = externalTurnId ?? nanoid(8);
@@ -369,6 +406,10 @@ export class Session extends TypedEmitter<SessionEvents> {
     }
   }
 
+  /**
+   * Transcribe audio attachments to text if the agent doesn't support audio natively.
+   * Audio attachments are removed and their transcriptions are appended to the prompt text.
+   */
   private async maybeTranscribeAudio(
     text: string,
     attachments?: Attachment[],
@@ -427,6 +468,7 @@ export class Session extends TypedEmitter<SessionEvents> {
     };
   }
 
+  /** Extract [TTS] block from agent response, synthesize speech, and emit audio_content event. */
   private async processTTSResponse(responseText: string): Promise<void> {
     const match = TTS_BLOCK_REGEX.exec(responseText);
     if (!match?.[1]) {
@@ -668,6 +710,7 @@ export class Session extends TypedEmitter<SessionEvents> {
     this.log.info({ from: this.agentSwitchHistory.at(-1)!.agentName, to: agentName }, "Agent switched");
   }
 
+  /** Tear down the session: reject pending permissions, clear queue, destroy agent subprocess. */
   async destroy(): Promise<void> {
     this.log.info("Session destroyed");
     // Reject any pending permission promise so callers don't hang

--- a/src/core/sessions/terminal-manager.ts
+++ b/src/core/sessions/terminal-manager.ts
@@ -31,6 +31,15 @@ interface WaitForExitResult {
   signal: string | null;
 }
 
+/**
+ * Manages child-process terminals for agents that need interactive command execution.
+ *
+ * Agents request terminals via ACP's terminal_create method. Each terminal is a
+ * spawned child process whose stdout/stderr is captured into a ring buffer
+ * (capped at maxOutputBytes). The agent can poll output, wait for exit, or kill
+ * the process. Terminals are auto-cleaned up 30s after the process exits to allow
+ * final output retrieval.
+ */
 export class TerminalManager {
   private terminals: Map<string, TerminalState> = new Map();
   private maxOutputBytes: number;
@@ -39,6 +48,11 @@ export class TerminalManager {
     this.maxOutputBytes = maxOutputBytes;
   }
 
+  /**
+   * Spawn a new terminal process. Runs terminal:beforeCreate middleware first
+   * (which can modify command/args/env or block creation entirely).
+   * Returns a terminalId for subsequent output/wait/kill operations.
+   */
   async createTerminal(
     sessionId: string,
     params: CreateTerminalParams,
@@ -92,6 +106,8 @@ export class TerminalManager {
 
     const outputByteLimit = params.outputByteLimit ?? this.maxOutputBytes;
 
+    // Ring buffer: keep only the latest outputByteLimit bytes — oldest output
+    // is trimmed from the front when the buffer exceeds the limit.
     const appendOutput = (chunk: string) => {
       state.output += chunk;
       const bytes = Buffer.byteLength(state.output, "utf-8");
@@ -131,6 +147,7 @@ export class TerminalManager {
     return { terminalId };
   }
 
+  /** Retrieve accumulated stdout/stderr output for a terminal. */
   getOutput(terminalId: string): TerminalOutputResult {
     const state = this.terminals.get(terminalId);
     if (!state) {
@@ -148,6 +165,7 @@ export class TerminalManager {
     };
   }
 
+  /** Block until the terminal process exits, returning exit code and signal. */
   async waitForExit(terminalId: string): Promise<WaitForExitResult> {
     const state = this.terminals.get(terminalId);
     if (!state) {
@@ -175,6 +193,7 @@ export class TerminalManager {
     });
   }
 
+  /** Send SIGTERM to a terminal process (graceful shutdown). */
   kill(terminalId: string): void {
     const state = this.terminals.get(terminalId);
     if (!state) {
@@ -183,6 +202,7 @@ export class TerminalManager {
     state.process.kill("SIGTERM");
   }
 
+  /** Force-kill (SIGKILL) and immediately remove a terminal from the registry. */
   release(terminalId: string): void {
     const state = this.terminals.get(terminalId);
     if (!state) {
@@ -192,6 +212,7 @@ export class TerminalManager {
     this.terminals.delete(terminalId);
   }
 
+  /** Force-kill all terminals. Used during session/system teardown. */
   destroyAll(): void {
     for (const [, t] of this.terminals) {
       t.process.kill("SIGKILL");

--- a/src/core/sessions/turn-context.ts
+++ b/src/core/sessions/turn-context.ts
@@ -1,12 +1,26 @@
 import { nanoid } from "nanoid";
 import type { AgentEvent } from "../types.js";
 
+/**
+ * Immutable context for a single user-prompt → agent-response cycle ("turn").
+ *
+ * Sealed when a prompt is dequeued from the PromptQueue and cleared after the turn
+ * completes. Bridges use this to route agent events to the correct adapter when
+ * multiple adapters are attached to the same session.
+ */
 export interface TurnContext {
+  /** Unique identifier for this turn — shared between message:queued and message:processing events. */
   turnId: string;
+  /** The adapter that originated this prompt. */
   sourceAdapterId: string;
-  responseAdapterId?: string | null; // null = silent, undefined = use sourceAdapterId
+  /** Where to send the response: null = silent (suppress), undefined = same as source, string = explicit target. */
+  responseAdapterId?: string | null;
 }
 
+/**
+ * Routing hints attached to an incoming prompt — carried through the queue
+ * and used to construct TurnContext when the prompt is dequeued.
+ */
 export interface TurnRouting {
   sourceAdapterId: string;
   responseAdapterId?: string | null;

--- a/src/core/setup/git-protect.ts
+++ b/src/core/setup/git-protect.ts
@@ -1,3 +1,14 @@
+/**
+ * Git protection for local OpenACP instances.
+ *
+ * When a workspace is set up inside a project directory (as opposed to the
+ * global ~/.openacp), the .openacp/ folder contains bot tokens, API keys,
+ * and other secrets that must NEVER be committed to version control.
+ *
+ * This module automatically adds .openacp/ to .gitignore and documents
+ * the restriction in CLAUDE.md so AI coding agents know to avoid it.
+ */
+
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -17,6 +28,7 @@ export function protectLocalInstance(projectDir: string): void {
   printSecurityWarning()
 }
 
+/** Adds `.openacp` to .gitignore, creating the file if it doesn't exist. */
 function ensureGitignore(projectDir: string): void {
   const gitignorePath = path.join(projectDir, '.gitignore')
   const entry = '.openacp'
@@ -37,6 +49,10 @@ function ensureGitignore(projectDir: string): void {
   }
 }
 
+/**
+ * Adds a warning section to CLAUDE.md so AI coding agents (e.g. Claude Code)
+ * know not to read or reference files inside .openacp/.
+ */
 function ensureClaudeMd(projectDir: string): void {
   const claudeMdPath = path.join(projectDir, 'CLAUDE.md')
   const marker = '## Local OpenACP Workspace'

--- a/src/core/setup/helpers.ts
+++ b/src/core/setup/helpers.ts
@@ -1,8 +1,13 @@
+/**
+ * Shared prompt helpers, formatters, and validation utilities used
+ * across all setup wizard steps.
+ */
+
 import * as clack from "@clack/prompts";
 import type { Config } from "../config/config.js";
 import type { SettingsManager } from "../plugin/settings-manager.js";
 
-// --- ANSI colors ---
+// --- ANSI color constants for CLI output formatting ---
 
 export const c = {
   reset: "\x1b[0m",
@@ -15,14 +20,24 @@ export const c = {
   white: "\x1b[37m",
 };
 
+/** Format a success message with a green checkmark prefix. */
 export const ok = (msg: string) =>
   `${c.green}${c.bold}✓${c.reset} ${c.green}${msg}${c.reset}`;
+/** Format a warning message with a yellow triangle prefix. */
 export const warn = (msg: string) => `${c.yellow}⚠ ${msg}${c.reset}`;
+/** Format an error message with a red X prefix. */
 export const fail = (msg: string) => `${c.red}✗ ${msg}${c.reset}`;
+/** Format a wizard step header showing progress (e.g. "[2/5] Channels"). */
 export const step = (n: number, total: number, title: string) =>
   `\n${c.cyan}${c.bold}[${n}/${total}]${c.reset} ${c.bold}${title}${c.reset}\n`;
 export const dim = (msg: string) => `${c.dim}${msg}${c.reset}`;
 
+/**
+ * Unwraps a clack prompt result, exiting the process if the user cancelled.
+ *
+ * clack prompts return `symbol` on Ctrl+C — this guard centralizes that
+ * check so each step doesn't need its own cancellation handling.
+ */
 export function guardCancel<T>(value: T | symbol): T {
   if (clack.isCancel(value)) {
     clack.cancel("Setup cancelled.");
@@ -53,6 +68,7 @@ const BANNER = `
    ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝╚═╝  ╚═╝ ╚═════╝╚═╝
 `;
 
+/** Prints the ASCII art banner with gradient coloring and version number. */
 export async function printStartBanner(): Promise<void> {
   let version = "0.0.0";
   try {
@@ -67,6 +83,10 @@ export async function printStartBanner(): Promise<void> {
 
 // --- Config summary ---
 
+/**
+ * Builds a human-readable summary of the current config for display
+ * in the reconfigure wizard's "Current configuration" note.
+ */
 export async function summarizeConfig(config: Config, settingsManager?: SettingsManager): Promise<string> {
   const lines: string[] = [];
 

--- a/src/core/setup/setup-agents.ts
+++ b/src/core/setup/setup-agents.ts
@@ -1,3 +1,8 @@
+/**
+ * Agent setup step — detects installed agents, offers additional installs
+ * from the agent registry, and lets the user pick a default agent.
+ */
+
 import { execFileSync } from "node:child_process";
 import * as clack from "@clack/prompts";
 import { commandExists } from "../agents/agent-dependencies.js";
@@ -10,6 +15,10 @@ const KNOWN_AGENTS: Array<{ name: string; commands: string[] }> = [
   { name: "codex", commands: ["codex"] },
 ];
 
+/**
+ * Scans PATH and local node_modules for known agent commands.
+ * Returns the first available command for each agent (priority order).
+ */
 export async function detectAgents(): Promise<
   Array<{ name: string; command: string }>
 > {
@@ -30,6 +39,7 @@ export async function detectAgents(): Promise<
   return found;
 }
 
+/** Checks whether a command is available in the system PATH. */
 export async function validateAgentCommand(command: string): Promise<boolean> {
   try {
     execFileSync("which", [command], { stdio: "pipe" });
@@ -39,6 +49,15 @@ export async function validateAgentCommand(command: string): Promise<boolean> {
   }
 }
 
+/**
+ * Runs the agent installation and selection step of the setup wizard.
+ *
+ * Ensures Claude Agent is always available (bundled fallback), refreshes the
+ * agent registry, offers installation of additional agents, and prompts for
+ * a default agent when multiple are installed.
+ *
+ * @returns The key of the selected default agent (e.g. "claude")
+ */
 export async function setupAgents(instanceRoot?: string): Promise<{
   defaultAgent: string;
 }> {

--- a/src/core/setup/setup-channels.ts
+++ b/src/core/setup/setup-channels.ts
@@ -1,3 +1,8 @@
+/**
+ * Channel configuration step — manages messaging platform setup
+ * (Telegram, Discord, Desktop App) via plugin install/configure hooks.
+ */
+
 import * as clack from "@clack/prompts";
 import type { Config } from "../config/config.js";
 import type { SettingsManager } from "../plugin/settings-manager.js";
@@ -6,11 +11,15 @@ import { CHANNEL_META } from "./types.js";
 import { guardCancel, ok, c } from "./helpers.js";
 
 // Maps logical channel ID → plugin name used for settings storage and dynamic import.
-// Telegram is built-in so it has no entry here (handled separately via direct import).
+// Telegram is built-in so it uses a direct import path instead of this map.
 const CHANNEL_PLUGIN_NAME: Record<string, string> = {
   discord: "@openacp/discord-adapter",
 };
 
+/**
+ * Reads the current configuration status of all known channels by
+ * checking plugin settings for required credentials.
+ */
 export async function getChannelStatuses(config: Config, settingsManager?: SettingsManager): Promise<ChannelStatus[]> {
   const statuses: ChannelStatus[] = [];
 
@@ -42,6 +51,7 @@ export async function getChannelStatuses(config: Config, settingsManager?: Setti
   return statuses;
 }
 
+/** Prints a formatted summary of all channel statuses to the console. */
 export async function noteChannelStatus(config: Config, settingsManager?: SettingsManager): Promise<void> {
   const statuses = await getChannelStatuses(config, settingsManager);
   const lines = statuses.map((s) => {
@@ -71,6 +81,12 @@ async function promptConfiguredAction(label: string): Promise<ConfiguredChannelA
   );
 }
 
+/**
+ * Delegates channel configuration to the plugin's install() or configure() hook.
+ *
+ * First-time setup calls install() for the full guided flow;
+ * reconfiguration calls configure() for editing individual settings.
+ */
 async function configureViaPlugin(channelId: string, isConfigured: boolean, settingsManager?: SettingsManager): Promise<void> {
   // SSE (Desktop App) connects automatically; no user configuration needed.
   if (channelId === 'sse') return;
@@ -117,6 +133,13 @@ async function configureViaPlugin(channelId: string, isConfigured: boolean, sett
   }
 }
 
+/**
+ * Interactive channel management loop — lets users select a channel,
+ * configure/modify/disable/delete it, then repeat until they choose "Finished".
+ *
+ * Channel credentials are stored in plugin settings (not config.json),
+ * so changes here write to ~/.openacp/plugins/data/<plugin>/settings.json.
+ */
 export async function configureChannels(config: Config, settingsManager?: SettingsManager): Promise<{ config: Config; changed: boolean }> {
   const next = structuredClone(config);
   let changed = false;

--- a/src/core/setup/setup-integrations.ts
+++ b/src/core/setup/setup-integrations.ts
@@ -2,6 +2,11 @@ import * as clack from "@clack/prompts";
 import { getIntegration } from "../../cli/integrate.js";
 import { guardCancel } from "./helpers.js";
 
+/**
+ * Offers to install the Claude CLI integration, which enables
+ * `/openacp:handoff` in the terminal for session transfer between
+ * Claude Code and OpenACP.
+ */
 export async function setupIntegrations(): Promise<void> {
   const integration = getIntegration("claude");
   const isInstalled = integration?.items[0]?.isInstalled() ?? false;

--- a/src/core/setup/setup-run-mode.ts
+++ b/src/core/setup/setup-run-mode.ts
@@ -2,6 +2,16 @@ import * as clack from "@clack/prompts";
 import { expandHome } from "../config/config.js";
 import { guardCancel, ok, warn, dim, step } from "./helpers.js";
 
+/**
+ * Prompts the user to choose between foreground and daemon run modes.
+ *
+ * Daemon mode installs an OS-level autostart entry (launchd on macOS,
+ * systemd on Linux). When switching from daemon to foreground, the
+ * running daemon is stopped and autostart is uninstalled.
+ *
+ * Daemon mode is not available on Windows — the function silently
+ * defaults to foreground in that case.
+ */
 export async function setupRunMode(opts?: {
   existing?: { runMode: string; autoStart: boolean };
   stepNum?: number;

--- a/src/core/setup/types.ts
+++ b/src/core/setup/types.ts
@@ -1,21 +1,35 @@
+/**
+ * Configurable sections of the setup wizard. Each section maps to a
+ * dedicated setup step that can be run independently during reconfiguration.
+ */
 export type OnboardSection =
   | "channels"
   | "agents"
   | "runMode"
   | "integrations";
 
+/** Action a user can take on an already-configured channel during reconfiguration. */
 export type ConfiguredChannelAction = "modify" | "disable" | "delete" | "skip";
 
+/** Logical identifier for a messaging channel (e.g. "telegram", "discord", "sse"). */
 export type ChannelId = string;
 
+/** Runtime status of a channel, used by the wizard to show current state. */
 export type ChannelStatus = {
   id: ChannelId;
   label: string;
+  /** Whether the channel has been configured (has required credentials). */
   configured: boolean;
+  /** Whether the channel is actively enabled — a channel can be configured but disabled. */
   enabled: boolean;
+  /** Additional context shown in the status line (e.g. "Chat ID: 12345"). */
   hint?: string;
 };
 
+/**
+ * Menu options for the reconfigure wizard's section picker.
+ * Order here determines display order in the CLI menu.
+ */
 export const ONBOARD_SECTION_OPTIONS: Array<{
   value: OnboardSection;
   label: string;
@@ -27,16 +41,22 @@ export const ONBOARD_SECTION_OPTIONS: Array<{
   { value: "integrations", label: "Integrations", hint: "Claude CLI session transfer" },
 ];
 
+/** Display metadata for each built-in channel type. */
 export const CHANNEL_META: Record<string, { label: string; method: string }> = {
   sse: { label: "Desktop App", method: "SSE" },
   telegram: { label: "Telegram", method: "Bot API" },
   discord: { label: "Discord", method: "Bot API" },
 };
 
+/** A community adapter discovered from the OpenACP plugin registry. */
 export interface CommunityAdapterOption {
-  name: string           // npm package name, e.g. "@openacp/adapter-slack"
-  displayName: string    // e.g. "Slack Adapter"
-  icon: string           // e.g. "💬"
+  /** npm package name, e.g. "@openacp/adapter-slack" */
+  name: string
+  /** Human-readable name, e.g. "Slack Adapter" */
+  displayName: string
+  /** Emoji icon for display in the CLI menu */
+  icon: string
+  /** Whether the plugin has been verified by the OpenACP team */
   verified: boolean
 }
 

--- a/src/core/setup/wizard.ts
+++ b/src/core/setup/wizard.ts
@@ -23,6 +23,10 @@ import { protectLocalInstance } from "./git-protect.js";
 
 // ─── Registry discovery ───
 
+/**
+ * Fetches verified community adapter plugins from the OpenACP registry.
+ * Returns an empty array on network failure so setup can proceed without registry access.
+ */
 async function fetchCommunityAdapters(): Promise<CommunityAdapterOption[]> {
   try {
     const client = new RegistryClient()
@@ -42,6 +46,10 @@ async function fetchCommunityAdapters(): Promise<CommunityAdapterOption[]> {
 
 // ─── Desktop App detection ───
 
+/**
+ * Checks whether the OpenACP Desktop App is installed by probing
+ * platform-specific install locations. Used to show status during setup.
+ */
 function checkDesktopAppInstalled(): boolean {
   // TODO: replace with exact app bundle / executable path once the Desktop App ships
   const candidates: string[] = [];
@@ -66,6 +74,23 @@ function checkDesktopAppInstalled(): boolean {
 
 // ─── First-run setup ───
 
+/**
+ * Runs the interactive first-run setup wizard.
+ *
+ * The wizard flows through these steps in order:
+ *   1. Instance naming
+ *   2. Copy-from existing workspace (optional — reuses credentials/settings)
+ *   3. Channel selection and configuration (Telegram, Desktop App, plugins)
+ *   4. Agent installation and default agent selection
+ *   5. Integration setup (Claude CLI session transfer)
+ *   6. Run mode selection (foreground vs daemon)
+ *
+ * On completion, writes config.json, registers the instance in the global
+ * registry, and adds .openacp/ to .gitignore. The wizard is NOT resumable —
+ * if cancelled partway, it must be restarted from scratch.
+ *
+ * @returns `true` if setup completed successfully, `false` if cancelled or failed
+ */
 export async function runSetup(
   configManager: ConfigManager,
   opts?: {
@@ -73,8 +98,10 @@ export async function runSetup(
     settingsManager?: SettingsManager
     pluginRegistry?: PluginRegistry
     instanceName?: string
-    from?: string       // path to copy from (parent dir, not .openacp)
-    instanceRoot?: string  // the .openacp dir being set up
+    /** Path to copy from (parent dir, not .openacp) */
+    from?: string
+    /** The .openacp dir being set up */
+    instanceRoot?: string
   },
 ): Promise<boolean> {
   await printStartBanner();
@@ -515,8 +542,16 @@ async function registerBuiltinPlugins(
 
 // ─── Inheritable keys for copy flow ───
 
+/**
+ * Returns the set of plugin settings keys that are safe to copy between workspaces.
+ *
+ * Only non-secret, structural settings are included. Secrets (tokens, API keys)
+ * are NOT inherited — each workspace must configure its own credentials.
+ *
+ * This map covers built-in plugins only. Community plugins declare their own
+ * inheritable keys in their plugin definition and handle copying themselves.
+ */
 function buildInheritableKeysMap(): Record<string, string[]> {
-  // Hardcoded for built-in plugins — community plugins declare their own
   return {
     '@openacp/tunnel': ['provider', 'maxUserTunnels', 'auth'],
     '@openacp/api-server': ['host'],
@@ -547,6 +582,13 @@ async function selectSection(hasSelection: boolean): Promise<ReconfigureSection>
   ) as ReconfigureSection;
 }
 
+/**
+ * Runs the reconfigure wizard for an existing OpenACP installation.
+ *
+ * Unlike `runSetup`, this presents a section-picker menu and lets users
+ * modify individual sections (channels, agents, run mode, integrations)
+ * in any order. The loop continues until the user selects "Continue".
+ */
 export async function runReconfigure(configManager: ConfigManager, settingsManager?: SettingsManager): Promise<void> {
   await printStartBanner();
   clack.intro("OpenACP — Reconfigure");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,6 +3,13 @@ import type { TurnRouting } from "./sessions/turn-context.js";
 
 export type { TurnRouting };
 
+/**
+ * A file attachment sent to or received from an agent.
+ *
+ * Agents receive attachments as content blocks in their prompt input.
+ * `originalFilePath` preserves the user's original path before any
+ * conversion (e.g., audio transcoding or image resizing).
+ */
 export interface Attachment {
   type: 'image' | 'audio' | 'file';
   filePath: string;
@@ -12,6 +19,13 @@ export interface Attachment {
   originalFilePath?: string;
 }
 
+/**
+ * A message arriving from a channel adapter (Telegram, Slack, SSE, etc.)
+ * destined for a session's agent.
+ *
+ * `routing` controls how the message is dispatched when multiple adapters
+ * are attached to the same session (e.g., which adapter should receive the response).
+ */
 export interface IncomingMessage {
   channelId: string;
   threadId: string;
@@ -21,6 +35,17 @@ export interface IncomingMessage {
   routing?: TurnRouting;
 }
 
+/**
+ * A message flowing from the agent back to channel adapters for display.
+ *
+ * The `type` field determines how the adapter renders the message:
+ * - text/thought/plan/error — rendered as formatted text blocks
+ * - tool_call/tool_update — rendered as collapsible tool activity
+ * - usage — token/cost summary (typically shown in a status bar)
+ * - attachment — binary content (image, audio, file)
+ * - session_end — signals the agent turn is complete
+ * - ACP Phase 2 types (mode_change, config_update, etc.) — interactive controls
+ */
 export interface OutgoingMessage {
   type:
     | "text"
@@ -45,35 +70,62 @@ export interface OutgoingMessage {
   attachment?: Attachment;
 }
 
+/**
+ * A permission request sent by the agent when it needs user approval.
+ *
+ * The agent blocks until the user picks one of the `options`.
+ * PermissionGate holds the request, emits it to adapters via SessionEv,
+ * and resumes the agent with the chosen option when resolved.
+ */
 export interface PermissionRequest {
   id: string;
   description: string;
   options: PermissionOption[];
 }
 
+/** A single choice within a permission request (e.g., "Allow once", "Deny"). */
 export interface PermissionOption {
   id: string;
   label: string;
+  /** Whether this option grants the requested permission. */
   isAllow: boolean;
 }
 
+/**
+ * A notification pushed to the user outside of the normal message flow.
+ *
+ * Used for background alerts when the user isn't actively watching the session
+ * (e.g., agent completed, permission needed, budget warning).
+ */
 export interface NotificationMessage {
   sessionId: string;
   sessionName?: string;
   type: "completed" | "error" | "permission" | "input_required" | "budget_warning";
   summary: string;
+  /** URL to jump directly to the session in the adapter UI. */
   deepLink?: string;
 }
 
+/** A command exposed by the agent, surfaced as interactive buttons in the chat UI. */
 export interface AgentCommand {
   name: string;
   description: string;
   input?: unknown;
 }
 
+/**
+ * Union of all events that an AgentInstance can emit during a prompt turn.
+ *
+ * Each variant maps to an ACP protocol event. AgentInstance translates raw
+ * ACP SDK events into these normalized types, which then flow through
+ * middleware (Hook.AGENT_BEFORE_EVENT) and into SessionBridge for rendering.
+ */
 export type AgentEvent =
+  /** Streamed text content from the agent's response. */
   | { type: "text"; content: string }
+  /** Agent's internal reasoning (displayed in a collapsible block). */
   | { type: "thought"; content: string }
+  /** Agent started or completed a tool invocation. */
   | {
       type: "tool_call";
       id: string;
@@ -86,6 +138,7 @@ export type AgentEvent =
       rawOutput?: unknown;
       meta?: unknown;
     }
+  /** Progress update for an in-flight tool call (partial output, status change). */
   | {
       type: "tool_update";
       id: string;
@@ -98,33 +151,52 @@ export type AgentEvent =
       rawOutput?: unknown;
       meta?: unknown;
     }
+  /** Agent's execution plan with prioritized steps. */
   | { type: "plan"; entries: PlanEntry[] }
+  /** Token usage and cost report for the current turn. */
   | {
       type: "usage";
       tokensUsed?: number;
       contextSize?: number;
       cost?: { amount: number; currency: string };
     }
+  /** Agent updated its available slash commands. */
   | { type: "commands_update"; commands: AgentCommand[] }
+  /** Agent produced an image as output (base64-encoded). */
   | { type: "image_content"; data: string; mimeType: string }
+  /** Agent produced audio as output (base64-encoded). */
   | { type: "audio_content"; data: string; mimeType: string }
+  /** Agent ended the session (no more prompts accepted). */
   | { type: "session_end"; reason: string }
+  /** Agent-level error (non-fatal — session may continue). */
   | { type: "error"; message: string }
+  /** System message injected by OpenACP (not from the agent itself). */
   | { type: "system_message"; message: string }
   // ACP Phase 2 additions
+  /** Agent updated session metadata (title, timestamps). */
   | { type: "session_info_update"; title?: string; updatedAt?: string; _meta?: Record<string, unknown> }
+  /** Agent updated its config options (modes, models, toggles). */
   | { type: "config_option_update"; options: ConfigOption[] }
+  /** Echoed user message chunk — used for cross-adapter input visibility. */
   | { type: "user_message_chunk"; content: string }
+  /** Agent returned a resource's content (file, data). */
   | { type: "resource_content"; uri: string; name: string; text?: string; blob?: string; mimeType?: string }
+  /** Agent returned a link to a resource (without inline content). */
   | { type: "resource_link"; uri: string; name: string; mimeType?: string; title?: string; description?: string; size?: number }
+  /** Signals that TTS output should be stripped from the response. */
   | { type: "tts_strip" };
 
+/** A single step in an agent's execution plan. */
 export interface PlanEntry {
   content: string;
   status: "pending" | "in_progress" | "completed";
   priority: "high" | "medium" | "low";
 }
 
+/**
+ * Static definition of an agent — the command, args, and environment
+ * needed to spawn its subprocess.
+ */
 export interface AgentDefinition {
   name: string;
   command: string;
@@ -135,8 +207,10 @@ export interface AgentDefinition {
 
 // --- Agent Registry Types ---
 
+/** How the agent is distributed and installed. */
 export type AgentDistribution = "npx" | "uvx" | "binary" | "custom";
 
+/** An agent that has been installed locally and is ready to spawn. */
 export interface InstalledAgent {
   registryId: string | null;
   name: string;
@@ -147,9 +221,11 @@ export interface InstalledAgent {
   env: Record<string, string>;
   workingDirectory?: string;
   installedAt: string;
+  /** Absolute path to the binary on disk (only for "binary" distribution). */
   binaryPath: string | null;
 }
 
+/** Platform-specific binary download target from the agent registry. */
 export interface RegistryBinaryTarget {
   archive: string;
   cmd: string;
@@ -157,12 +233,15 @@ export interface RegistryBinaryTarget {
   env?: Record<string, string>;
 }
 
+/** Distribution methods available for a registry agent. */
 export interface RegistryDistribution {
   npx?: { package: string; args?: string[]; env?: Record<string, string> };
   uvx?: { package: string; args?: string[]; env?: Record<string, string> };
+  /** Platform → arch → binary target mapping. */
   binary?: Record<string, RegistryBinaryTarget>;
 }
 
+/** An agent entry from the remote agent registry. */
 export interface RegistryAgent {
   id: string;
   name: string;
@@ -176,6 +255,7 @@ export interface RegistryAgent {
   distribution: RegistryDistribution;
 }
 
+/** Merged view of a registry agent with local install status. */
 export interface AgentListItem {
   key: string;
   registryId: string;
@@ -185,15 +265,18 @@ export interface AgentListItem {
   distribution: AgentDistribution;
   installed: boolean;
   available: boolean;
+  /** Runtime dependencies that are missing on this machine. */
   missingDeps?: string[];
 }
 
+/** Result of checking whether an agent can run on this machine. */
 export interface AvailabilityResult {
   available: boolean;
   reason?: string;
   missing?: Array<{ label: string; installHint: string }>;
 }
 
+/** Callbacks for reporting agent installation progress to the UI. */
 export interface InstallProgress {
   onStart(agentId: string, agentName: string): void | Promise<void>;
   onStep(step: string): void | Promise<void>;
@@ -202,6 +285,7 @@ export interface InstallProgress {
   onError(error: string, hint?: string): void | Promise<void>;
 }
 
+/** Result of an agent install operation. */
 export interface InstallResult {
   ok: boolean;
   agentKey: string;
@@ -210,6 +294,16 @@ export interface InstallResult {
   setupSteps?: string[];
 }
 
+/**
+ * Session lifecycle status.
+ *
+ * Valid transitions:
+ *   initializing → active | error
+ *   active       → error | finished | cancelled
+ *   error        → active | cancelled  (recovery or user cancels)
+ *   cancelled    → active              (user resumes)
+ *   finished     → (terminal — no transitions)
+ */
 export type SessionStatus =
   | "initializing"
   | "active"
@@ -217,6 +311,7 @@ export type SessionStatus =
   | "finished"
   | "error";
 
+/** Record of an agent switch within a session (for history tracking). */
 export interface AgentSwitchEntry {
   agentName: string;
   agentSessionId: string;
@@ -224,6 +319,12 @@ export interface AgentSwitchEntry {
   promptCount: number;
 }
 
+/**
+ * Persisted session state — serialized to the session store (JSON file).
+ *
+ * Generic parameter `P` is the primary adapter's platform-specific data
+ * (e.g., TelegramPlatformData). Additional adapters store data in `platforms`.
+ */
 export interface SessionRecord<P = Record<string, unknown>> {
   sessionId: string;
   agentSessionId: string;
@@ -260,12 +361,14 @@ export interface SessionRecord<P = Record<string, unknown>> {
   };
 }
 
+/** Telegram-specific data stored per session in the session record. */
 export interface TelegramPlatformData {
   topicId: number;
   skillMsgId?: number;
   controlMsgId?: number;
 }
 
+/** A single token usage data point for cost tracking. */
 export interface UsageRecord {
   id: string;
   sessionId: string;
@@ -276,6 +379,7 @@ export interface UsageRecord {
   timestamp: string;
 }
 
+/** Usage event emitted on the EventBus for the usage-tracking plugin. */
 export interface UsageRecordEvent {
   sessionId: string;
   agentName: string;
@@ -288,31 +392,40 @@ export interface UsageRecordEvent {
 
 // --- ACP Protocol Types (Phase 2) ---
 
-// Session Modes
+/** An agent operating mode (e.g., "code", "architect", "ask"). */
 export interface SessionMode {
   id: string;
   name: string;
   description?: string;
 }
 
+/** Current mode and all available modes for a session. */
 export interface SessionModeState {
   currentModeId: string;
   availableModes: SessionMode[];
 }
 
-// Config Options (matches ACP SDK SessionConfigOption)
+/** A single choice within a select-type config option. */
 export interface ConfigSelectChoice {
   value: string;
   name: string;
   description?: string;
 }
 
+/** A named group of select choices (for categorized dropdowns). */
 export interface ConfigSelectGroup {
   group: string;
   name: string;
   options: ConfigSelectChoice[];
 }
 
+/**
+ * Agent-exposed configuration options surfaced as interactive controls in chat.
+ *
+ * These are settings the agent advertises via the ACP config_option_update event.
+ * Adapters render them as select menus, toggles, etc. in the chat UI.
+ * When the user changes a value, OpenACP sends a setConfigOption request to the agent.
+ */
 export type ConfigOption =
   | {
       id: string;
@@ -334,27 +447,37 @@ export type ConfigOption =
       _meta?: Record<string, unknown>;
     };
 
+/** Value payload for updating a config option on the agent. */
 export type SetConfigOptionValue =
   | { type: "select"; value: string }
   | { type: "boolean"; value: boolean };
 
 // Model Selection
+
+/** An AI model available for the agent to use. */
 export interface ModelInfo {
   id: string;
   name: string;
   description?: string;
 }
 
+/** Current model and all available models for a session. */
 export interface SessionModelState {
   currentModelId: string;
   availableModels: ModelInfo[];
 }
 
-// Agent Capabilities (from initialize response)
+/**
+ * Capabilities advertised by the agent in its initialize response.
+ *
+ * These determine which ACP features the agent supports — OpenACP uses
+ * them to enable/disable UI features (e.g., session list, fork, MCP).
+ */
 export interface AgentCapabilities {
   name: string;
   title?: string;
   version?: string;
+  /** Whether the agent supports loading (resuming) existing sessions. */
   loadSession?: boolean;
   promptCapabilities?: {
     image?: boolean;
@@ -370,7 +493,7 @@ export interface AgentCapabilities {
   authMethods?: AuthMethod[];
 }
 
-// Session Response (modes, configOptions, models from session/new response)
+/** Response from the agent when creating a new session. */
 export interface NewSessionResponse {
   sessionId: string;
   modes?: SessionModeState;
@@ -379,16 +502,29 @@ export interface NewSessionResponse {
 }
 
 // Auth
+
+/** Authentication method supported by the agent. */
 export type AuthMethod =
   | { type: "agent" }
   | { type: "env_var"; name: string; description?: string }
   | { type: "terminal" };
 
+/** Request to authenticate with a specific method. */
 export interface AuthenticateRequest {
   methodId: string;
 }
 
 // Prompt Response
+
+/**
+ * Reason why the agent stopped generating.
+ *
+ * - end_turn: agent completed its response normally
+ * - max_tokens / max_turn_requests: hit a limit
+ * - refusal: agent declined the request
+ * - cancelled / interrupted: user or system stopped the prompt
+ * - error: agent encountered an error
+ */
 export type StopReason =
   | "end_turn"
   | "max_tokens"
@@ -398,12 +534,15 @@ export type StopReason =
   | "error"
   | "interrupted";
 
+/** Final response from the agent after a prompt completes. */
 export interface PromptResponse {
   stopReason: StopReason;
   _meta?: Record<string, unknown>;
 }
 
 // Content Blocks (for prompt input)
+
+/** A content block within a prompt message sent to the agent. */
 export type ContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; data: string; mimeType: string; uri?: string }
@@ -412,6 +551,8 @@ export type ContentBlock =
   | { type: "resource_link"; uri: string; name: string; mimeType?: string; title?: string; description?: string; size?: number };
 
 // Session List
+
+/** A session entry returned by the agent's session list endpoint. */
 export interface SessionListItem {
   sessionId: string;
   title?: string;
@@ -420,12 +561,15 @@ export interface SessionListItem {
   _meta?: Record<string, unknown>;
 }
 
+/** Paginated response from the agent's session list endpoint. */
 export interface SessionListResponse {
   sessions: SessionListItem[];
   nextCursor?: string;
 }
 
 // MCP Server Config
+
+/** Configuration for connecting to an MCP (Model Context Protocol) server. */
 export type McpServerConfig =
   | { type?: "stdio"; name: string; command: string; args?: string[]; env?: Record<string, string> }
   | { type: "http"; name: string; url: string; headers?: Record<string, string> }

--- a/src/core/utils/apply-patch-detection.ts
+++ b/src/core/utils/apply-patch-detection.ts
@@ -1,15 +1,34 @@
+/**
+ * Detection utilities for apply_patch tool calls.
+ *
+ * Some agents (e.g., OpenCode) use an "apply_patch" tool with kind "other"
+ * to modify files via unified diff patches. These need special handling:
+ * - Security: permission gating must treat them as write operations
+ * - File preview: extractFileInfo must parse the patch output format
+ *   instead of the standard read/edit/write content format
+ */
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
 }
 
+/** Check if rawInput contains a patchText/patch_text field (indicates apply_patch semantics). */
 export function hasApplyPatchPatchText(rawInput: unknown): boolean {
   const input = asRecord(rawInput);
   return !!input && (typeof input.patchText === "string" || typeof input.patch_text === "string");
 }
 
+/**
+ * Determine if a tool call is an apply_patch operation.
+ *
+ * Matches either by explicit tool name ("apply_patch") or by the presence
+ * of a patchText field in rawInput — both indicate file modification via
+ * unified diff that requires write-level permission gating.
+ */
 export function isApplyPatchOtherTool(kind: string | undefined, name: string, rawInput: unknown): boolean {
+  // Only "other" kind tools can be apply_patch — read/edit/write are handled normally
   if (kind !== "other") return false;
   if (name.toLowerCase() === "apply_patch") return true;
   return hasApplyPatchPatchText(rawInput);

--- a/src/core/utils/bypass-detection.ts
+++ b/src/core/utils/bypass-detection.ts
@@ -1,8 +1,20 @@
+/**
+ * Detection for permission-bypass configuration values.
+ *
+ * When a user sets an agent's permission mode to a bypass value (e.g., "yolo",
+ * "dangerous"), ALL tool calls are auto-approved without prompting. This is
+ * distinct from "dontask"/"dont_ask"/"skip" which DENY unknown permissions
+ * rather than approving them.
+ *
+ * Used by PermissionGate to determine whether to show permission prompts
+ * or auto-approve.
+ */
+
 /** Keywords that indicate a permission-bypass (auto-approve) value.
  * NOTE: "dontask"/"dont_ask"/"skip" are NOT bypass — they DENY unknown permissions. */
 export const BYPASS_KEYWORDS = ['bypass', 'dangerous', 'auto_accept', 'yolo']
 
-/** Returns true if the given value string contains a bypass keyword (case-insensitive) */
+/** Returns true if the given value string contains a bypass keyword (case-insensitive). */
 export function isPermissionBypass(value: string): boolean {
   const lower = value.toLowerCase()
   return BYPASS_KEYWORDS.some(kw => lower.includes(kw))

--- a/src/core/utils/debug-tracer.ts
+++ b/src/core/utils/debug-tracer.ts
@@ -7,12 +7,15 @@ export type TraceLayer = "acp" | "core" | "telegram";
 const DEBUG_ENABLED = process.env.OPENACP_DEBUG === "true" || process.env.OPENACP_DEBUG === "1";
 
 /**
- * Per-session debug trace logger. Writes JSONL files to <workingDirectory>/.log/.
- * Only active when OPENACP_DEBUG=true. Zero overhead when disabled.
+ * Per-session debug trace logger that writes JSONL files to `<workingDirectory>/.log/`.
  *
- * Note: Uses appendFileSync for simplicity. This blocks the event loop briefly per write,
- * which is acceptable for a debug-only tool. The DEBUG_ENABLED guard ensures zero overhead
- * in production.
+ * Only active when `OPENACP_DEBUG=true` is set in the environment.
+ * Each trace layer (acp, core, telegram) gets its own file, making it easy
+ * to inspect protocol-level, core-level, or adapter-level events separately.
+ *
+ * Uses appendFileSync for simplicity — this blocks the event loop briefly per write,
+ * which is acceptable for a debug-only tool. The DEBUG_ENABLED guard ensures zero
+ * overhead in production.
  */
 export class DebugTracer {
   private dirCreated = false;
@@ -25,6 +28,12 @@ export class DebugTracer {
     this.logDir = path.join(workingDirectory, ".log");
   }
 
+  /**
+   * Write a timestamped JSONL entry to the trace file for the given layer.
+   *
+   * Handles circular references gracefully and silently swallows errors —
+   * debug logging must never crash the application.
+   */
   log(layer: TraceLayer, data: Record<string, unknown>): void {
     try {
       if (!this.dirCreated) {
@@ -32,6 +41,7 @@ export class DebugTracer {
         this.dirCreated = true;
       }
       const filePath = path.join(this.logDir, `${this.sessionId}_${layer}.jsonl`);
+      // WeakSet tracks seen objects to replace circular references with "[Circular]"
       const seen = new WeakSet();
       const line =
         JSON.stringify({ ts: Date.now(), ...data }, (_key, value) => {
@@ -55,7 +65,9 @@ export class DebugTracer {
 
 /**
  * Create a DebugTracer if debug mode is enabled, otherwise return null.
- * The DEBUG_ENABLED const is evaluated once at module load time from process.env.OPENACP_DEBUG.
+ *
+ * The DEBUG_ENABLED const is evaluated once at module load time from
+ * `process.env.OPENACP_DEBUG`, so there is no per-call overhead when disabled.
  */
 export function createDebugTracer(sessionId: string, workingDirectory: string): DebugTracer | null {
   if (!DEBUG_ENABLED) return null;

--- a/src/core/utils/extract-file-info.ts
+++ b/src/core/utils/extract-file-info.ts
@@ -1,13 +1,31 @@
 import { isApplyPatchOtherTool } from './apply-patch-detection.js'
 
+/**
+ * Extracted file content from an agent tool call.
+ *
+ * Used by the file-service plugin to provide live file previews —
+ * when an agent reads, edits, or writes a file, this structure
+ * captures what changed so adapters can show inline diffs or previews.
+ */
 export interface FileInfo {
   filePath: string
   content: string
+  /** Previous content before an edit — enables diff rendering in adapters. */
   oldContent?: string
 }
 
 /**
- * Extract file path and content from ACP tool_call/tool_update content.
+ * Extract file path and content from ACP tool_call/tool_update payloads.
+ *
+ * Different agents (Claude Code, OpenCode, etc.) encode file operations in
+ * varying formats. This function normalizes them all into a single FileInfo
+ * structure by trying multiple extraction strategies in priority order:
+ *
+ *   1. Agent-specific _meta extensions (highest fidelity — raw file content)
+ *   2. rawInput fields (file_path + content)
+ *   3. Known ACP content patterns (diff blocks, text blocks, content wrappers)
+ *
+ * Returns null if the tool call doesn't involve a file operation.
  *
  * ACP content formats observed:
  * - Diff block: [{ type: "diff", path: "...", oldText: "...", newText: "..." }]
@@ -24,7 +42,7 @@ export function extractFileInfo(
   meta?: unknown,
   rawOutput?: unknown,
 ): FileInfo | null {
-  // Only process file-related tool kinds
+  // apply_patch is a special "other" tool that modifies files via patch text
   if (isApplyPatchOtherTool(kind, name, rawInput)) {
     return parseApplyPatchRawOutput(rawOutput)
   }
@@ -97,7 +115,7 @@ export function extractFileInfo(
 
   if (!info) return null
 
-  // Infer file path from tool name if not in content
+  // Infer file path from tool name if not in content (e.g., "Read src/index.ts")
   if (!info.filePath) {
     const pathMatch = name.match(/(?:Read|Edit|Write|View)\s+(.+)/i)
     if (pathMatch) info.filePath = pathMatch[1].trim()
@@ -107,6 +125,12 @@ export function extractFileInfo(
   return info as FileInfo
 }
 
+/**
+ * Extract file info from apply_patch rawOutput format.
+ *
+ * Picks the file with the most changes (additions + deletions) as
+ * the primary file to preview — patches can touch multiple files.
+ */
 function parseApplyPatchRawOutput(rawOutput: unknown): FileInfo | null {
   if (!rawOutput || typeof rawOutput !== 'object' || Array.isArray(rawOutput)) return null
 
@@ -117,6 +141,7 @@ function parseApplyPatchRawOutput(rawOutput: unknown): FileInfo | null {
   const files = (metadata as Record<string, unknown>).files
   if (!Array.isArray(files)) return null
 
+  // Sort by change size (descending) to pick the most-changed file for preview
   const sortedFiles = [...files].sort((a, b) => getApplyPatchFileScore(b) - getApplyPatchFileScore(a))
 
   for (const file of sortedFiles) {
@@ -144,6 +169,7 @@ function parseApplyPatchRawOutput(rawOutput: unknown): FileInfo | null {
   return null
 }
 
+/** Score a file by total change volume (additions + deletions) for ranking. */
 function getApplyPatchFileScore(file: unknown): number {
   if (!file || typeof file !== 'object' || Array.isArray(file)) return 0
   const f = file as Record<string, unknown>
@@ -154,8 +180,9 @@ function getApplyPatchFileScore(file: unknown): number {
 
 /**
  * Resolve toolResponse from agent-specific _meta namespaces.
- * Supports: _meta.claudeCode.toolResponse (Claude Code)
- * Add new agents here as they adopt the pattern.
+ *
+ * Currently supports: `_meta.claudeCode.toolResponse` (Claude Code).
+ * Add new agent namespaces here as they adopt the pattern.
  */
 function resolveToolResponse(meta: Record<string, unknown>): Record<string, unknown> | undefined {
   // Claude Code namespace
@@ -170,13 +197,19 @@ function resolveToolResponse(meta: Record<string, unknown>): Record<string, unkn
   return undefined
 }
 
+/**
+ * Recursively parse ACP content structures into a partial FileInfo.
+ *
+ * Handles all known content shapes: plain strings, diff blocks,
+ * content wrappers, text blocks, and nested input/output objects.
+ */
 function parseContent(content: unknown): Partial<FileInfo> | null {
   if (typeof content === 'string') {
     return { content }
   }
 
   if (Array.isArray(content)) {
-    // Array of content blocks — try each
+    // Return the first block that yields a result — order matters for priority
     for (const block of content) {
       const result = parseContent(block)
       if (result?.content || result?.filePath) return result

--- a/src/core/utils/install-binary.ts
+++ b/src/core/utils/install-binary.ts
@@ -12,6 +12,12 @@ const log = createChildLogger({ module: 'binary-installer' })
 const DEFAULT_BIN_DIR = path.join(os.homedir(), '.openacp', 'bin')
 const IS_WINDOWS = os.platform() === 'win32'
 
+/**
+ * Specification for a binary that can be auto-downloaded from GitHub releases.
+ *
+ * Used by ensureBinary() to resolve the correct download URL for the
+ * current platform/architecture and handle archive extraction if needed.
+ */
 export interface BinarySpec {
   name: string
   /** GitHub base URL for releases, e.g. "https://github.com/jqlang/jq/releases/latest/download" */
@@ -22,6 +28,11 @@ export interface BinarySpec {
   isArchive?: (url: string) => boolean
 }
 
+/**
+ * Download a file via HTTPS with redirect following and size limit enforcement.
+ *
+ * Cleans up partial downloads on failure to avoid leaving corrupt files.
+ */
 function downloadFile(url: string, dest: string, maxRedirects = 10): Promise<string> {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest)
@@ -54,6 +65,7 @@ function downloadFile(url: string, dest: string, maxRedirects = 10): Promise<str
         return
       }
 
+      // Enforce size limit to prevent malicious or oversized downloads
       let totalBytes = 0
       const request = response
 
@@ -85,6 +97,7 @@ function downloadFile(url: string, dest: string, maxRedirects = 10): Promise<str
   })
 }
 
+/** Resolve the download URL for the current platform and architecture. */
 function getDownloadUrl(spec: BinarySpec): string {
   const platform = os.platform()
   const arch = os.arch()
@@ -96,10 +109,15 @@ function getDownloadUrl(spec: BinarySpec): string {
 }
 
 /**
- * Ensure a binary is available.
- * 1. Check PATH first (respects user's system install)
- * 2. Check ~/.openacp/bin/
- * 3. Download from GitHub releases
+ * Ensure a binary is available, downloading it from GitHub if needed.
+ *
+ * Resolution order:
+ *   1. System PATH — respects user's existing install
+ *   2. ~/.openacp/bin/ — previously downloaded by OpenACP
+ *   3. Download from GitHub releases — fetch, verify, extract if needed
+ *
+ * For archives (.tgz), tar contents are validated before extraction
+ * to prevent path traversal attacks.
  */
 export async function ensureBinary(spec: BinarySpec, binDir?: string): Promise<string> {
   const resolvedBinDir = binDir ?? DEFAULT_BIN_DIR
@@ -130,6 +148,7 @@ export async function ensureBinary(spec: BinarySpec, binDir?: string): Promise<s
   await downloadFile(url, downloadDest)
 
   if (isArchive) {
+    // Validate tar contents before extraction to prevent path traversal
     const listing = execFileSync('tar', ['-tf', downloadDest], { stdio: 'pipe' })
       .toString().trim().split("\n").filter(Boolean);
     validateTarContents(listing, resolvedBinDir);

--- a/src/core/utils/install-jq.ts
+++ b/src/core/utils/install-jq.ts
@@ -1,5 +1,6 @@
 import { ensureBinary, type BinarySpec } from './install-binary.js'
 
+/** Platform/arch mapping for jq binary downloads from GitHub releases. */
 const JQ_SPEC: BinarySpec = {
   name: 'jq',
   githubBaseUrl: 'https://github.com/jqlang/jq/releases/latest/download',
@@ -18,6 +19,13 @@ const JQ_SPEC: BinarySpec = {
   },
 }
 
+/**
+ * Ensure jq is available, downloading from GitHub releases if not found.
+ *
+ * jq is used for JSON processing in agent tool output parsing.
+ * Delegates to ensureBinary() which checks PATH, then ~/.openacp/bin/,
+ * then downloads if needed.
+ */
 export async function ensureJq(): Promise<string> {
   return ensureBinary(JQ_SPEC)
 }

--- a/src/core/utils/log.ts
+++ b/src/core/utils/log.ts
@@ -7,6 +7,9 @@ import type { LoggingConfig } from '../config/config.js'
 export type Logger = pino.Logger
 
 // --- Default console-only logger (pre-init) ---
+// Before initLogger() is called (e.g., during module-level imports),
+// a basic pino-pretty logger writes to stderr. initLogger() replaces it
+// with a multi-target logger (console + rolling file).
 let rootLogger: pino.Logger = pino({
   level: 'debug',
   transport: { target: 'pino-pretty', options: { colorize: true, translateTime: 'SYS:standard', destination: 2 } },
@@ -20,6 +23,9 @@ function expandHome(p: string): string {
 }
 
 // --- Variadic wrapper for backward compatibility ---
+// Pino's API requires (obj, msg) or (msg) — this wrapper allows
+// callers to use log.info(obj, ...strings) or log.info(...strings),
+// matching the more permissive console.log-style API.
 function wrapVariadic(logger: pino.Logger) {
   return {
     info: (...args: unknown[]) => {
@@ -73,6 +79,14 @@ export const log = wrapVariadic(rootLogger)
 let muteCount = 0
 let savedLevel = 'info'
 
+/**
+ * Suppress all log output. Calls are ref-counted — each muteLogger()
+ * must be balanced by an unmuteLogger(). Used during interactive CLI
+ * prompts (e.g., setup wizard) to avoid log noise in the terminal.
+ *
+ * Must always be paired with a corresponding `unmuteLogger()` call;
+ * otherwise the logger remains permanently silenced.
+ */
 export function muteLogger(): void {
   if (muteCount === 0) {
     savedLevel = rootLogger.level
@@ -81,6 +95,7 @@ export function muteLogger(): void {
   muteCount++
 }
 
+/** Decrement the mute ref count and restore log level when it reaches zero. */
 export function unmuteLogger(): void {
   muteCount--
   if (muteCount <= 0) {
@@ -91,6 +106,15 @@ export function unmuteLogger(): void {
 
 // --- Public API ---
 
+/**
+ * Initialize the root logger with file + console output.
+ *
+ * Sets up a multi-target pino transport: pino-pretty to stderr (for humans)
+ * and pino-roll to a rotating log file (for persistence). Also creates
+ * the sessions/ subdirectory for per-session log files.
+ *
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
 export function initLogger(config: LoggingConfig): Logger {
   if (initialized) return rootLogger
 
@@ -145,10 +169,14 @@ export function setLogLevel(level: string): void {
   rootLogger.level = level
 }
 
+/**
+ * Create a child logger scoped to a module (e.g., "core", "session", "telegram").
+ *
+ * Returns a Proxy that always delegates to the current rootLogger — this
+ * ensures child loggers created at module-level (before initLogger runs)
+ * pick up the initialized logger with proper transports once it's ready.
+ */
 export function createChildLogger(context: { module: string; [key: string]: unknown }): Logger {
-  // Return a proxy that always delegates to the current rootLogger.
-  // This ensures child loggers created at module-level (before initLogger)
-  // pick up the initialized logger with pino-pretty transport.
   return new Proxy({} as Logger, {
     get(_target, prop, receiver) {
       const child = rootLogger.child(context)
@@ -158,6 +186,16 @@ export function createChildLogger(context: { module: string; [key: string]: unkn
   })
 }
 
+/**
+ * Create a per-session logger that writes to both the combined log and
+ * a session-specific file (`<logDir>/sessions/<sessionId>.log`).
+ *
+ * This dual-write pattern allows operators to view all logs in one place
+ * (combined log) while also being able to inspect a single session's
+ * activity in isolation (session file).
+ *
+ * Falls back to a simple child logger if the session log file can't be created.
+ */
 export function createSessionLogger(sessionId: string, parentLogger: Logger): Logger {
   const sessionLogDir = logDir ? path.join(logDir, 'sessions') : undefined
   if (!sessionLogDir) {
@@ -210,6 +248,7 @@ export function createSessionLogger(sessionId: string, parentLogger: Logger): Lo
   }
 }
 
+/** Close the per-session log file destination to release the file handle. */
 export function closeSessionLogger(logger: Logger): void {
   const dest = (logger as any).__sessionDest
   if (dest && typeof dest.destroy === 'function') {
@@ -217,6 +256,12 @@ export function closeSessionLogger(logger: Logger): void {
   }
 }
 
+/**
+ * Flush and close the root logger transport.
+ *
+ * Resets all state so the logger can be re-initialized (e.g., after restart).
+ * Waits up to 3 seconds for the transport to close gracefully.
+ */
 export async function shutdownLogger(): Promise<void> {
   if (!initialized) return
 
@@ -241,6 +286,12 @@ export async function shutdownLogger(): Promise<void> {
   }
 }
 
+/**
+ * Delete session log files older than the given retention period.
+ *
+ * Called during startup to prevent unbounded disk usage from accumulated
+ * per-session log files.
+ */
 export async function cleanupOldSessionLogs(retentionDays: number): Promise<void> {
   if (!logDir) return
 

--- a/src/core/utils/read-text-file.ts
+++ b/src/core/utils/read-text-file.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 
 /**
  * Read a text file, optionally returning only a range of lines.
- * Pure utility — no dependencies on plugin code.
+ *
+ * The `line` and `limit` options enable partial file reads — used by the
+ * file-service plugin when agents request specific line ranges (e.g.,
+ * "read lines 50-100 of config.ts"). This avoids sending entire large
+ * files over the ACP protocol when the agent only needs a slice.
  */
 export async function readTextFileWithRange(
   filePath: string,
@@ -11,6 +15,7 @@ export async function readTextFileWithRange(
   const content = await fs.promises.readFile(filePath, "utf-8");
   if (!options?.line && !options?.limit) return content;
   const lines = content.split("\n");
+  // ACP line numbers are 1-based; array indices are 0-based
   const start = Math.max(0, (options.line ?? 1) - 1);
   const end = options.limit ? start + options.limit : lines.length;
   return lines.slice(start, end).join("\n");

--- a/src/core/utils/stderr-capture.ts
+++ b/src/core/utils/stderr-capture.ts
@@ -1,8 +1,17 @@
+/**
+ * Rolling buffer that captures the last N lines of an agent subprocess's stderr.
+ *
+ * Agent stdout carries the ACP protocol (JSON-RPC); stderr is used for
+ * debug/diagnostic output. This capture provides context when the agent
+ * crashes or errors — the last lines of stderr are included in error
+ * messages shown to the user.
+ */
 export class StderrCapture {
   private lines: string[] = []
 
   constructor(private maxLines: number = 50) {}
 
+  /** Append a chunk of stderr output, splitting on newlines and trimming to maxLines. */
   append(chunk: string): void {
     this.lines.push(...chunk.split('\n').filter(Boolean))
     if (this.lines.length > this.maxLines) {
@@ -10,6 +19,7 @@ export class StderrCapture {
     }
   }
 
+  /** Return all captured lines joined as a single string. */
   getLastLines(): string {
     return this.lines.join('\n')
   }

--- a/src/core/utils/streams.ts
+++ b/src/core/utils/streams.ts
@@ -1,3 +1,13 @@
+// The ACP SDK uses the Web Streams API (ReadableStream / WritableStream),
+// but Node's child_process.spawn returns Node streams. These adapters bridge
+// the two so AgentInstance can pipe subprocess stdio through the ACP SDK.
+
+/**
+ * Wrap a Node.js WritableStream as a Web API WritableStream.
+ *
+ * Handles backpressure by waiting for the 'drain' event when the Node
+ * stream's internal buffer is full.
+ */
 export function nodeToWebWritable(nodeStream: NodeJS.WritableStream): WritableStream<Uint8Array> {
   return new WritableStream<Uint8Array>({
     write(chunk) {
@@ -19,6 +29,11 @@ export function nodeToWebWritable(nodeStream: NodeJS.WritableStream): WritableSt
   });
 }
 
+/**
+ * Wrap a Node.js ReadableStream as a Web API ReadableStream.
+ *
+ * Converts Node Buffer chunks to Uint8Array for Web Streams compatibility.
+ */
 export function nodeToWebReadable(nodeStream: NodeJS.ReadableStream): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {

--- a/src/core/utils/typed-emitter.ts
+++ b/src/core/utils/typed-emitter.ts
@@ -1,5 +1,10 @@
 /**
- * A minimal, generic typed event emitter.
+ * Type-safe event emitter where the event map is enforced at compile time.
+ *
+ * Unlike Node's EventEmitter, event names and listener signatures are
+ * validated by TypeScript — no stringly-typed events. Supports pause/resume
+ * with buffering, used by Session and EventBus to defer events during
+ * initialization or agent switches.
  *
  * Usage:
  *   interface MyEvents {
@@ -19,6 +24,7 @@ export class TypedEmitter<T extends Record<string & keyof T, (...args: any[]) =>
   private paused = false
   private buffer: Array<{ event: keyof T; args: unknown[] }> = []
 
+  /** Register a listener for the given event. Returns `this` for chaining. */
   on<K extends keyof T>(event: K, listener: T[K]): this {
     let set = this.listeners.get(event)
     if (!set) {
@@ -29,11 +35,18 @@ export class TypedEmitter<T extends Record<string & keyof T, (...args: any[]) =>
     return this
   }
 
+  /** Remove a specific listener for the given event. */
   off<K extends keyof T>(event: K, listener: T[K]): this {
     this.listeners.get(event)?.delete(listener)
     return this
   }
 
+  /**
+   * Emit an event to all registered listeners.
+   *
+   * When paused, events are buffered (up to MAX_BUFFER_SIZE) unless
+   * the passthrough filter allows them through immediately.
+   */
   emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): void {
     if (this.paused) {
       // Check passthrough filter — some events may bypass the pause
@@ -84,6 +97,7 @@ export class TypedEmitter<T extends Record<string & keyof T, (...args: any[]) =>
     return this.buffer.length
   }
 
+  /** Remove all listeners for a specific event, or all events if none specified. */
   removeAllListeners(event?: keyof T): void {
     if (event) {
       this.listeners.delete(event)
@@ -92,6 +106,7 @@ export class TypedEmitter<T extends Record<string & keyof T, (...args: any[]) =>
     }
   }
 
+  /** Deliver an event to listeners, isolating errors so one broken listener doesn't break others. */
   private deliver(event: keyof T, args: unknown[]): void {
     const set = this.listeners.get(event)
     if (!set) return

--- a/src/data/product-guide.ts
+++ b/src/data/product-guide.ts
@@ -1,6 +1,15 @@
 /**
- * OpenACP Product Guide — comprehensive reference for the AI assistant.
- * The assistant reads this at runtime to answer user questions about features.
+ * OpenACP Product Guide — comprehensive reference text injected into the AI assistant's system prompt.
+ *
+ * The assistant (in the Assistant topic/thread) reads this at startup to answer user questions
+ * about features, CLI commands, configuration, and troubleshooting without hitting the network.
+ *
+ * **How it's used:** The assistant plugin reads `PRODUCT_GUIDE` and prepends it to the system
+ * prompt so the AI has full product knowledge baked in, not fetched per-session.
+ *
+ * **How to update:** Edit the Markdown content below. Keep it accurate with the current feature set —
+ * outdated entries cause the assistant to give wrong answers. Sections use `---` dividers and
+ * `##` headings so the assistant can navigate the content efficiently.
  */
 export const PRODUCT_GUIDE = `
 # OpenACP — Product Guide

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,37 @@
-export * from './core/index.js'
-export { PRODUCT_GUIDE } from './data/product-guide.js'
-export { TelegramAdapter } from './plugins/telegram/adapter.js'
-export { AgentCatalog } from "./core/agents/agent-catalog.js";
-export { AgentStore } from "./core/agents/agent-store.js";
-export type { InstalledAgent, RegistryAgent, AgentListItem } from "./core/types.js";
+// Public API surface for the `@openacp/cli` package.
+//
+// Most exports come from `core/index.ts` which provides the full set of
+// core modules, plugin types, and adapter primitives for plugin authors.
+// The exports below supplement that with top-level package-specific symbols.
 
+export * from './core/index.js'
+
+/** Full product guide text injected into the assistant's system prompt at runtime. */
+export { PRODUCT_GUIDE } from './data/product-guide.js'
+
+/**
+ * Telegram adapter implementation.
+ *
+ * Re-exported here for consumers who need to reference the class directly
+ * (e.g., in tests or custom adapter setups) without importing from the deep plugin path.
+ */
+export { TelegramAdapter } from './plugins/telegram/adapter.js'
+
+/**
+ * Manages the local catalog of installed agents (read/write to agents.json).
+ *
+ * Plugin authors building agent-aware features should use this to query
+ * which agents are installed and their configurations.
+ */
+export { AgentCatalog } from "./core/agents/agent-catalog.js";
+
+/**
+ * Low-level persistent store for agent records.
+ *
+ * AgentCatalog is the preferred higher-level interface; AgentStore is
+ * exported for advanced use cases that require direct record access.
+ */
+export { AgentStore } from "./core/agents/agent-store.js";
+
+/** Agent-related types shared across the public API. */
+export type { InstalledAgent, RegistryAgent, AgentListItem } from "./core/types.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+// Server entry point — orchestrates the full startup sequence:
+//   1. Instance context resolution (finds the .openacp/ workspace root)
+//   2. Config load + Zod validation
+//   3. Plugin boot in dependency order (services → infrastructure → adapters)
+//   4. Adapter wiring from ServiceRegistry into OpenACPCore
+//   5. Signal handlers for graceful shutdown (SIGINT / SIGTERM)
+
 import path from 'node:path'
 import { ConfigManager } from './core/config/config.js'
 import type { InstanceContext } from './core/instance/instance-context.js'
@@ -19,16 +26,41 @@ import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import { BusEvent } from './core/events.js'
 
+/** Exit code that signals the process manager (or self-respawn logic) to restart the server. */
 export const RESTART_EXIT_CODE = 75
+
+// Module-level guard — prevents re-entrant shutdown if a second signal arrives mid-teardown.
 let shuttingDown = false
 
-
+/**
+ * Options for programmatic server startup.
+ *
+ * All fields are optional: when omitted, startServer() resolves them
+ * from the environment (OPENACP_INSTANCE_ROOT or CWD traversal).
+ */
 export interface StartServerOptions {
+  /** Absolute path to a dev plugin directory — enables hot-reload during plugin development. */
   devPluginPath?: string
+  /** Disable file-watcher hot-reload for the dev plugin (useful in CI or when watching externally). */
   noWatch?: boolean
+  /** Pre-resolved instance context — skip the CWD/env resolution step (used by CLI and daemon child). */
   instanceContext?: InstanceContext
 }
 
+/**
+ * Starts the OpenACP server for a given instance.
+ *
+ * The startup sequence is intentionally ordered:
+ *   1. Instance context — must exist before any path resolution
+ *   2. SettingsManager + PluginRegistry — needed by setup wizard if config is missing
+ *   3. Config load — required before logger init (log level comes from config)
+ *   4. Plugin boot — services first, then infrastructure (tunnel, API), then adapters
+ *   5. Adapter wiring — adapters register as services during boot; wired after all plugins are up
+ *   6. core.start() — begins listening only after all plugins and adapters are ready
+ *
+ * Can be called programmatically (e.g., from tests or embedded use) by passing
+ * a pre-built `instanceContext`. When omitted, resolves from env or CWD.
+ */
 export async function startServer(opts?: StartServerOptions) {
   if (!opts?.instanceContext) {
     const { resolveInstanceRoot } = await import('./core/instance/instance-context.js')
@@ -294,7 +326,9 @@ export async function startServer(opts?: StartServerOptions) {
       }
     }
 
-    // Wire adapters from service registry into core (discovered dynamically)
+    // Adapters register themselves into the ServiceRegistry under the key "adapter:<name>"
+    // during their plugin setup() hook. We discover them here after all plugins have booted,
+    // then wire each one into core so it can route incoming messages and send agent responses.
     for (const { name } of serviceRegistry.list()) {
       if (!name.startsWith('adapter:')) continue
       const adapterName = name.slice('adapter:'.length)
@@ -330,6 +364,13 @@ export async function startServer(opts?: StartServerOptions) {
   }
 
   // 5. Setup shutdown handler
+  // Teardown order mirrors the reverse of boot order:
+  //   notifications → sessions → lifecycle (adapters, api-server, tunnel, etc.)
+  // Notifications must fire first while the adapter is still connected.
+  // Sessions are persisted before the plugin layer tears down (some plugins
+  // handle session events during shutdown). core.stop() is intentionally
+  // NOT called — lifecycleManager.shutdown() already stops adapters, and
+  // calling core.stop() afterwards would double-stop and use already-torn-down plugins.
   const shutdown = async (signal: string, exitCode = 0) => {
     if (shuttingDown) return
     shuttingDown = true

--- a/src/plugins/api-server/auth/jwt.ts
+++ b/src/plugins/api-server/auth/jwt.ts
@@ -6,18 +6,37 @@ export interface SignPayload {
   sub: string;
   role: string;
   scopes?: string[];
+  /** Refresh deadline as Unix timestamp (seconds). Embedded in the JWT so the refresh endpoint
+   *  can enforce it without a database lookup when the access token has already expired. */
   rfd: number;
 }
 
+/**
+ * Signs a short-lived access token using HS256.
+ *
+ * HS256 is sufficient here because the secret never leaves the server process;
+ * asymmetric keys would add complexity with no security benefit in this deployment model.
+ */
 export function signToken(payload: SignPayload, secret: string, expiresIn: string): string {
   const opts: SignOptions = { algorithm: 'HS256', expiresIn: expiresIn as SignOptions['expiresIn'] };
   return jwt.sign(payload, secret, opts);
 }
 
+/**
+ * Verifies a JWT and returns its decoded payload.
+ *
+ * Throws if the token is invalid, has been tampered with, or is expired.
+ */
 export function verifyToken(token: string, secret: string): JwtPayload {
   return jwt.verify(token, secret, { algorithms: ['HS256'] }) as JwtPayload;
 }
 
+/**
+ * Verifies a JWT signature but ignores expiration — used exclusively during token refresh.
+ *
+ * The caller must check `rfd` (refresh deadline) separately: once that deadline passes,
+ * refreshing is no longer permitted regardless of the original expiry window.
+ */
 export function verifyForRefresh(token: string, secret: string): JwtPayload {
   return jwt.verify(token, secret, { algorithms: ['HS256'], ignoreExpiration: true }) as JwtPayload;
 }

--- a/src/plugins/api-server/auth/roles.ts
+++ b/src/plugins/api-server/auth/roles.ts
@@ -1,5 +1,6 @@
 // sessions:dangerous is intentionally not assigned to any named role.
-// Only admin (via wildcard '*') has it. Operators must be explicitly granted it.
+// Only admin (via wildcard '*') has it. Operators must be explicitly granted it
+// via custom scopes to prevent accidental bypass-permission escalation.
 export const ROLES = {
   admin: ['*'],
   operator: [
@@ -19,15 +20,22 @@ export const KNOWN_SCOPES = [
 
 export type RoleName = keyof typeof ROLES;
 
+/** Returns true if `role` is one of the known built-in role names. */
 export function isValidRole(role: string): role is RoleName {
   return role in ROLES;
 }
 
+/** Returns the default scope list for a role, or an empty array for unknown roles. */
 export function getRoleScopes(role: string): string[] {
   if (!isValidRole(role)) return [];
   return [...ROLES[role]];
 }
 
+/**
+ * Returns true if `userScopes` contains `requiredScope`.
+ *
+ * The wildcard `'*'` short-circuits all checks — it is only granted to admin-type tokens.
+ */
 export function hasScope(userScopes: string[], requiredScope: string): boolean {
   if (userScopes.includes('*')) return true;
   return userScopes.includes(requiredScope);

--- a/src/plugins/api-server/auth/token-store.ts
+++ b/src/plugins/api-server/auth/token-store.ts
@@ -2,12 +2,21 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import type { StoredToken, CreateTokenOpts, StoredCode, CreateCodeOpts } from './types.js';
 
+// After this window expires the token can no longer be refreshed and the user must re-authenticate.
+// 7 days is a deliberate balance: long enough that a session-idle app does not surprise the user,
+// short enough that a stolen token has a bounded blast radius.
 const REFRESH_DEADLINE_MS = 7 * 24 * 60 * 60 * 1000;
 
 function generateTokenId(): string {
   return `tok_${randomBytes(12).toString('hex')}`;
 }
 
+/**
+ * Parses a simple duration string (e.g. "24h", "7d", "30m") into milliseconds.
+ *
+ * Supported units: `m` (minutes), `h` (hours), `d` (days).
+ * Throws for unrecognized formats or units.
+ */
 export function parseDuration(duration: string): number {
   const match = duration.match(/^(\d+)(h|d|m)$/);
   if (!match) throw new Error(`Invalid duration: ${duration}`);
@@ -20,6 +29,17 @@ export function parseDuration(duration: string): number {
   }
 }
 
+/**
+ * Persists JWT tokens and one-time authorization codes to a JSON file.
+ *
+ * Revocation is flag-based: tokens are marked `revoked: true` rather than deleted,
+ * so the auth middleware can distinguish a revoked token from an unknown one.
+ * Periodic cleanup (via `cleanup()`) removes tokens past their refresh deadline
+ * and expired/used codes to prevent unbounded file growth.
+ *
+ * Saves are asynchronous and coalesced: concurrent mutations schedule a single write
+ * to avoid thundering-herd disk I/O under bursty auth traffic.
+ */
 export class TokenStore {
   private tokens = new Map<string, StoredToken>();
   private codes = new Map<string, StoredCode>();
@@ -28,6 +48,7 @@ export class TokenStore {
 
   constructor(private filePath: string) {}
 
+  /** Loads token and code state from disk. Safe to call at startup; missing file is not an error. */
   async load(): Promise<void> {
     try {
       const data = await readFile(this.filePath, 'utf-8');
@@ -61,6 +82,10 @@ export class TokenStore {
     await writeFile(this.filePath, JSON.stringify(data, null, 2), 'utf-8');
   }
 
+  /**
+   * Coalesces concurrent writes: if a save is in-flight, sets a pending flag
+   * so the next save fires immediately after the current one completes.
+   */
   private scheduleSave(): void {
     if (this.savePromise) {
       this.savePending = true;
@@ -79,6 +104,7 @@ export class TokenStore {
       });
   }
 
+  /** Creates a new token record and schedules a persist. Returns the stored token including its generated id. */
   create(opts: CreateTokenOpts): StoredToken {
     const now = new Date();
     const token: StoredToken = {
@@ -99,6 +125,7 @@ export class TokenStore {
     return this.tokens.get(id);
   }
 
+  /** Marks a token as revoked; future auth checks will reject it immediately. */
   revoke(id: string): void {
     const token = this.tokens.get(id);
     if (token) {
@@ -107,12 +134,19 @@ export class TokenStore {
     }
   }
 
+  /** Returns all non-revoked tokens. Revoked tokens are retained until cleanup() removes them. */
   list(): StoredToken[] {
     return Array.from(this.tokens.values()).filter((t) => !t.revoked);
   }
 
   private lastUsedSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /**
+   * Records the current timestamp as `lastUsedAt` for the given token.
+   *
+   * Writes are debounced to 60 seconds — every API request updates this field,
+   * so flushing on every call would cause excessive disk I/O.
+   */
   updateLastUsed(id: string): void {
     const token = this.tokens.get(id);
     if (token) {
@@ -148,6 +182,12 @@ export class TokenStore {
     }
   }
 
+  /**
+   * Generates a one-time authorization code that can be exchanged for a JWT.
+   *
+   * Used for the CLI login flow: the server emits a code that the user copies into
+   * the App, which exchanges it for a proper JWT without ever exposing the raw API secret.
+   */
   createCode(opts: CreateCodeOpts): StoredCode {
     const code = randomBytes(16).toString('hex');
     const now = new Date();
@@ -175,6 +215,13 @@ export class TokenStore {
     return stored;
   }
 
+  /**
+   * Atomically marks a code as used and returns it.
+   *
+   * Returns undefined if the code is unknown, already used, or expired.
+   * The one-time-use flag is set before returning, so concurrent calls for the
+   * same code will only succeed once.
+   */
   exchangeCode(code: string): StoredCode | undefined {
     const stored = this.codes.get(code);
     if (!stored) return undefined;
@@ -197,6 +244,13 @@ export class TokenStore {
     this.scheduleSave();
   }
 
+  /**
+   * Removes tokens past their refresh deadline and expired/used codes.
+   *
+   * Called on a 1-hour interval from the plugin setup to prevent unbounded file growth.
+   * Tokens within their refresh deadline are retained even if revoked, so that the
+   * "token revoked" error can be returned instead of "token unknown".
+   */
   cleanup(): void {
     const now = Date.now();
     for (const [id, token] of this.tokens) {

--- a/src/plugins/api-server/auth/types.ts
+++ b/src/plugins/api-server/auth/types.ts
@@ -1,30 +1,38 @@
+/** A token record persisted in tokens.json. Tokens are never deleted; they are revoked by flag. */
 export interface StoredToken {
   id: string;
   name: string;
   role: string;
+  /** Custom scope overrides; when absent, role defaults from ROLES apply. */
   scopes?: string[];
   createdAt: string;
+  /** Absolute deadline after which the token cannot be refreshed — requires re-authentication. */
   refreshDeadline: string;
   lastUsedAt?: string;
   revoked: boolean;
 }
 
+/** Claims embedded in a signed JWT. `rfd` (refresh deadline) is a Unix timestamp (seconds). */
 export interface JwtPayload {
   sub: string;
   role: string;
+  /** Token-level scope overrides, or undefined to fall back to role defaults. */
   scopes?: string[];
   iat: number;
   exp: number;
+  /** Refresh deadline as Unix timestamp (seconds); mirrors StoredToken.refreshDeadline. */
   rfd: number;
 }
 
 export interface CreateTokenOpts {
   role: string;
   name: string;
+  /** Duration string, e.g. "24h", "7d". Parsed by parseDuration(). */
   expire: string;
   scopes?: string[];
 }
 
+/** Shape returned to the caller when a new token is issued. */
 export interface TokenInfo {
   tokenId: string;
   accessToken: string;
@@ -32,11 +40,16 @@ export interface TokenInfo {
   refreshDeadline: string;
 }
 
+/**
+ * A one-time authorization code stored until exchange.
+ * The code is a 32-char hex string; it becomes unusable after `expiresAt` or first use.
+ */
 export interface StoredCode {
   code: string;
   role: string;
   scopes?: string[];
   name: string;
+  /** Duration that the resulting JWT will be valid for. */
   expire: string;
   createdAt: string;
   expiresAt: string;
@@ -48,5 +61,6 @@ export interface CreateCodeOpts {
   name: string;
   expire: string;
   scopes?: string[];
-  codeTtlMs?: number; // default 30 minutes
+  /** How long the code itself is valid; defaults to 30 minutes. */
+  codeTtlMs?: number;
 }

--- a/src/plugins/api-server/index.ts
+++ b/src/plugins/api-server/index.ts
@@ -18,6 +18,7 @@ const log = createChildLogger({ module: 'api-server' })
 
 let cachedVersion: string | undefined
 
+/** Reads the package.json version once and caches it for the lifetime of the process. */
 function getVersion(): string {
   if (cachedVersion) return cachedVersion
   try {
@@ -31,6 +32,14 @@ function getVersion(): string {
   return cachedVersion!
 }
 
+/**
+ * Loads a secret from disk, or generates a new one and persists it with mode 0600.
+ *
+ * Used for both the raw API secret and the JWT signing secret. The file is created
+ * with restrictive permissions on first run; subsequent starts re-use the existing value
+ * so secrets survive restarts. An SSH-style warning is logged if the file permissions
+ * are too open (group/other readable), which can happen if the user copied the file.
+ */
 function loadOrCreateSecret(secretFilePath: string): string {
   const dir = path.dirname(secretFilePath)
   fs.mkdirSync(dir, { recursive: true })
@@ -63,12 +72,19 @@ function loadOrCreateSecret(secretFilePath: string): string {
   return secret
 }
 
+/**
+ * Writes the actual listening port to `<instanceRoot>/api.port`.
+ *
+ * The CLI reads this file to locate the running server when the user runs
+ * `openacp` commands against a daemonized instance.
+ */
 function writePortFile(portFilePath: string, port: number): void {
   const dir = path.dirname(portFilePath)
   fs.mkdirSync(dir, { recursive: true })
   fs.writeFileSync(portFilePath, String(port))
 }
 
+/** Removes the port file on shutdown so stale files don't mislead CLI auto-discovery. */
 function removePortFile(portFilePath: string): void {
   try {
     fs.unlinkSync(portFilePath)
@@ -86,6 +102,19 @@ export interface ApiConfig {
 
 // ─── Plugin Definition ─────────────────────────────────────────────────────
 
+/**
+ * Creates the `@openacp/api-server` plugin.
+ *
+ * This plugin wires together:
+ * - A Fastify HTTP server with JWT auth, rate limiting, and Swagger docs
+ * - REST route groups for sessions, agents, config, system, auth, plugins, topics, tunnel, etc.
+ * - An SSE manager that relays EventBus events to connected App clients in real time
+ * - Static file serving for the bundled OpenACP App dashboard
+ * - An `api-server` service registered in ServiceRegistry for other plugins to extend
+ *
+ * Startup is deferred to the `SYSTEM_READY` event so all other plugins are fully
+ * booted before the server accepts connections.
+ */
 function createApiServerPlugin(): OpenACPPlugin {
   let server: ApiServerInstance | null = null
   let portFilePath = ''
@@ -273,9 +302,10 @@ function createApiServerPlugin(): OpenACPPlugin {
         })
       })
 
-      // Exchange endpoint — NO auth (code in body IS the credential)
-      // Fastify encapsulation makes dual registerPlugin on the same prefix safe —
-      // each registration gets its own scope with independent hooks.
+      // Exchange endpoint — NO auth. The one-time code in the request body IS the
+      // credential; adding Bearer auth here would require the caller to already have a
+      // token, defeating the purpose. Fastify encapsulation makes dual registerPlugin
+      // on the same prefix safe — each call creates an independent scope with its own hooks.
       server.registerPlugin('/api/v1/auth', async (app) => {
         const { ExchangeCodeBodySchema } = await import('./schemas/auth.js')
         const { signToken } = await import('./auth/jwt.js')

--- a/src/plugins/api-server/middleware/auth.ts
+++ b/src/plugins/api-server/middleware/auth.ts
@@ -8,10 +8,13 @@ import { createChildLogger } from '../../../core/utils/log.js';
 
 const log = createChildLogger({ module: 'api-auth' });
 
+// Augment FastifyRequest so all route handlers have typed access to the authenticated identity.
 declare module 'fastify' {
   interface FastifyRequest {
     auth: {
+      /** "secret" = raw API secret (full admin); "jwt" = scoped JWT token. */
       type: 'secret' | 'jwt';
+      /** Present for JWT auth; used to look up the token record for revocation checks. */
       tokenId?: string;
       role: string;
       scopes: string[];
@@ -26,6 +29,17 @@ function constantTimeSecretCheck(token: string, secret: string): boolean {
   return timingSafeEqual(tokenHash, secretHash);
 }
 
+/**
+ * Creates a Fastify pre-handler that validates incoming auth tokens.
+ *
+ * Two credential types are accepted in priority order:
+ * 1. Raw API secret — constant-time compared; grants full admin access (`scopes: ['*']`).
+ * 2. JWT — verified with HS256, then checked against TokenStore for revocation.
+ *
+ * On success, `request.auth` is populated with role and scopes for downstream handlers.
+ * Token may be provided via `Authorization: Bearer <token>` or `?token=` query param
+ * (the latter is warned against because tunnel providers log query strings).
+ */
 export function createAuthPreHandler(
   getSecret: () => string,
   getJwtSecret: () => string,
@@ -64,16 +78,13 @@ export function createAuthPreHandler(
       throw new AuthError('UNAUTHORIZED', 'Invalid authentication token');
     }
 
-    // 3. Check if token is revoked in TokenStore
     const stored = tokenStore.get(payload.sub);
     if (!stored || stored.revoked) {
       throw new AuthError('UNAUTHORIZED', 'Token has been revoked');
     }
 
-    // 4. Update lastUsedAt
     tokenStore.updateLastUsed(payload.sub);
 
-    // 5. Resolve scopes from token override or role defaults
     const scopes = payload.scopes ?? getRoleScopes(payload.role);
 
     request.auth = {
@@ -85,6 +96,12 @@ export function createAuthPreHandler(
   };
 }
 
+/**
+ * Returns a Fastify pre-handler that enforces one or more required scopes.
+ *
+ * Wildcard `'*'` (admin secret auth) bypasses all scope checks.
+ * Throws 403 listing the specific missing scopes for easier debugging.
+ */
 export function requireScopes(...scopes: string[]): preHandlerHookHandler {
   return async function scopeCheck(request: FastifyRequest, _reply: FastifyReply) {
     const { scopes: userScopes } = request.auth;
@@ -97,6 +114,12 @@ export function requireScopes(...scopes: string[]): preHandlerHookHandler {
   };
 }
 
+/**
+ * Returns a Fastify pre-handler that enforces a minimum role level.
+ *
+ * Roles form a hierarchy: viewer < operator < admin. A user with a higher role
+ * always passes a lower-role gate, so `requireRole('operator')` also admits admins.
+ */
 export function requireRole(role: string): preHandlerHookHandler {
   const roleHierarchy: Record<string, number> = { viewer: 0, operator: 1, admin: 2 };
 

--- a/src/plugins/api-server/middleware/error-handler.ts
+++ b/src/plugins/api-server/middleware/error-handler.ts
@@ -2,6 +2,7 @@ import type { FastifyError, FastifyReply, FastifyRequest } from 'fastify';
 import { ZodError } from 'zod';
 import { ConfigValidationError } from '../../../core/config/config-registry.js';
 
+/** Standard error envelope returned by all API error responses. */
 export interface ApiErrorResponse {
   error: {
     code: string;
@@ -11,6 +12,7 @@ export interface ApiErrorResponse {
   };
 }
 
+/** Thrown by route handlers when a requested resource does not exist (→ 404). */
 export class NotFoundError extends Error {
   constructor(
     public code: string,
@@ -21,6 +23,7 @@ export class NotFoundError extends Error {
   }
 }
 
+/** Thrown when the client sends a malformed or semantically invalid request (→ 400). */
 export class BadRequestError extends Error {
   constructor(
     public code: string,
@@ -31,6 +34,7 @@ export class BadRequestError extends Error {
   }
 }
 
+/** Thrown when a required backing service (e.g. file-service) is not loaded (→ 503). */
 export class ServiceUnavailableError extends Error {
   constructor(
     public code: string,
@@ -41,6 +45,7 @@ export class ServiceUnavailableError extends Error {
   }
 }
 
+/** Thrown by auth middleware and routes for authentication/authorization failures (→ 401 or 403). */
 export class AuthError extends Error {
   constructor(
     public code: string,
@@ -52,6 +57,11 @@ export class AuthError extends Error {
   }
 }
 
+/**
+ * Fastify global error handler that normalizes all thrown errors into the `ApiErrorResponse`
+ * envelope. Maps known error classes to their corresponding HTTP status codes and falls back
+ * to 500 for anything unrecognized.
+ */
 export function globalErrorHandler(
   error: FastifyError | Error,
   _request: FastifyRequest,

--- a/src/plugins/api-server/routes/agents.ts
+++ b/src/plugins/api-server/routes/agents.ts
@@ -5,6 +5,12 @@ import { NotFoundError } from '../middleware/error-handler.js';
 import { requireScopes } from '../middleware/auth.js';
 import { getAgentCapabilities } from '../../../core/agents/agent-registry.js';
 
+/**
+ * Agent catalog routes under `/api/v1/agents`.
+ *
+ * Routes: list all (`GET /`), reload from disk (`POST /reload`), get one (`GET /:name`).
+ * Requires `agents:read` for reads and `agents:write` for the reload mutation.
+ */
 export async function agentRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/auth.ts
+++ b/src/plugins/api-server/routes/auth.ts
@@ -8,16 +8,34 @@ import { requireScopes, requireRole } from '../middleware/auth.js';
 
 export interface AuthRouteDeps {
   tokenStore: TokenStore;
+  /** Returns the current JWT signing secret. Fetched lazily to support future rotation. */
   getJwtSecret: () => string;
 }
 
+/**
+ * Auth management routes under `/api/v1/auth`.
+ *
+ * Token lifecycle:
+ * - `POST /tokens` — create a scoped JWT (secret-token auth only).
+ * - `GET /tokens` — list non-revoked tokens.
+ * - `DELETE /tokens/:id` — revoke a token by ID.
+ * - `POST /refresh` — re-issue an expired JWT within the refresh deadline window.
+ * - `GET /me` — return the current authenticated identity.
+ * - `POST /codes` — generate a one-time code for the App login flow (secret-token only).
+ * - `GET /codes` — list active (unused, unexpired) codes (truncated for security).
+ * - `DELETE /codes/:code` — revoke a pending code.
+ *
+ * The `POST /exchange` endpoint lives in `index.ts` (unauthenticated, separate Fastify scope).
+ */
 export async function authRoutes(
   app: FastifyInstance,
   deps: AuthRouteDeps,
 ): Promise<void> {
   const { tokenStore, getJwtSecret } = deps;
 
-  // POST /tokens — generate a new JWT (secret token auth only)
+  // POST /tokens — generate a new JWT (secret token auth only).
+  // Restricting to secret-token type prevents a compromised JWT from self-escalating
+  // by minting additional tokens with different roles or longer lifetimes.
   app.post('/tokens', async (request) => {
     if (request.auth.type !== 'secret') {
       throw new AuthError('FORBIDDEN', 'Only secret token can create new tokens', 403);
@@ -152,7 +170,9 @@ export async function authRoutes(
     return reply.send({ code: code.code, expiresAt: code.expiresAt });
   });
 
-  // GET /codes — list active codes (auth:manage scope)
+  // GET /codes — list active codes (auth:manage scope).
+  // The code value itself is truncated to prevent this endpoint from being used to
+  // harvest valid codes — it's for audit/display purposes only.
   app.get('/codes', {
     preHandler: [requireScopes('auth:manage')],
   }, async (_request, reply) => {

--- a/src/plugins/api-server/routes/commands.ts
+++ b/src/plugins/api-server/routes/commands.ts
@@ -3,6 +3,16 @@ import type { RouteDeps } from './types.js';
 import { requireScopes } from '../middleware/auth.js';
 import { ExecuteCommandBodySchema } from '../schemas/commands.js';
 
+/**
+ * Command routes under `/api/v1/commands`.
+ *
+ * `GET /` lists all registered chat commands (plugin commands included).
+ * `POST /execute` dispatches a command through the CommandRegistry with `channelId: 'api'`
+ * so the result can be returned synchronously to the HTTP caller rather than routed
+ * back to a messaging adapter.
+ *
+ * Requires `commands:execute` scope.
+ */
 export async function commandRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/config.ts
+++ b/src/plugins/api-server/routes/config.ts
@@ -3,6 +3,8 @@ import type { RouteDeps } from './types.js';
 import { requireScopes } from '../middleware/auth.js';
 import { UpdateConfigBodySchema } from '../schemas/config.js';
 
+// Keys redacted in config API responses to prevent credentials leaking to UI clients.
+// This list covers common naming conventions across all plugin configs.
 const SENSITIVE_KEYS = [
   'botToken',
   'token',
@@ -33,6 +35,18 @@ function redactDeep(obj: Record<string, unknown>): void {
   }
 }
 
+/**
+ * Config routes under `/api/v1/config`.
+ *
+ * `GET /` returns the full config with sensitive values redacted.
+ * `GET /editable` returns only fields marked `scope: 'safe'` in the config registry,
+ * which are the fields the App UI may display and modify.
+ * `GET /schema` returns the full JSON Schema for documentation/form generation.
+ * `PATCH /` updates a single field by dot-notation path; only `safe`-scoped fields
+ * are permitted to prevent unauthorized changes to security-sensitive settings.
+ *
+ * Requires `config:read` for reads; `config:write` for mutations.
+ */
 export async function configRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/notify.ts
+++ b/src/plugins/api-server/routes/notify.ts
@@ -7,6 +7,13 @@ const NotifyBodySchema = z.object({
   message: z.string().min(1).max(4_000),
 });
 
+/**
+ * Notification broadcast route under `/api/v1/notify`.
+ *
+ * `POST /` sends a system notification to all connected adapters (Telegram, Slack, etc.)
+ * via the notification manager. Requires `sessions:write` scope.
+ * Used by CLI tools and external integrations to push custom alerts to the operator.
+ */
 export async function notifyRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/plugins.ts
+++ b/src/plugins/api-server/routes/plugins.ts
@@ -5,9 +5,20 @@ import { requireScopes } from '../middleware/auth.js'
 import { corePlugins } from '../../../plugins/core-plugins.js'
 import { RegistryClient } from '../../../core/plugin/registry-client.js'
 
-// Singleton so the 1-minute TTL cache is shared across requests
+// Singleton so the 1-minute TTL cache is shared across requests to avoid
+// hammering the remote registry on every marketplace page load.
 const registryClient = new RegistryClient()
 
+/**
+ * Plugin management routes under `/api/v1/plugins`.
+ *
+ * All routes require `system:admin` scope.
+ * - `GET /` — lists installed plugins with their runtime state (loaded, failed, essential).
+ * - `GET /marketplace` — proxies the remote plugin registry, annotated with installed status.
+ * - `POST /:name/enable` — hot-loads a disabled plugin without restarting the server.
+ * - `POST /:name/disable` — gracefully unloads an active plugin; blocks essential plugins.
+ * - `DELETE /:name` — uninstalls an npm/local plugin; builtin plugins cannot be removed.
+ */
 export async function pluginRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/sessions.ts
+++ b/src/plugins/api-server/routes/sessions.ts
@@ -19,6 +19,19 @@ import {
 } from '../schemas/sessions.js';
 
 
+/**
+ * Session management routes under `/api/v1/sessions`.
+ *
+ * Covers the full session lifecycle:
+ * - CRUD: list, get, create (POST /), adopt (from existing agent), delete (cancel)
+ * - Messaging: prompt (POST /:id/prompt), permission resolution (POST /:id/permission)
+ * - Mutation: patch agent/voice/dangerousMode, archive, attach/detach adapter
+ * - Config: read/write per-session config options and client overrides
+ * - History: retrieve full conversation history via context manager
+ *
+ * `sessions:dangerous` scope is required for bypass-permissions routes because it is
+ * not included in the default `operator` role — it must be explicitly granted.
+ */
 export async function sessionRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/topics.ts
+++ b/src/plugins/api-server/routes/topics.ts
@@ -10,6 +10,15 @@ const TopicCleanupBodySchema = z.object({
   statuses: z.array(z.enum(VALID_TOPIC_STATUSES)).optional(),
 });
 
+/**
+ * Telegram topic management routes under `/api/v1/topics`.
+ *
+ * Topics are Telegram forum threads created per session. These routes let the App
+ * UI manage topic lifecycle without going through the Telegram adapter directly.
+ * All routes require `sessions:write` scope and return 501 if no topic manager is loaded.
+ *
+ * `DELETE /:sessionId` with `?force=true` bypasses the active-session confirmation gate.
+ */
 export async function topicRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/tunnel.ts
+++ b/src/plugins/api-server/routes/tunnel.ts
@@ -9,6 +9,13 @@ const AddTunnelBodySchema = z.object({
   sessionId: z.string().max(200).optional(),
 });
 
+/**
+ * Tunnel management routes under `/api/v1/tunnel`.
+ *
+ * Read operations (status, list) require `system:health` scope.
+ * Mutations (add, stop) require `system:admin` scope.
+ * All routes return 400 if the tunnel service is not enabled.
+ */
 export async function tunnelRoutes(
   app: FastifyInstance,
   deps: RouteDeps,

--- a/src/plugins/api-server/routes/workspace.ts
+++ b/src/plugins/api-server/routes/workspace.ts
@@ -1,12 +1,21 @@
 import type { FastifyInstance } from 'fastify'
 
+/** Options injected when the workspace route is registered. */
 export interface WorkspaceRouteOpts {
+  /** Unique workspace/instance identifier. */
   id: string
   name: string
+  /** Absolute path to the workspace directory. */
   directory: string
   version: string
 }
 
+/**
+ * Registers `GET /workspace` which returns identity info about the running instance.
+ *
+ * The App uses this on first connect to display the workspace name and verify it is
+ * talking to the correct instance when multiple workspaces are configured.
+ */
 export async function workspaceRoute(
   app: FastifyInstance,
   opts: WorkspaceRouteOpts,

--- a/src/plugins/api-server/schemas/agents.ts
+++ b/src/plugins/api-server/schemas/agents.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+// Zod schemas for agent catalog API responses.
+
 export const AgentResponseSchema = z.object({
   name: z.string(),
   command: z.string(),

--- a/src/plugins/api-server/schemas/auth.ts
+++ b/src/plugins/api-server/schemas/auth.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+// Zod schemas for token and code auth API requests.
+// Security constraints (max length, regex, expiry cap) are intentional — see inline comments.
+
 // Valid scope strings — prevents arbitrary scope injection and limits payload size.
 // Each scope is at most 50 chars; the array is capped at 20 to prevent DoS.
 const ScopeItemSchema = z.string().min(1).max(50).regex(/^[a-z*]+(?::[a-z]+)?$/, 'Invalid scope format');

--- a/src/plugins/api-server/schemas/commands.ts
+++ b/src/plugins/api-server/schemas/commands.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+// Zod schemas for the commands API.
+
 export const ExecuteCommandBodySchema = z.object({
   command: z.string().min(1).max(1_000),
   sessionId: z.string().optional(),

--- a/src/plugins/api-server/schemas/common.ts
+++ b/src/plugins/api-server/schemas/common.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+// Shared Zod schemas reused across multiple route groups.
+
 export const PaginationQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),

--- a/src/plugins/api-server/schemas/config.ts
+++ b/src/plugins/api-server/schemas/config.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+// Zod schemas for config API requests.
+
 export const UpdateConfigBodySchema = z.object({
   path: z.string().min(1),
   value: z.unknown(),

--- a/src/plugins/api-server/schemas/sessions.ts
+++ b/src/plugins/api-server/schemas/sessions.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+// Zod schemas for session API requests. Security-relevant size limits are documented inline.
+
 export const ListSessionsQuerySchema = z.object({
   status: z.enum(['initializing', 'active', 'finished', 'cancelled', 'error']).optional(),
   agentName: z.string().max(200).optional(),

--- a/src/plugins/api-server/schemas/system.ts
+++ b/src/plugins/api-server/schemas/system.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+// Zod schemas for system health API responses.
+
 export const HealthResponseSchema = z.object({
   status: z.string(),
   timestamp: z.string(),

--- a/src/plugins/api-server/server.ts
+++ b/src/plugins/api-server/server.ts
@@ -9,19 +9,41 @@ import { createAuthPreHandler } from './middleware/auth.js';
 export interface ApiServerOptions {
   port: number;
   host: string;
+  /** Returns the raw API secret used for full-admin Bearer auth. Fetched lazily so rotation is safe. */
   getSecret: () => string;
+  /** Returns the HMAC secret used to sign and verify JWTs. */
   getJwtSecret: () => string;
   tokenStore: import('./auth/token-store.js').TokenStore;
   logger?: boolean;
 }
 
+/**
+ * The handle returned by `createApiServer`.
+ *
+ * Route plugins are registered before `start()` is called; Fastify's plugin
+ * encapsulation keeps each prefix isolated with its own auth hooks.
+ */
 export interface ApiServerInstance {
   app: FastifyInstance;
+  /** Binds to the configured host/port, auto-incrementing if EADDRINUSE. */
   start(): Promise<{ port: number; host: string }>;
   stop(): Promise<void>;
+  /**
+   * Registers a Fastify plugin scoped to `prefix`.
+   *
+   * Auth is applied by default. Pass `{ auth: false }` only for public endpoints
+   * (e.g. `/api/v1/system` health, `/api/v1/auth/exchange`).
+   */
   registerPlugin(prefix: string, plugin: FastifyPluginAsync, opts?: { auth?: boolean }): void;
 }
 
+/**
+ * Creates and configures the Fastify HTTP server.
+ *
+ * Sets up in order: Zod validation, CORS, rate limiting, Swagger docs,
+ * backward-compat redirects (`/api/*` → `/api/v1/*`), and the global error handler.
+ * Route plugins are registered after this returns via `ApiServerInstance.registerPlugin`.
+ */
 export async function createApiServer(options: ApiServerOptions): Promise<ApiServerInstance> {
   const app = Fastify({ logger: options.logger ?? false, forceCloseConnections: true });
 
@@ -105,6 +127,8 @@ export async function createApiServer(options: ApiServerOptions): Promise<ApiSer
 
     registerPlugin(prefix: string, plugin: FastifyPluginAsync, opts?: { auth?: boolean }) {
       const wrappedPlugin: FastifyPluginAsync = async (pluginApp, pluginOpts) => {
+        // Fastify encapsulation means this hook only applies to routes in this scope,
+        // so unauthenticated prefixes (e.g. /exchange) don't accidentally inherit auth.
         if (opts?.auth !== false) {
           pluginApp.addHook('onRequest', authPreHandler);
         }

--- a/src/plugins/api-server/service.ts
+++ b/src/plugins/api-server/service.ts
@@ -2,16 +2,34 @@ import type { FastifyPluginAsync, preHandlerHookHandler } from 'fastify';
 import type { ApiServerInstance } from './server.js';
 import { requireScopes, requireRole } from './middleware/auth.js';
 
+/**
+ * The `api-server` service interface exposed to other plugins via ServiceRegistry.
+ *
+ * Other plugins (e.g. SSE adapter, tunnel plugin) use this to register their own
+ * Fastify route plugins under the shared HTTP server without needing a direct
+ * reference to the Fastify instance.
+ */
 export interface ApiServerService {
+  /** Register a Fastify plugin at the given prefix, with optional auth bypass. */
   registerPlugin(prefix: string, plugin: FastifyPluginAsync, opts?: { auth?: boolean }): void;
+  /** Pre-handler that validates Bearer/JWT auth — attach to routes that need custom auth. */
   authPreHandler: preHandlerHookHandler;
+  /** Creates a pre-handler that requires all listed scopes. */
   requireScopes(...scopes: string[]): preHandlerHookHandler;
+  /** Creates a pre-handler that requires a minimum role level. */
   requireRole(role: string): preHandlerHookHandler;
   getPort(): number;
   getBaseUrl(): string;
+  /** Returns the public tunnel URL, or null if no tunnel is active. */
   getTunnelUrl(): string | null;
 }
 
+/**
+ * Wraps an `ApiServerInstance` as a service object registered in the ServiceRegistry.
+ *
+ * The getPort/getBaseUrl/getTunnelUrl callbacks are evaluated lazily so callers always
+ * get the current values (port is only known after the server starts listening).
+ */
 export function createApiServerService(
   server: ApiServerInstance,
   getPort: () => number,

--- a/src/plugins/api-server/sse-manager.ts
+++ b/src/plugins/api-server/sse-manager.ts
@@ -17,6 +17,18 @@ interface SessionStats {
 // attacker opening many persistent connections via the public tunnel.
 const MAX_SSE_CONNECTIONS = 50;
 
+/**
+ * Manages Server-Sent Events (SSE) connections and broadcasts OpenACP bus events to clients.
+ *
+ * SSE is used instead of WebSockets because:
+ * - It works natively through HTTP/1.1 proxies (Cloudflare, nginx) without upgrade negotiation.
+ * - The communication is unidirectional (server → client); clients send commands via REST.
+ * - It requires no additional dependencies and is built into all modern browsers.
+ *
+ * Clients can subscribe to a specific session by passing `?sessionId=` to filter the stream.
+ * Health heartbeats are sent every 15 seconds to keep the connection alive through idle-timeout
+ * proxies and to deliver periodic memory/session stats to the dashboard.
+ */
 export class SSEManager {
   private sseConnections = new Set<http.ServerResponse>();
   private sseCleanupHandlers = new Map<http.ServerResponse, () => void>();
@@ -32,6 +44,13 @@ export class SSEManager {
     private startedAt: number,
   ) {}
 
+  /**
+   * Subscribes to EventBus events and starts the health heartbeat interval.
+   *
+   * Must be called after the HTTP server is listening, not during plugin setup —
+   * before `setup()` runs, no EventBus listeners are registered, so any events
+   * emitted in the interim are silently missed.
+   */
   setup(): void {
     if (!this.eventBus) return;
 
@@ -70,6 +89,13 @@ export class SSEManager {
     }, 15_000);
   }
 
+  /**
+   * Handles an incoming SSE request by upgrading the HTTP response to an event stream.
+   *
+   * The response is kept open indefinitely; cleanup runs when the client disconnects.
+   * An initial `: connected` comment is written immediately so proxies and browsers
+   * flush the response headers before the first real event arrives.
+   */
   handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     if (this.sseConnections.size >= MAX_SSE_CONNECTIONS) {
       res.writeHead(503, { "Content-Type": "application/json" });
@@ -116,6 +142,13 @@ export class SSEManager {
     req.on("close", cleanup);
   }
 
+  /**
+   * Broadcasts an event to all connected SSE clients.
+   *
+   * Session-scoped events (agent_event, permission_request, etc.) are filtered per-connection:
+   * a client that subscribed with `?sessionId=X` only receives events for session X.
+   * Global events (session_created, health) are delivered to every client.
+   */
   broadcast(event: string, data: unknown): void {
     const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
     // Events that carry sessionId and should be filtered
@@ -152,6 +185,12 @@ export class SSEManager {
     };
   }
 
+  /**
+   * Stops the heartbeat, removes all EventBus listeners, and closes all open SSE connections.
+   *
+   * Only listeners registered by this instance are removed — other consumers on the same
+   * EventBus are unaffected.
+   */
   stop(): void {
     if (this.healthInterval) clearInterval(this.healthInterval);
 

--- a/src/plugins/api-server/static-server.ts
+++ b/src/plugins/api-server/static-server.ts
@@ -16,6 +16,22 @@ const MIME_TYPES: Record<string, string> = {
   ".woff2": "font/woff2",
 };
 
+/**
+ * Serves the bundled OpenACP App (a Vite SPA) from the local filesystem.
+ *
+ * Two directory layouts are probed at startup to support both the development
+ * build (`ui/dist/`) and the npm publish layout (`../ui/`). If neither exists,
+ * `isAvailable()` returns false and the server skips static file serving.
+ *
+ * Path traversal is blocked in two stages:
+ * 1. String prefix check before resolving symlinks (catches obvious `..` segments).
+ * 2. `realpathSync` check after resolution (catches symlinks that escape the UI dir).
+ *
+ * Vite content-hashed assets (`*.{hash}.js/css`) receive a 1-year immutable cache.
+ * All other files use `no-cache` so updates roll out on the next page refresh.
+ *
+ * Non-asset routes fall through to `index.html` (SPA client-side routing).
+ */
 export class StaticServer {
   private uiDir: string | undefined;
 
@@ -41,10 +57,16 @@ export class StaticServer {
     }
   }
 
+  /** Returns true if a UI build was found and static serving is active. */
   isAvailable(): boolean {
     return this.uiDir !== undefined;
   }
 
+  /**
+   * Attempts to serve a static file or SPA fallback for the given request.
+   *
+   * @returns true if the response was handled, false if the caller should return a 404.
+   */
   serve(req: http.IncomingMessage, res: http.ServerResponse): boolean {
     if (!this.uiDir) return false;
 

--- a/src/plugins/context/context-cache.ts
+++ b/src/plugins/context/context-cache.ts
@@ -3,8 +3,18 @@ import * as path from "node:path";
 import * as crypto from "node:crypto";
 import type { ContextResult } from "./context-provider.js";
 
+// Building context from checkpoints or history involves disk reads and markdown rendering.
+// Cache results on disk for 1 hour so repeated agent switches to the same context are fast.
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
 
+/**
+ * Disk-backed cache for built ContextResult objects.
+ *
+ * Cache keys are a hash of (repoPath + queryKey) so different repos and query
+ * parameters never collide. TTL is enforced on read — stale files are deleted lazily.
+ * Callers can bypass the cache via `ContextOptions.noCache` for live agent switches
+ * where history was just written and would otherwise be served stale.
+ */
 export class ContextCache {
   constructor(private cacheDir: string, private ttlMs: number = DEFAULT_TTL_MS) {
     fs.mkdirSync(cacheDir, { recursive: true });

--- a/src/plugins/context/context-manager.ts
+++ b/src/plugins/context/context-manager.ts
@@ -3,6 +3,18 @@ import type { HistoryStore } from "./history/history-store.js";
 import type { SessionHistory } from "./history/types.js";
 import { ContextCache } from "./context-cache.js";
 
+/**
+ * Orchestrates context providers and caching.
+ *
+ * Providers are tried in registration order — the first one that is available
+ * and returns non-empty markdown wins. This lets the "local" history provider
+ * take priority over the "entire" checkpoint provider for sessions that are
+ * still in progress (not yet checkpointed).
+ *
+ * The context service is registered under the `"context"` key in the
+ * ServiceRegistry so other plugins (e.g. the git-pilot plugin) can call
+ * `buildContext()` before injecting context into a new agent.
+ */
 export class ContextManager {
   private providers: ContextProvider[] = [];
   private cache: ContextCache;
@@ -13,6 +25,12 @@ export class ContextManager {
     this.cache = new ContextCache(cachePath);
   }
 
+  /**
+   * Wire in the history store after construction.
+   *
+   * Injected separately because the history store (backed by the context plugin's
+   * recorder) may not be ready when ContextManager is first instantiated.
+   */
   setHistoryStore(store: HistoryStore): void {
     this.historyStore = store;
   }
@@ -31,15 +49,32 @@ export class ContextManager {
     if (this.sessionFlusher) await this.sessionFlusher(sessionId);
   }
 
+  /**
+   * Read the raw history for a session directly from the history store.
+   *
+   * Returns null if no historyStore has been configured via `setHistoryStore()`,
+   * or if the session has no recorded history.
+   */
   async getHistory(sessionId: string): Promise<SessionHistory | null> {
     if (!this.historyStore) return null;
     return this.historyStore.read(sessionId);
   }
 
+  /**
+   * Register a provider. Providers are queried in insertion order.
+   * Register higher-priority sources (e.g. local history) before lower-priority ones (e.g. entire).
+   */
   register(provider: ContextProvider): void {
     this.providers.push(provider);
   }
 
+  /**
+   * Return the first provider that reports itself available for the given repo.
+   *
+   * This is a availability check — it returns the highest-priority available provider
+   * (i.e. the first registered one that passes `isAvailable`), not necessarily the
+   * one that would yield the richest context for a specific query.
+   */
   async getProvider(repoPath: string): Promise<ContextProvider | null> {
     for (const provider of this.providers) {
       if (await provider.isAvailable(repoPath)) return provider;
@@ -47,6 +82,13 @@ export class ContextManager {
     return null;
   }
 
+  /**
+   * List sessions using the same provider-waterfall logic as `buildContext`.
+   *
+   * Tries each registered provider in order, returning the first non-empty result.
+   * Unlike `buildContext`, results are not cached — callers should avoid calling
+   * this in hot paths.
+   */
   async listSessions(query: ContextQuery): Promise<SessionListResult | null> {
     for (const provider of this.providers) {
       if (!(await provider.isAvailable(query.repoPath))) continue;
@@ -56,6 +98,13 @@ export class ContextManager {
     return null;
   }
 
+  /**
+   * Build a context block for injection into an agent prompt.
+   *
+   * Tries each registered provider in order. Results are cached by (repoPath + queryKey)
+   * to avoid redundant disk reads. Pass `options.noCache = true` when the caller knows
+   * the history just changed (e.g. immediately after an agent switch + flush).
+   */
   async buildContext(query: ContextQuery, options?: ContextOptions): Promise<ContextResult | null> {
     const queryKey = `${query.type}:${query.value}:${options?.limit ?? ""}:${options?.maxTokens ?? ""}:${options?.labelAgent ?? ""}`;
 

--- a/src/plugins/context/context-provider.ts
+++ b/src/plugins/context/context-provider.ts
@@ -3,6 +3,12 @@
 // Providers may only support a subset of query types and should return empty results
 // for unsupported types rather than throwing.
 
+/**
+ * Abstract interface for conversation context sources.
+ *
+ * Two providers are built-in: "local" (history recorder) and "entire" (Claude Code checkpoints).
+ * ContextManager iterates providers in priority order and returns the first non-empty result.
+ */
 export interface ContextProvider {
   readonly name: string;
   isAvailable(repoPath: string): Promise<boolean>;
@@ -10,6 +16,14 @@ export interface ContextProvider {
   buildContext(query: ContextQuery, options?: ContextOptions): Promise<ContextResult>;
 }
 
+/**
+ * Describes which sessions to include in a context build.
+ *
+ * - `type: "latest"` with `value: "5"` returns the 5 most recent sessions.
+ * - `type: "session"` with a UUID returns exactly that session.
+ * - `type: "branch"` / `"commit"` / `"pr"` are only supported by the "entire" provider
+ *   which reads Claude Code checkpoints stored in the git repo.
+ */
 export interface ContextQuery {
   repoPath: string;
   type: "branch" | "commit" | "pr" | "latest" | "checkpoint" | "session";
@@ -25,6 +39,11 @@ export interface ContextOptions {
   noCache?: boolean;
 }
 
+/**
+ * Metadata for a single recorded session, used when listing available context.
+ * Fields like `checkpointId` and `transcriptPath` are populated by the "entire" provider;
+ * the "local" provider leaves them empty since it stores sessions in its own HistoryStore.
+ */
 export interface SessionInfo {
   checkpointId: string;
   sessionIndex: string;
@@ -43,8 +62,19 @@ export interface SessionListResult {
   estimatedTokens: number;
 }
 
+/**
+ * Controls how much detail is rendered per turn in the context markdown.
+ * - `full`: full diffs, tool call outputs, thinking blocks, usage stats
+ * - `balanced`: diffs truncated, thinking omitted
+ * - `compact`: single-line summary per turn pair (user + tools used)
+ */
 export type ContextMode = "full" | "balanced" | "compact";
 
+/**
+ * The built context block to be prepended to an agent prompt.
+ * `markdown` is the formatted text; `truncated` is true when oldest sessions
+ * were dropped to fit within `maxTokens`.
+ */
 export interface ContextResult {
   markdown: string;
   tokenEstimate: number;

--- a/src/plugins/context/entire/checkpoint-reader.ts
+++ b/src/plugins/context/entire/checkpoint-reader.ts
@@ -26,11 +26,25 @@ interface SessionMeta {
 
 // ─── CheckpointReader ─────────────────────────────────────────────────────────
 
+// The Entire Claude Code extension pushes session data to this branch.
+// All git show / ls-tree commands read from this remote branch so we never
+// need to check it out locally.
 const ENTIRE_BRANCH = "origin/entire/checkpoints/v1";
 const CHECKPOINT_ID_RE = /^[0-9a-f]{12}$/;
 const SESSION_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
+/**
+ * Reads Claude Code session data from the `origin/entire/checkpoints/v1` git branch.
+ *
+ * The branch layout is:
+ *   `<shard[0:2]>/<shard[2:12]>/metadata.json` — checkpoint-level metadata
+ *   `<shard[0:2]>/<shard[2:12]>/<session-idx>/metadata.json` — per-session metadata
+ *   `<shard[0:2]>/<shard[2:12]>/<session-idx>/transcript.jsonl` — raw JSONL conversation
+ *
+ * All git operations use `execFileSync` so errors are caught and returned as
+ * empty strings rather than throwing — callers get null/[] on missing data.
+ */
 export class CheckpointReader {
   constructor(private readonly repoPath: string) {}
 
@@ -125,7 +139,8 @@ export class CheckpointReader {
     const ids = new Set<string>();
     for (const file of out.split("\n")) {
       const parts = file.split("/");
-      // Checkpoint-level metadata: XX/YYYYYYYYYY/metadata.json (3 parts)
+      // Checkpoint-level metadata lives at depth 3: XX/YYYYYYYYYY/metadata.json
+      // Session-level files are deeper — skip them here.
       if (parts.length === 3 && parts[2] === "metadata.json") {
         ids.add(parts[0] + parts[1]);
       }
@@ -173,7 +188,9 @@ export class CheckpointReader {
         sessionIndex: String(idx),
         transcriptPath,
         createdAt,
-        endedAt: createdAt, // will be filled from JSONL by conversation builder
+        // endedAt isn't stored in the checkpoint metadata; EntireProvider fills
+        // it from the last turn timestamp when parsing the JSONL transcript.
+        endedAt: createdAt,
         branch: smeta.branch ?? cpMeta.branch ?? "",
         agent: smeta.agent ?? "",
         turnCount: smeta.session_metrics?.turn_count ?? 0,

--- a/src/plugins/context/entire/conversation-builder.ts
+++ b/src/plugins/context/entire/conversation-builder.ts
@@ -39,6 +39,7 @@ export interface SessionMarkdownInput {
 
 /**
  * Select rendering mode based on total turn count.
+ * Mirrors the same thresholds used by HistoryProvider to keep context depth consistent.
  *   ≤10  → full
  *   11-25 → balanced
  *   >25  → compact
@@ -51,6 +52,7 @@ export function selectMode(totalTurns: number): ContextMode {
 
 // ─── Token estimation ─────────────────────────────────────────────────────────
 
+// Rough heuristic: 1 token ≈ 4 chars for English/code mixed text.
 export function estimateTokens(text: string): number {
   return Math.floor(text.length / 4);
 }
@@ -197,6 +199,16 @@ interface RawEvent {
   gitBranch?: string;
 }
 
+/**
+ * Parse a Claude Code JSONL transcript into structured turns.
+ *
+ * The JSONL format emitted by Claude Code contains one JSON object per line,
+ * with `type` being either "user" or "assistant". Tool results appear as
+ * "user" messages with `tool_result` content blocks — these are filtered out
+ * since they duplicate information already captured in the assistant's tool_use
+ * blocks. Only Edit and Write tool calls are surfaced; read-only tools are skipped
+ * because they don't contribute meaningful context about what the agent did.
+ */
 export function parseJsonlToTurns(jsonl: string): ParseResult {
   const events: RawEvent[] = [];
   for (const rawLine of jsonl.split("\n")) {
@@ -284,7 +296,7 @@ export function parseJsonlToTurns(jsonl: string): ParseResult {
               fileContent: inp.content ?? "",
             });
           }
-          // Skip Read, Bash, Grep, Glob, etc.
+          // Skip Read, Bash, Grep, Glob, etc. — these don't show what was *changed*
         }
       }
 

--- a/src/plugins/context/entire/entire-provider.ts
+++ b/src/plugins/context/entire/entire-provider.ts
@@ -4,6 +4,18 @@ import { DEFAULT_MAX_TOKENS, TOKENS_PER_TURN_ESTIMATE } from "../context-provide
 import { CheckpointReader } from "./checkpoint-reader.js";
 import { parseJsonlToTurns, buildSessionMarkdown, mergeSessionsMarkdown, selectMode, estimateTokens, type SessionMarkdownInput } from "./conversation-builder.js";
 
+/**
+ * Context provider backed by Claude Code checkpoint data stored in the git repo.
+ *
+ * Only available when the repo has an `origin/entire/checkpoints/v1` branch,
+ * which is pushed by the Entire Claude Code extension. Supports all query types
+ * (branch, commit, PR, session, latest) by reading checkpoint metadata and
+ * reconstructing conversation turns from JSONL transcripts.
+ *
+ * Used as a lower-priority fallback after HistoryProvider: the live history
+ * recorder takes precedence for sessions still in memory, while this provider
+ * covers older sessions or cross-branch queries.
+ */
 export class EntireProvider implements ContextProvider {
   readonly name = "entire";
 
@@ -31,7 +43,8 @@ export class EntireProvider implements ContextProvider {
       return { markdown: "", tokenEstimate: 0, sessionCount: 0, totalTurns: 0, mode: "full", truncated: false, timeRange: { start: "", end: "" } };
     }
 
-    // Rebuild each session, cache parsed turns for potential re-render
+    // Parse all transcripts upfront so we know total turns before selecting mode.
+    // We may need to re-render with a different mode, so we keep the raw JSONL.
     const parsedSessions: { session: SessionInfo; jsonl: string; }[] = [];
     for (const sess of sessions) {
       const jsonl = reader.getTranscript(sess.transcriptPath);

--- a/src/plugins/context/entire/message-cleaner.ts
+++ b/src/plugins/context/entire/message-cleaner.ts
@@ -1,3 +1,6 @@
+// Claude Code injects XML tags into user prompts to pass context (IDE state, commands, etc.).
+// These tags are machine-generated noise that would pollute the conversation history shown
+// to the next agent. Strip them before storing or rendering turns.
 const SYSTEM_TAG_PATTERNS: RegExp[] = [
   /<system-reminder>[\s\S]*?<\/system-reminder>/g,
   /<local-command-caveat>[\s\S]*?<\/local-command-caveat>/g,
@@ -14,8 +17,16 @@ const SYSTEM_TAG_PATTERNS: RegExp[] = [
   /<task-notification>[\s\S]*?<\/task-notification>/g,
 ];
 
+// `<command-args>` is special: its content is the user-visible portion of a slash command.
+// Preserve that text while stripping the wrapping tag.
 const COMMAND_ARGS_RE = /<command-args>([\s\S]*?)<\/command-args>/;
 
+/**
+ * Remove Claude Code XML injection tags from a user message.
+ *
+ * `<command-args>` content is extracted and appended as plain text so the
+ * human-readable portion of slash commands survives after tag removal.
+ */
 export function cleanSystemTags(text: string): string {
   const argsMatch = COMMAND_ARGS_RE.exec(text);
   const userArgs = argsMatch?.[1]?.trim() ?? "";
@@ -29,6 +40,9 @@ export function cleanSystemTags(text: string): string {
   return text || userArgs;
 }
 
+// Skill prompts are large structured instructions injected by the slash-command system.
+// They're not real user messages — including them in history would add thousands of tokens
+// of structured boilerplate that provides no useful context for subsequent agents.
 const SKILL_INDICATORS = [
   "Base directory for this skill:",
   "<HARD-GATE>",
@@ -39,10 +53,15 @@ const SKILL_INDICATORS = [
   "You MUST create a task for each",
 ];
 
+/**
+ * Returns true for injected skill/command prompts that should be omitted from history.
+ * Heuristic: known indicator strings OR very long prompts with many H2 headers.
+ */
 export function isSkillPrompt(text: string): boolean {
   for (const indicator of SKILL_INDICATORS) {
     if (text.includes(indicator)) return true;
   }
+  // Long prompts with 3+ H2 headers are almost certainly structured skill instructions
   if (text.length > 2000) {
     const headerCount = (text.match(/## /g) || []).length;
     if (headerCount >= 3) return true;
@@ -50,12 +69,17 @@ export function isSkillPrompt(text: string): boolean {
   return false;
 }
 
+/**
+ * Returns true for short, meaningless messages that don't belong in history.
+ * Covers: blank messages after tag removal, model-select commands, deprecated command stubs.
+ */
 export function isNoiseMessage(text: string): boolean {
   const cleaned = cleanSystemTags(text);
   if (!cleaned) return true;
   if (/^(ready|ready\.)$/i.test(cleaned)) return true;
   if (cleaned.includes("Tell your human partner that this command is deprecated")) return true;
   if (cleaned.startsWith("Read the output file to retrieve the result:")) return true;
+  // Model selection shortcuts (e.g. "sonnet", "opus[1m]") — not real user messages
   if (/^(opus|sonnet|haiku|claude)(\[.*\])?$/i.test(cleaned)) return true;
   return false;
 }

--- a/src/plugins/context/history/history-context-builder.ts
+++ b/src/plugins/context/history/history-context-builder.ts
@@ -1,16 +1,29 @@
 import type { ContextMode } from "../context-provider.js";
 import type { Turn, Step, ToolCallStep } from "./types.js";
 
+/**
+ * Choose a rendering mode based on the total number of turns.
+ * Short sessions get full fidelity; large sessions fall back to compact
+ * to stay within the prompt token budget.
+ *   ≤10 turns  → full
+ *   11-25 turns → balanced
+ *   >25 turns  → compact
+ */
 export function selectLevel(turnCount: number): ContextMode {
   if (turnCount <= 10) return "full";
   if (turnCount <= 25) return "balanced";
   return "compact";
 }
 
+// Rough heuristic: 1 token ≈ 4 chars for English/code mixed text.
 export function estimateTokens(text: string): number {
   return Math.floor(text.length / 4);
 }
 
+/**
+ * Render a list of turns to markdown in the requested detail level.
+ * Used both for single-session display and as a building block for merged output.
+ */
 export function buildHistoryMarkdown(turns: Turn[], mode: ContextMode): string {
   if (turns.length === 0) return "";
   switch (mode) {

--- a/src/plugins/context/history/history-provider.ts
+++ b/src/plugins/context/history/history-provider.ts
@@ -26,6 +26,16 @@ const EMPTY_RESULT: ContextResult = {
   timeRange: { start: "", end: "" },
 };
 
+/**
+ * Context provider backed by the local HistoryStore (recorded by HistoryRecorder).
+ *
+ * Always available (does not require git or external tools).
+ * Supports `type: "session"` (exact match) and `type: "latest"` (N most recent).
+ * Branch/commit/PR queries are unsupported — the EntireProvider handles those.
+ *
+ * Context detail is auto-downgraded from "full" → "balanced" → "compact" and
+ * oldest sessions are dropped if the result would exceed `maxTokens`.
+ */
 export class HistoryProvider implements ContextProvider {
   readonly name = "local";
 

--- a/src/plugins/context/history/history-recorder.ts
+++ b/src/plugins/context/history/history-recorder.ts
@@ -63,6 +63,8 @@ function extractLocations(
   return result.length > 0 ? result : undefined;
 }
 
+// These event types carry no meaningful conversation history — skip them to keep
+// the history compact and avoid noise in future context builds.
 const IGNORED_TYPES = new Set([
   "session_end",
   "error",
@@ -74,8 +76,23 @@ const IGNORED_TYPES = new Set([
   "tts_strip",
 ]);
 
+// Debounce intermediate writes — during a long agent turn, events arrive at high
+// frequency. We flush at most once per 2s so we don't hammer the disk, but we
+// always do a final write on turn end regardless of the debounce timer.
 const DEBOUNCE_MS = 2000;
 
+/**
+ * Records conversation turns to the HistoryStore in real-time by hooking into
+ * the `agent:beforePrompt`, `agent:afterEvent`, `turn:end`, `permission:afterResolve`,
+ * and `session:afterDestroy` middleware hooks.
+ *
+ * Each call to `onBeforePrompt` opens a new user→assistant turn pair.
+ * `onAfterEvent` streams agent events into the current assistant turn.
+ * `onTurnEnd` finalises the turn and flushes to disk.
+ *
+ * In-memory state is keyed by sessionId. Sessions are cleaned up on destroy
+ * or explicit `finalize()`.
+ */
 export class HistoryRecorder {
   private states = new Map<string, RecorderState>();
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -336,6 +353,8 @@ export class HistoryRecorder {
     }
   }
 
+  // Search backwards so we match the most recent tool call with this ID first,
+  // in case the same tool is invoked multiple times within one turn.
   private findToolCall(steps: Step[], id: string): ToolCallStep | undefined {
     for (let i = steps.length - 1; i >= 0; i--) {
       const s = steps[i];

--- a/src/plugins/context/history/history-store.ts
+++ b/src/plugins/context/history/history-store.ts
@@ -2,6 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import type { SessionHistory } from "./types.js";
 
+/**
+ * Persists session history to disk as one JSON file per session.
+ *
+ * Files are stored as `<dir>/<sessionId>.json`. The path is validated to prevent
+ * directory traversal — session IDs that resolve outside `dir` are rejected.
+ */
 export class HistoryStore {
   constructor(private readonly dir: string) {}
 
@@ -50,6 +56,8 @@ export class HistoryStore {
   }
 
   private filePath(sessionId: string): string {
+    // Use basename to strip any path components from the session ID, then
+    // verify the resolved path stays within the store directory.
     const basename = path.basename(sessionId);
     const resolved = path.join(this.dir, `${basename}.json`);
     if (!resolved.startsWith(this.dir)) {

--- a/src/plugins/context/history/types.ts
+++ b/src/plugins/context/history/types.ts
@@ -1,11 +1,22 @@
 import type { Attachment } from "../../../core/types.js";
 
+/**
+ * Root structure persisted to disk for one session.
+ * `version` allows future schema migrations without breaking existing files.
+ */
 export interface SessionHistory {
   version: 1;
   sessionId: string;
   turns: Turn[];
 }
 
+/**
+ * One complete user→assistant exchange within a session.
+ *
+ * User turns carry `content` + optional `attachments`.
+ * Assistant turns carry `steps` (the sequence of actions the agent took)
+ * plus optional `usage` (token/cost accounting) and `stopReason`.
+ */
 export interface Turn {
   index: number;
   role: "user" | "assistant";

--- a/src/plugins/context/index.ts
+++ b/src/plugins/context/index.ts
@@ -8,6 +8,15 @@ import { HistoryRecorder } from './history/history-recorder.js'
 import { HistoryStore } from './history/history-store.js'
 import { Hook } from '../../core/events.js'
 
+/**
+ * Context plugin — records conversation history and injects it into agent prompts.
+ *
+ * Setup wires up five middleware hooks that together keep a rolling history of every
+ * session on disk and prepend it to the next agent prompt via `agent:beforePrompt`.
+ * Two providers are registered in priority order:
+ *   1. HistoryProvider (local) — always available, covers live/recent sessions
+ *   2. EntireProvider — available when the repo has the Entire checkpoint branch
+ */
 const contextPlugin: OpenACPPlugin = {
   name: '@openacp/context',
   version: '1.0.0',

--- a/src/plugins/core-plugins.ts
+++ b/src/plugins/core-plugins.ts
@@ -13,6 +13,20 @@ import apiServerPlugin from './api-server/index.js'
 import sseAdapterPlugin from './sse-adapter/index.js'
 import telegramPlugin from './telegram/index.js'
 
+/**
+ * Ordered list of all bundled plugins, passed to `LifecycleManager.boot()` on startup.
+ *
+ * Boot order matters: plugins listed earlier are set up first. Dependencies declared
+ * via `pluginDependencies` / `optionalPluginDependencies` are enforced by the
+ * lifecycle manager, but the order here also determines boot sequence within each
+ * dependency tier:
+ *
+ * 1. **Service plugins** — security, file-service, context, speech, notifications.
+ *    These provide services that infrastructure and adapter plugins depend on.
+ * 2. **Infrastructure plugins** — tunnel (exposes the local server), api-server (HTTP + SSE).
+ * 3. **Adapter plugins** — sse-adapter, telegram. Both depend on api-server, security, and
+ *    notifications, so they must boot after those services are ready.
+ */
 export const corePlugins = [
   // Service plugins (no adapter dependencies)
   securityPlugin,

--- a/src/plugins/file-service/file-service.ts
+++ b/src/plugins/file-service/file-service.ts
@@ -44,6 +44,17 @@ function classifyMime(mimeType: string): Attachment["type"] {
   return "file";
 }
 
+/**
+ * Provides file I/O for session attachments and agent-generated files.
+ *
+ * All files are stored under `baseDir/<sessionId>/` so that access is naturally
+ * scoped per session and cleanup is a single directory removal. File names are
+ * sanitized and prefixed with a timestamp to prevent collisions and path traversal.
+ *
+ * This service acts as the security boundary between adapters/agents and the
+ * filesystem — callers never write directly; they go through `saveFile` so that
+ * naming, MIME classification, and path normalization are always applied.
+ */
 export class FileService {
   constructor(readonly baseDir: string) {}
 
@@ -75,6 +86,14 @@ export class FileService {
     return removed;
   }
 
+  /**
+   * Persist a file to the session's directory and return an `Attachment` descriptor.
+   *
+   * The file name is sanitized (non-safe characters replaced with `_`) and prefixed
+   * with a millisecond timestamp to prevent name collisions across multiple saves in
+   * the same session. The original `fileName` is preserved in the returned descriptor
+   * so the user-facing name is not lost.
+   */
   async saveFile(
     sessionId: string,
     fileName: string,
@@ -84,6 +103,7 @@ export class FileService {
     const sessionDir = path.join(this.baseDir, sessionId);
     await fs.promises.mkdir(sessionDir, { recursive: true });
 
+    // Sanitize to prevent path traversal and filesystem issues
     const safeName = `${Date.now()}-${fileName.replace(/[^a-zA-Z0-9._-]/g, "_")}`;
     const filePath = path.join(sessionDir, safeName);
     await fs.promises.writeFile(filePath, data);
@@ -97,6 +117,10 @@ export class FileService {
     };
   }
 
+  /**
+   * Build an `Attachment` descriptor for a file that already exists on disk.
+   * Returns `null` if the path does not exist or is not a regular file.
+   */
   async resolveFile(filePath: string): Promise<Attachment | null> {
     try {
       const stat = await fs.promises.stat(filePath);
@@ -155,6 +179,7 @@ export class FileService {
     return FileService.extensionFromMime(mimeType);
   }
 
+  /** Returns the canonical file extension for a given MIME type (e.g. `"image/png"` → `".png"`). */
   static extensionFromMime(mimeType: string): string {
     return MIME_TO_EXT[mimeType] || ".bin";
   }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,5 @@
+// Legacy export name kept for backward compatibility — callers that import
+// `builtInPlugins` from this path continue to work unchanged.
 import securityPlugin from './security/index.js'
 import fileServicePlugin from './file-service/index.js'
 import contextPlugin from './context/index.js'

--- a/src/plugins/notifications/index.ts
+++ b/src/plugins/notifications/index.ts
@@ -7,6 +7,7 @@ function createNotificationsPlugin(): OpenACPPlugin {
     version: '1.0.0',
     description: 'Cross-session notification routing',
     essential: false,
+    // Depends on security so the notification service is only active for authorized sessions
     pluginDependencies: { '@openacp/security': '^1.0.0' },
     permissions: ['services:register', 'kernel:access'],
 

--- a/src/plugins/notifications/notification.ts
+++ b/src/plugins/notifications/notification.ts
@@ -1,9 +1,27 @@
 import type { IChannelAdapter } from '../../core/channel.js'
 import type { NotificationMessage } from '../../core/types.js'
 
+/**
+ * Routes cross-session notifications to the appropriate channel adapter.
+ *
+ * Notifications are triggered by `SessionBridge` when a session completes,
+ * errors, or hits a budget threshold. Unlike regular messages, notifications
+ * are not tied to a specific outgoing message stream — they are pushed to the
+ * channel that owns the session (identified by `channelId` on the session).
+ *
+ * The adapters Map is the live registry maintained by `OpenACPCore`. Holding a
+ * reference to the Map (rather than a snapshot) ensures that adapters registered
+ * after this service is created are still reachable.
+ */
 export class NotificationManager {
   constructor(private adapters: Map<string, IChannelAdapter>) {}
 
+  /**
+   * Send a notification to a specific channel adapter.
+   *
+   * Failures are swallowed — notifications are best-effort and must not crash
+   * the session or caller (e.g. on session completion).
+   */
   async notify(channelId: string, notification: NotificationMessage): Promise<void> {
     const adapter = this.adapters.get(channelId)
     if (!adapter) return
@@ -14,6 +32,12 @@ export class NotificationManager {
     }
   }
 
+  /**
+   * Broadcast a notification to every registered adapter.
+   *
+   * Used for system-wide alerts (e.g. global budget exhausted). Each adapter
+   * failure is isolated so one broken adapter cannot block the rest.
+   */
   async notifyAll(notification: NotificationMessage): Promise<void> {
     for (const adapter of this.adapters.values()) {
       try {

--- a/src/plugins/security/index.ts
+++ b/src/plugins/security/index.ts
@@ -19,6 +19,7 @@ function createSecurityPlugin(): OpenACPPlugin {
     description: 'User access control and session limits',
     essential: false,
     permissions: ['services:register', 'middleware:register', 'kernel:access', 'commands:register'],
+    // These keys are propagated to child plugin configs so adapters can read them directly.
     inheritableKeys: ['allowedUserIds', 'maxConcurrentSessions', 'sessionTimeoutMinutes'],
 
     async install(ctx: InstallContext) {
@@ -96,6 +97,8 @@ function createSecurityPlugin(): OpenACPPlugin {
       const settingsManager = core.lifecycleManager?.settingsManager
       const pluginName = ctx.pluginName
 
+      // Config is re-fetched on every call so that hot-reload changes take effect
+      // without requiring a plugin restart.
       const getSecurityConfig = async (): Promise<SecurityConfig> => {
         if (settingsManager) {
           const settings = await settingsManager.loadSettings(pluginName)

--- a/src/plugins/security/security-guard.ts
+++ b/src/plugins/security/security-guard.ts
@@ -1,14 +1,39 @@
+/**
+ * Configuration for the SecurityGuard access policy.
+ *
+ * `allowedUserIds`: if non-empty, only users whose string ID appears in this list
+ * are permitted. An empty array means "allow all" (open access).
+ * `maxConcurrentSessions`: caps how many active/initializing sessions may exist
+ * at once across all users, preventing resource exhaustion.
+ */
 export interface SecurityConfig {
   allowedUserIds: string[];
   maxConcurrentSessions: number;
 }
 
+/**
+ * Enforces user allowlist and global session-count limits on every incoming message.
+ *
+ * Implemented as a plugin service (rather than baked into core) so that the access
+ * policy is swappable — deployments can replace or extend it without touching core.
+ * The plugin registers this guard as a `message:incoming` middleware handler.
+ */
 export class SecurityGuard {
   constructor(
     private getSecurityConfig: () => Promise<SecurityConfig>,
     private sessionManager: { listSessions(): Array<{ status: string }> },
   ) {}
 
+  /**
+   * Returns `{ allowed: true }` when the message may proceed, or
+   * `{ allowed: false, reason }` when it should be blocked.
+   *
+   * Two checks run in order:
+   * 1. **Allowlist** — if `allowedUserIds` is non-empty, the user's ID (coerced to string)
+   *    must appear in the list. Telegram/Slack IDs are numbers, so coercion is required.
+   * 2. **Session cap** — counts sessions in `active` or `initializing` state. `initializing`
+   *    is included because a session holds resources before it reaches `active`.
+   */
   async checkAccess(message: { userId: string | number }):
     Promise<{ allowed: true } | { allowed: false; reason: string }>
   {
@@ -17,6 +42,7 @@ export class SecurityGuard {
     const maxSessions = config.maxConcurrentSessions ?? 20;
 
     if (allowedIds.length > 0) {
+      // Coerce to string: platform adapters may deliver userId as a number (e.g. Telegram)
       const userId = String(message.userId);
       if (!allowedIds.includes(userId)) {
         return { allowed: false, reason: "Unauthorized user" };

--- a/src/plugins/speech/exports.ts
+++ b/src/plugins/speech/exports.ts
@@ -1,3 +1,5 @@
+// Public surface of the speech plugin — re-exported for use by the plugin index
+// and by external TTS plugins that need to register against SpeechService.
 export type { STTProvider, TTSProvider, STTOptions, STTResult, TTSOptions, TTSResult, SpeechServiceConfig, SpeechProviderConfig } from './speech-types.js';
 export { SpeechService } from './speech-service.js';
 export { GroqSTT } from './providers/groq.js';

--- a/src/plugins/speech/index.ts
+++ b/src/plugins/speech/index.ts
@@ -6,6 +6,8 @@ import { SpeechService, GroqSTT } from './exports.js'
 import type { SpeechServiceConfig } from './exports.js'
 import { installNpmPlugin } from '../../core/plugin/plugin-installer.js'
 
+// TTS is provided by a separate optional plugin so the core speech plugin
+// doesn't bundle a large native dependency on every install.
 const EDGE_TTS_PLUGIN = '@openacp/msedge-tts-plugin'
 
 const speechPlugin: OpenACPPlugin = {
@@ -13,6 +15,7 @@ const speechPlugin: OpenACPPlugin = {
   version: '1.0.0',
   description: 'Text-to-speech and speech-to-text with pluggable providers',
   essential: false,
+  // file-service is needed to persist synthesized audio for adapters that send files
   optionalPluginDependencies: { '@openacp/file-service': '^1.0.0' },
   permissions: ['services:register', 'commands:register', 'kernel:access'],
   inheritableKeys: ['ttsProvider', 'ttsVoice'],
@@ -129,6 +132,7 @@ const speechPlugin: OpenACPPlugin = {
     const config = ctx.pluginConfig as Record<string, unknown>
     const groqApiKey = config.groqApiKey as string | undefined
 
+    // STT provider is determined solely by whether an API key is present
     const sttProvider = groqApiKey ? 'groq' : null
     const speechConfig: SpeechServiceConfig = {
       stt: {
@@ -201,6 +205,7 @@ const speechPlugin: OpenACPPlugin = {
             const mod = await installNpmPlugin(EDGE_TTS_PLUGIN, pluginsDir)
             const plugin = mod.default
             if (plugin && ctx.core) {
+              // Boot the newly installed plugin without restarting the process
               const lm = (ctx.core as OpenACPCore).lifecycleManager
               const registry = lm.registry
               if (registry) {

--- a/src/plugins/speech/providers/groq.ts
+++ b/src/plugins/speech/providers/groq.ts
@@ -1,7 +1,17 @@
 import type { STTProvider, STTOptions, STTResult } from '../speech-types.js';
 
+// Groq's Whisper-compatible transcription endpoint (OpenAI-compatible API)
 const GROQ_API_URL = "https://api.groq.com/openai/v1/audio/transcriptions";
 
+/**
+ * Speech-to-text provider backed by Groq's hosted Whisper API.
+ *
+ * Groq requires the audio to be submitted as a multipart form upload. The file
+ * must have a valid extension matching its MIME type — Groq uses the extension
+ * to determine the codec, so a mismatch causes a transcription error.
+ *
+ * Free tier limit: 28,800 seconds of audio per day. Max file size: 25 MB.
+ */
 export class GroqSTT implements STTProvider {
   readonly name = "groq";
 
@@ -10,9 +20,16 @@ export class GroqSTT implements STTProvider {
     private defaultModel: string = "whisper-large-v3-turbo",
   ) {}
 
+  /**
+   * Transcribes audio using the Groq Whisper API.
+   *
+   * `verbose_json` response format is requested so the API returns language
+   * detection and duration metadata alongside the transcript text.
+   */
   async transcribe(audioBuffer: Buffer, mimeType: string, options?: STTOptions): Promise<STTResult> {
     const ext = mimeToExt(mimeType);
     const form = new FormData();
+    // Groq uses the filename extension to identify the audio codec — must match mimeType
     form.append("file", new Blob([new Uint8Array(audioBuffer)], { type: mimeType }), `audio${ext}`);
     form.append("model", options?.model || this.defaultModel);
     form.append("response_format", "verbose_json");
@@ -49,6 +66,7 @@ export class GroqSTT implements STTProvider {
   }
 }
 
+/** Maps MIME types to file extensions required by the Groq upload API. */
 function mimeToExt(mimeType: string): string {
   const map: Record<string, string> = {
     "audio/ogg": ".ogg",

--- a/src/plugins/speech/speech-service.ts
+++ b/src/plugins/speech/speech-service.ts
@@ -1,7 +1,25 @@
 import type { STTProvider, TTSProvider, STTOptions, STTResult, TTSOptions, TTSResult, SpeechServiceConfig } from './speech-types.js';
 
+/**
+ * A factory that recreates provider instances from a new config snapshot.
+ * Used for hot-reload: when settings change, the plugin calls `refreshProviders`
+ * which invokes this factory to build fresh provider objects.
+ *
+ * Returns separate Maps for STT and TTS so that externally-registered providers
+ * (e.g. from `@openacp/msedge-tts-plugin`) are not discarded — only factory-owned
+ * providers are overwritten.
+ */
 export type ProviderFactory = (config: SpeechServiceConfig) => { stt: Map<string, STTProvider>; tts: Map<string, TTSProvider> };
 
+/**
+ * Central service for speech-to-text and text-to-speech operations.
+ *
+ * Providers are registered at setup time and may also be registered by external
+ * plugins (e.g. `@openacp/msedge-tts-plugin` registers a TTS provider after boot).
+ * The service itself is registered under the `"speech"` key in the ServiceRegistry
+ * and accessed by `session.ts` to synthesize audio after agent responses when
+ * `voiceMode` is active.
+ */
 export class SpeechService {
   private sttProviders = new Map<string, STTProvider>();
   private ttsProviders = new Map<string, TTSProvider>();
@@ -14,28 +32,43 @@ export class SpeechService {
     this.providerFactory = factory;
   }
 
+  /** Register an STT provider by name. Overwrites any existing provider with the same name. */
   registerSTTProvider(name: string, provider: STTProvider): void {
     this.sttProviders.set(name, provider);
   }
 
+  /** Register a TTS provider by name. Called by external TTS plugins (e.g. msedge-tts-plugin). */
   registerTTSProvider(name: string, provider: TTSProvider): void {
     this.ttsProviders.set(name, provider);
   }
 
+  /** Remove a TTS provider — called by external plugins on teardown. */
   unregisterTTSProvider(name: string): void {
     this.ttsProviders.delete(name);
   }
 
+  /** Returns true if an STT provider is configured and has credentials. */
   isSTTAvailable(): boolean {
     const { provider, providers } = this.config.stt;
     return provider !== null && providers[provider]?.apiKey !== undefined;
   }
 
+  /**
+   * Returns true if a TTS provider is configured and an implementation is registered.
+   *
+   * Config alone is not enough — the TTS provider plugin must have registered
+   * its implementation via `registerTTSProvider` before this returns true.
+   */
   isTTSAvailable(): boolean {
     const provider = this.config.tts.provider;
     return provider !== null && this.ttsProviders.has(provider);
   }
 
+  /**
+   * Transcribes audio using the configured STT provider.
+   *
+   * @throws if no STT provider is configured or if the named provider is not registered.
+   */
   async transcribe(audioBuffer: Buffer, mimeType: string, options?: STTOptions): Promise<STTResult> {
     const providerName = this.config.stt.provider;
     if (!providerName || !this.config.stt.providers[providerName]?.apiKey) {
@@ -48,6 +81,11 @@ export class SpeechService {
     return provider.transcribe(audioBuffer, mimeType, options);
   }
 
+  /**
+   * Synthesizes speech using the configured TTS provider.
+   *
+   * @throws if no TTS provider is configured or if the named provider is not registered.
+   */
   async synthesize(text: string, options?: TTSOptions): Promise<TTSResult> {
     const providerName = this.config.tts.provider;
     if (!providerName) {
@@ -60,11 +98,18 @@ export class SpeechService {
     return provider.synthesize(text, options);
   }
 
+  /** Replace the active config without rebuilding providers. Use `refreshProviders` to also rebuild. */
   updateConfig(config: SpeechServiceConfig): void {
     this.config = config;
   }
 
-  /** Re-create factory-managed providers from config. Preserves externally-registered providers (e.g. from plugins). */
+  /**
+   * Reloads TTS and STT providers from a new config snapshot.
+   *
+   * Called after config changes or plugin hot-reload. Factory-managed providers are
+   * rebuilt via the registered `ProviderFactory`; externally-registered providers
+   * (e.g. from `@openacp/msedge-tts-plugin`) are preserved rather than discarded.
+   */
   refreshProviders(newConfig: SpeechServiceConfig): void {
     this.config = newConfig;
     if (this.providerFactory) {

--- a/src/plugins/speech/speech-types.ts
+++ b/src/plugins/speech/speech-types.ts
@@ -1,41 +1,61 @@
+/** Options passed to an STT provider for a single transcription request. */
 export interface STTOptions {
+  /** BCP-47 language code hint (e.g. `"en"`, `"vi"`). Improves accuracy when known. */
   language?: string;
+  /** Override the default model for this request. */
   model?: string;
 }
 
+/** Result returned by an STT provider after transcription. */
 export interface STTResult {
   text: string;
+  /** Detected or confirmed language (BCP-47). */
   language?: string;
+  /** Audio duration in seconds. */
   duration?: number;
 }
 
+/** Options passed to a TTS provider for a single synthesis request. */
 export interface TTSOptions {
   language?: string;
+  /** Voice identifier (provider-specific, e.g. `"en-US-AriaNeural"` for Edge TTS). */
   voice?: string;
   model?: string;
 }
 
+/** Audio data produced by a TTS provider. */
 export interface TTSResult {
   audioBuffer: Buffer;
+  /** MIME type of the audio (e.g. `"audio/mp3"`, `"audio/wav"`). */
   mimeType: string;
 }
 
+/** Contract for a speech-to-text provider. */
 export interface STTProvider {
   readonly name: string;
   transcribe(audioBuffer: Buffer, mimeType: string, options?: STTOptions): Promise<STTResult>;
 }
 
+/** Contract for a text-to-speech provider. */
 export interface TTSProvider {
   readonly name: string;
   synthesize(text: string, options?: TTSOptions): Promise<TTSResult>;
 }
 
+/** Provider-level configuration stored in plugin settings (API key, model override, etc.). */
 export interface SpeechProviderConfig {
   apiKey?: string;
   model?: string;
   [key: string]: unknown;
 }
 
+/**
+ * Top-level configuration for SpeechService.
+ *
+ * `stt.provider` and `tts.provider` name the active provider.
+ * `null` disables the respective capability.
+ * `providers` holds per-provider credentials and options.
+ */
 export interface SpeechServiceConfig {
   stt: {
     provider: string | null;

--- a/src/plugins/sse-adapter/adapter.ts
+++ b/src/plugins/sse-adapter/adapter.ts
@@ -10,8 +10,27 @@ import {
   serializeSSE,
 } from './event-serializer.js';
 
+// Keep idle connections alive through proxy timeout windows (typically 60–90 s).
+// 30 s is well within that range while being infrequent enough to not generate noise.
 const HEARTBEAT_INTERVAL_MS = 30_000;
 
+/**
+ * SSE-based channel adapter for the OpenACP web app.
+ *
+ * Unlike Telegram/Slack adapters (which extend `MessagingAdapter` and have
+ * platform-specific rendering), SSEAdapter implements `IChannelAdapter` directly.
+ * It does not format messages — it serializes them as JSON and pushes them over
+ * the SSE stream so the web app can render them natively.
+ *
+ * Key differences from Telegram/Slack:
+ * - No platform SDK: communication is via raw HTTP responses (Node.js `ServerResponse`).
+ * - No threads: SSE has no concept of topics — `createSessionThread` returns sessionId.
+ * - Every outbound event is also pushed to the `EventBuffer` so reconnecting clients
+ *   can catch up via `Last-Event-ID` replay.
+ *
+ * Session connections are managed by `ConnectionManager`. A session can have multiple
+ * concurrent SSE connections (e.g. two open browser tabs), all receiving the same events.
+ */
 export class SSEAdapter implements IChannelAdapter {
   readonly name = 'sse';
   readonly capabilities: AdapterCapabilities = {
@@ -30,6 +49,12 @@ export class SSEAdapter implements IChannelAdapter {
     private readonly eventBuffer: EventBuffer,
   ) {}
 
+  /**
+   * Starts the heartbeat timer that keeps idle SSE connections alive.
+   *
+   * `.unref()` prevents the timer from blocking the Node.js event loop from
+   * exiting if this is the only remaining async operation (e.g. during tests).
+   */
   async start(): Promise<void> {
     this.heartbeatTimer = setInterval(() => {
       const heartbeat = serializeHeartbeat();
@@ -45,6 +70,7 @@ export class SSEAdapter implements IChannelAdapter {
     }
   }
 
+  /** Stops the heartbeat timer and closes all active connections. */
   async stop(): Promise<void> {
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
@@ -53,6 +79,13 @@ export class SSEAdapter implements IChannelAdapter {
     this.connectionManager.cleanup();
   }
 
+  /**
+   * Serializes an outgoing agent message, pushes it to the event buffer,
+   * then broadcasts it to all active connections for the session.
+   *
+   * Buffering before broadcast ensures that a client reconnecting immediately
+   * after this call can still replay the event via `Last-Event-ID`.
+   */
   async sendMessage(sessionId: string, content: OutgoingMessage): Promise<void> {
     const eventId = generateEventId();
     const serialized = serializeOutgoingMessage(sessionId, eventId, content);
@@ -60,6 +93,7 @@ export class SSEAdapter implements IChannelAdapter {
     this.connectionManager.broadcast(sessionId, serialized);
   }
 
+  /** Serializes and delivers a permission request UI to the session's SSE clients. */
   async sendPermissionRequest(sessionId: string, request: PermissionRequest): Promise<void> {
     const eventId = generateEventId();
     const serialized = serializePermissionRequest(sessionId, eventId, request);
@@ -67,23 +101,27 @@ export class SSEAdapter implements IChannelAdapter {
     this.connectionManager.broadcast(sessionId, serialized);
   }
 
+  /**
+   * Delivers a cross-session notification to the target session's SSE clients.
+   *
+   * Notifications are always buffered in addition to being broadcast so that
+   * a client reconnecting shortly after (e.g. page refresh) still sees the alert.
+   */
   async sendNotification(notification: NotificationMessage): Promise<void> {
-    // Notifications include a sessionId — buffer and broadcast to that session's connections
     if (notification.sessionId) {
       const eventId = generateEventId();
       const serialized = serializeSSE('notification', eventId, notification);
-      // Always buffer so reconnecting clients can receive missed notifications
       this.eventBuffer.push(notification.sessionId, { id: eventId, data: serialized });
       this.connectionManager.broadcast(notification.sessionId, serialized);
     }
   }
 
+  /** SSE has no concept of threads — return sessionId as the threadId */
   async createSessionThread(sessionId: string, _name: string): Promise<string> {
-    // SSE has no concept of threads — return sessionId as the threadId
     return sessionId;
   }
 
+  /** No-op for SSE — there are no named threads to rename. */
   async renameSessionThread(_sessionId: string, _newName: string): Promise<void> {
-    // No-op for SSE
   }
 }

--- a/src/plugins/sse-adapter/connection-manager.ts
+++ b/src/plugins/sse-adapter/connection-manager.ts
@@ -1,6 +1,15 @@
 import type { ServerResponse } from 'node:http';
 import { randomBytes } from 'node:crypto';
 
+/**
+ * Represents a single active SSE connection from a web client.
+ *
+ * `tokenId` is the auth token that opened this connection — used to forcibly
+ * disconnect all connections when a token is revoked.
+ * `lastEventId` tracks the most recent event delivered, for reconnection replay.
+ * `backpressured` indicates that the last `response.write()` returned false,
+ * meaning the OS send buffer is full.
+ */
 export interface SSEConnection {
   id: string;
   sessionId: string;
@@ -11,8 +20,20 @@ export interface SSEConnection {
   backpressured?: boolean;
 }
 
+/**
+ * Tracks all active SSE connections and provides session-scoped broadcast.
+ *
+ * Connections are indexed both globally (by connection ID) and by session ID
+ * so that `broadcast` can efficiently reach only the connections for a given session
+ * without scanning the entire connection set.
+ *
+ * Limits are enforced to prevent resource exhaustion:
+ * - Per-session limit prevents a single session from consuming all file descriptors.
+ * - Global limit caps total memory and FD usage regardless of distribution.
+ */
 export class ConnectionManager {
   private connections = new Map<string, SSEConnection>();
+  // Secondary index: sessionId → Set of connection IDs for O(1) broadcast targeting
   private sessionIndex = new Map<string, Set<string>>();
   private maxConnectionsPerSession: number;
   private maxTotalConnections: number;
@@ -22,6 +43,14 @@ export class ConnectionManager {
     this.maxTotalConnections = opts?.maxTotal ?? 100;
   }
 
+  /**
+   * Registers a new SSE connection for the given session.
+   *
+   * Wires a `close` listener on the response so the connection is automatically
+   * removed when the client disconnects (browser tab closed, network drop, etc.).
+   *
+   * @throws if the global or per-session connection limit is reached.
+   */
   addConnection(sessionId: string, tokenId: string, response: ServerResponse): SSEConnection {
     // Enforce global connection limit
     if (this.connections.size >= this.maxTotalConnections) {
@@ -51,6 +80,7 @@ export class ConnectionManager {
     return connection;
   }
 
+  /** Remove a connection from both indexes. Called automatically on client disconnect. */
   removeConnection(connectionId: string): void {
     const conn = this.connections.get(connectionId);
     if (!conn) return;
@@ -62,6 +92,7 @@ export class ConnectionManager {
     }
   }
 
+  /** Returns all active connections for a session. */
   getConnectionsBySession(sessionId: string): SSEConnection[] {
     const connIds = this.sessionIndex.get(sessionId);
     if (!connIds) return [];
@@ -70,6 +101,14 @@ export class ConnectionManager {
       .filter((c): c is SSEConnection => c !== undefined);
   }
 
+  /**
+   * Writes a serialized SSE event to all connections for the given session.
+   *
+   * Backpressure handling: if `response.write()` returns false (OS send buffer full),
+   * the connection is flagged as `backpressured`. On the next write attempt, if it is
+   * still backpressured, the connection is forcibly closed to prevent unbounded memory
+   * growth from queuing writes on a slow or stalled client.
+   */
   broadcast(sessionId: string, serializedEvent: string): void {
     for (const conn of this.getConnectionsBySession(sessionId)) {
       if (conn.response.writableEnded) continue;
@@ -92,6 +131,10 @@ export class ConnectionManager {
     }
   }
 
+  /**
+   * Force-close all connections associated with a given auth token.
+   * Called when a token is revoked to immediately terminate those streams.
+   */
   disconnectByToken(tokenId: string): void {
     for (const [id, conn] of this.connections) {
       if (conn.tokenId === tokenId) {
@@ -101,10 +144,12 @@ export class ConnectionManager {
     }
   }
 
+  /** Returns a snapshot of all active connections (used by the admin endpoint). */
   listConnections(): SSEConnection[] {
     return Array.from(this.connections.values());
   }
 
+  /** Close all connections and clear all indexes. Called on plugin teardown. */
   cleanup(): void {
     for (const [, conn] of this.connections) {
       if (!conn.response.writableEnded) conn.response.end();

--- a/src/plugins/sse-adapter/event-buffer.ts
+++ b/src/plugins/sse-adapter/event-buffer.ts
@@ -1,13 +1,30 @@
+/** A single buffered SSE event with its ID and serialized wire data. */
 export interface BufferedEvent {
   id: string;
   data: unknown;
 }
 
+/**
+ * Per-session ring buffer of recent SSE events, used to replay missed events on reconnect.
+ *
+ * SSE clients that drop and reconnect send the `Last-Event-ID` header with the ID of
+ * the last event they received. The buffer uses this ID to find the resume point and
+ * replay everything after it — bridging the gap without re-running any agent logic.
+ *
+ * Eviction strategy: when the buffer exceeds `maxSize`, the oldest event is dropped
+ * (FIFO). This means very long disconnections may cause gaps; the route handler signals
+ * this to the client with an `EVENTS_EXPIRED` error event so it can recover gracefully.
+ */
 export class EventBuffer {
   private buffers = new Map<string, BufferedEvent[]>();
 
+  /**
+   * @param maxSize Maximum events retained per session. Older events are evicted when
+   *   this limit is exceeded. Defaults to 100.
+   */
   constructor(private maxSize: number = 100) {}
 
+  /** Append an event to the session's buffer, evicting the oldest entry if at capacity. */
   push(sessionId: string, event: BufferedEvent): void {
     let buffer = this.buffers.get(sessionId);
     if (!buffer) {
@@ -15,11 +32,20 @@ export class EventBuffer {
       this.buffers.set(sessionId, buffer);
     }
     buffer.push(event);
+    // Drop oldest events once the ring is full to bound memory per session
     while (buffer.length > this.maxSize) {
       buffer.shift();
     }
   }
 
+  /**
+   * Returns events that occurred after `lastEventId`.
+   *
+   * - If `lastEventId` is `undefined`, returns all buffered events (fresh connection).
+   * - If `lastEventId` is not found in the buffer, returns `null` — the event has been
+   *   evicted and the client must be informed that a gap may exist.
+   * - Otherwise returns the slice after the matching event.
+   */
   getSince(sessionId: string, lastEventId: string | undefined): BufferedEvent[] | null {
     const buffer = this.buffers.get(sessionId);
     if (!buffer || buffer.length === 0) return [];
@@ -29,6 +55,7 @@ export class EventBuffer {
     return buffer.slice(index + 1);
   }
 
+  /** Remove the buffer for a session — called when the session ends to free memory. */
   cleanup(sessionId: string): void {
     this.buffers.delete(sessionId);
   }

--- a/src/plugins/sse-adapter/event-serializer.ts
+++ b/src/plugins/sse-adapter/event-serializer.ts
@@ -1,5 +1,9 @@
 import type { OutgoingMessage } from '../../core/types.js';
 
+/**
+ * Shape of every SSE event payload sent over the wire.
+ * Clients can use `event`, `id`, and `sessionId` to route and deduplicate messages.
+ */
 export interface SSEEvent {
   event: string;
   id?: string;
@@ -8,12 +12,26 @@ export interface SSEEvent {
   timestamp: string;
 }
 
+// Module-level counter combined with timestamp to guarantee event ID uniqueness
+// within a process, even if multiple events are generated in the same millisecond.
 let eventCounter = 0;
 
+/**
+ * Generates a unique event ID for SSE `id:` fields.
+ *
+ * IDs are used by clients in the `Last-Event-ID` header on reconnect so the
+ * server can replay missed events from the EventBuffer.
+ */
 export function generateEventId(): string {
   return `evt_${Date.now()}_${++eventCounter}`;
 }
 
+/**
+ * Serializes an event name and payload to the SSE wire format.
+ *
+ * SSE format: `event: <name>\nid: <id>\ndata: <json>\n\n`
+ * The double newline terminates the event block and triggers delivery in browsers.
+ */
 export function serializeSSE(event: string, id: string | undefined, data: unknown): string {
   let result = `event: ${event}\n`;
   if (id) {
@@ -23,6 +41,7 @@ export function serializeSSE(event: string, id: string | undefined, data: unknow
   return result;
 }
 
+/** Serialize an outgoing agent message as an SSE `message` event. */
 export function serializeOutgoingMessage(
   sessionId: string,
   eventId: string,
@@ -37,6 +56,7 @@ export function serializeOutgoingMessage(
   });
 }
 
+/** Serialize a permission request as an SSE `permission_request` event. */
 export function serializePermissionRequest(
   sessionId: string,
   eventId: string,
@@ -45,6 +65,7 @@ export function serializePermissionRequest(
   return serializeSSE('permission_request', eventId, { sessionId, ...request });
 }
 
+/** Serialize a session status/name change as an SSE `session_update` event. */
 export function serializeSessionUpdate(
   sessionId: string,
   eventId: string,
@@ -53,6 +74,12 @@ export function serializeSessionUpdate(
   return serializeSSE('session_update', eventId, { sessionId, ...update });
 }
 
+/**
+ * Serialize a heartbeat event.
+ *
+ * Heartbeats are sent every 30 seconds to keep idle connections alive through
+ * proxy timeout windows and to let clients detect stale connections.
+ */
 export function serializeHeartbeat(): string {
   return serializeSSE('heartbeat', undefined, {
     timestamp: new Date().toISOString(),
@@ -60,6 +87,7 @@ export function serializeHeartbeat(): string {
   });
 }
 
+/** Serialize the initial `connected` confirmation sent when a client opens a stream. */
 export function serializeConnected(connectionId: string, sessionId: string): string {
   return serializeSSE('connected', undefined, {
     connectionId,
@@ -68,6 +96,7 @@ export function serializeConnected(connectionId: string, sessionId: string): str
   });
 }
 
+/** Serialize an error event (e.g. replay gap, invalid state). */
 export function serializeError(eventId: string, code: string, details?: unknown): string {
   return serializeSSE('error', eventId, { code, ...((details && typeof details === 'object') ? details : {}) });
 }

--- a/src/plugins/sse-adapter/index.ts
+++ b/src/plugins/sse-adapter/index.ts
@@ -8,6 +8,8 @@ import { SSEAdapter } from './adapter.js';
 import { sseRoutes } from './routes.js';
 import { BusEvent } from '../../core/events.js';
 
+// Module-level references held for teardown — the plugin lifecycle doesn't
+// pass instances between setup() and teardown(), so we store them here.
 let _adapter: SSEAdapter | null = null;
 let _connectionManager: ConnectionManager | null = null;
 

--- a/src/plugins/sse-adapter/routes.ts
+++ b/src/plugins/sse-adapter/routes.ts
@@ -22,6 +22,7 @@ function decodeParam(value: string): string {
   }
 }
 
+/** Dependencies injected into the SSE route handlers. */
 export interface SSERouteDeps {
   core: OpenACPCore;
   connectionManager: ConnectionManager;
@@ -29,6 +30,12 @@ export interface SSERouteDeps {
   commandRegistry?: CommandRegistry;
 }
 
+/**
+ * Registers all SSE adapter routes on the given Fastify sub-app.
+ *
+ * Routes are mounted under `/api/v1/sse` by the plugin's `setup()` hook.
+ * All routes require authentication (scopes enforced per-route).
+ */
 export async function sseRoutes(app: FastifyInstance, deps: SSERouteDeps): Promise<void> {
   // GET /sessions/:sessionId/stream — SSE event stream
   app.get<{ Params: { sessionId: string } }>(
@@ -64,13 +71,15 @@ export async function sseRoutes(app: FastifyInstance, deps: SSERouteDeps): Promi
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
         'Connection': 'keep-alive',
+        // Disable buffering in Nginx/Cloudflare so events arrive without delay
         'X-Accel-Buffering': 'no',
       });
 
       // Send connected event
       raw.write(serializeConnected(connection.id, sessionId));
 
-      // Replay missed events from buffer using Last-Event-ID header
+      // Replay missed events from buffer using Last-Event-ID header.
+      // Null result means the referenced event ID has been evicted — notify the client.
       const lastEventId = request.headers['last-event-id'] as string | undefined;
       if (lastEventId) {
         const missed = deps.eventBuffer.getSince(sessionId, lastEventId);
@@ -201,6 +210,7 @@ export async function sseRoutes(app: FastifyInstance, deps: SSERouteDeps): Promi
       }
 
       const body = ExecuteCommandBodySchema.parse(request.body);
+      // Normalize command strings: ensure they start with `/` for CommandRegistry lookup
       const commandString = body.command.startsWith('/') ? body.command : `/${body.command}`;
 
       const result = await deps.commandRegistry.execute(commandString, {

--- a/src/plugins/telegram/activity.ts
+++ b/src/plugins/telegram/activity.ts
@@ -18,9 +18,18 @@ const log = createChildLogger({ module: "telegram:activity" });
 
 // ─── ThinkingIndicator ────────────────────────────────────────────────────────
 
+// Refresh the "thinking" message every 15s to show elapsed time.
+// Auto-stop after 3 minutes to avoid leaving stale indicators.
 const THINKING_REFRESH_MS = 15_000;
 const THINKING_MAX_MS = 3 * 60 * 1000;
 
+/**
+ * Manages the transient "💭 Thinking..." message shown while the agent is reasoning.
+ *
+ * Sends a message on `show()`, periodically edits it with elapsed time, and
+ * dismisses it (leaving the message in chat) when text output begins. Leaving
+ * the message avoids an extra API delete call; the indicator is just no longer updated.
+ */
 export class ThinkingIndicator {
   private msgId?: number;
   private sending = false;
@@ -139,6 +148,14 @@ export class ThinkingIndicator {
 
 // ─── ToolCard ─────────────────────────────────────────────────────────────────
 
+/**
+ * Displays the live tool execution card for a prompt cycle.
+ *
+ * Receives tool state updates via `ToolCardState` (which batches rapid updates
+ * and calls `onFlush` with a snapshot). Each flush either sends a new message or
+ * edits the existing one. When the card exceeds Telegram's 4096-char limit, it is
+ * split into overflow messages that are recycled on subsequent renders.
+ */
 export class ToolCard {
   private state: ToolCardState;
   private msgId?: number;
@@ -273,6 +290,17 @@ export class ToolCard {
 
 // ─── ActivityTracker ──────────────────────────────────────────────────────────
 
+/**
+ * Per-session coordinator for all live activity indicators in a topic.
+ *
+ * Owns the ThinkingIndicator and the current ToolCard for a session. On each
+ * new prompt cycle (`onNewPrompt`), the previous card is finalized (frozen) and
+ * a fresh card and thinking indicator are created for the new turn.
+ *
+ * The "seal" mechanism (`sealToolCardIfNeeded`) finalizes the current tool card
+ * when text output begins, preserving tool results as a historical record while
+ * the new streaming draft message appears below them.
+ */
 export class ActivityTracker {
   private isFirstEvent = true;
   private thinking: ThinkingIndicator;

--- a/src/plugins/telegram/adapter.ts
+++ b/src/plugins/telegram/adapter.ts
@@ -70,10 +70,11 @@ interface UsageMetadata {
 }
 
 /**
- * Wraps native fetch to work around grammY's polyfilled AbortController.
- * grammY uses abort-controller polyfill whose AbortSignal fails instanceof
- * checks in Node 24+ native fetch. This wrapper re-creates a native
- * AbortSignal from the polyfilled one before passing it to fetch.
+ * Wrap native fetch to work around grammY's polyfilled AbortController.
+ *
+ * grammY uses an abort-controller polyfill whose AbortSignal fails `instanceof`
+ * checks in Node 24+ native fetch. This wrapper re-creates a native AbortSignal
+ * from the polyfilled signal object before forwarding the request.
  */
 function patchedFetch(
   input: RequestInfo | URL,
@@ -95,6 +96,27 @@ function patchedFetch(
   return fetch(input, init);
 }
 
+/**
+ * Telegram adapter — bridges the OpenACP session system to a Telegram supergroup.
+ *
+ * Architecture overview:
+ * - **Topic-per-session model**: each agent session lives in its own Telegram forum
+ *   topic. The topic ID is stored as `session.threadId` and used to route all
+ *   inbound and outbound messages.
+ * - **Two system topics**: "📋 Notifications" (cross-session alerts) and
+ *   "🤖 Assistant" (conversational AI). Created once on first run, IDs persisted.
+ * - **Streaming**: agent text arrives as `text_delta` chunks. A `MessageDraft`
+ *   accumulates chunks and edits the message in-place every 5 seconds, reducing
+ *   API calls while keeping the response live.
+ * - **Callback routing**:
+ *   - `p:<key>:<optionId>` — permission approval buttons
+ *   - `c/<command>` (or `c/#<id>` for long commands) — command button actions
+ *   - `m:<itemId>` — MenuRegistry item dispatch
+ *   - Domain prefixes (`d:`, `v:`, `ns:`, `sw:`, etc.) — specific feature flows
+ * - **Two-phase startup**: Phase 1 starts the bot and registers handlers.
+ *   Phase 2 checks group prerequisites (admin, topics enabled) and creates
+ *   system topics. If prerequisites are not met, a background watcher retries.
+ */
 export class TelegramAdapter extends MessagingAdapter {
   readonly name = "telegram";
   readonly renderer: IRenderer = new TelegramRenderer();
@@ -138,7 +160,11 @@ export class TelegramAdapter extends MessagingAdapter {
   /** Background watcher timer — cancelled on stop() or when topics succeed */
   private _prerequisiteWatcher: ReturnType<typeof setTimeout> | null = null;
 
-  /** Store control message ID in memory + persist to session record */
+  /**
+   * Persist the control message ID both in-memory and to the session record.
+   * The control message is the pinned status card with bypass/TTS buttons; its ID
+   * is needed after a restart to edit it when config changes.
+   */
   private storeControlMsgId(sessionId: string, msgId: number): void {
     this.controlMsgIds.set(sessionId, msgId);
     const record = this.core.sessionManager.getSessionRecord(sessionId);
@@ -215,6 +241,12 @@ export class TelegramAdapter extends MessagingAdapter {
     this.saveTopicIds = saveTopicIds;
   }
 
+  /**
+   * Set up the grammY bot, register all callback and message handlers, then perform
+   * two-phase startup: Phase 1 starts polling immediately; Phase 2 checks group
+   * prerequisites (bot is admin, topics are enabled) and creates/restores system topics.
+   * If prerequisites are not met, a background watcher retries until they are.
+   */
   async start(): Promise<void> {
     this.bot = new Bot(this.telegramConfig.botToken, {
       client: {
@@ -744,6 +776,13 @@ export class TelegramAdapter extends MessagingAdapter {
     this._prerequisiteWatcher = setTimeout(retry, schedule[0]);
   }
 
+  /**
+   * Tear down the bot and release all associated resources.
+   *
+   * Cancels the background prerequisite watcher, destroys all per-session activity
+   * trackers (which hold interval timers), removes eventBus listeners, clears the
+   * send queue, and stops the grammY bot polling loop.
+   */
   async stop(): Promise<void> {
     // Cancel background prerequisite watcher if running
     if (this._prerequisiteWatcher !== null) {
@@ -1014,6 +1053,13 @@ export class TelegramAdapter extends MessagingAdapter {
     return this.core.sessionManager.getSession(sessionId)?.agentInstance?.debugTracer ?? null;
   }
 
+  /**
+   * Primary outbound dispatch method — routes an agent message to the session's Telegram topic.
+   *
+   * Wraps the base class `sendMessage` in a per-session promise chain (`_dispatchQueues`)
+   * so that concurrent events fired from SessionBridge are serialized and delivered in the
+   * order they arrive, preventing fast handlers from overtaking slower ones.
+   */
   async sendMessage(
     sessionId: string,
     content: OutgoingMessage,
@@ -1403,6 +1449,11 @@ export class TelegramAdapter extends MessagingAdapter {
     );
   }
 
+  /**
+   * Render a PermissionRequest as an inline keyboard in the session topic and
+   * notify the Notifications topic. Runs inside a sendQueue item, so
+   * notification is fire-and-forget to avoid deadlock.
+   */
   async sendPermissionRequest(
     sessionId: string,
     request: PermissionRequest,
@@ -1417,6 +1468,11 @@ export class TelegramAdapter extends MessagingAdapter {
     );
   }
 
+  /**
+   * Post a notification to the Notifications topic.
+   * Assistant session notifications are suppressed — the assistant topic is
+   * the user's primary interface and does not need a separate alert.
+   */
   async sendNotification(notification: NotificationMessage): Promise<void> {
     this.getTracer(notification.sessionId)?.log("telegram", { action: "notification:send", sessionId: notification.sessionId, type: notification.type });
     if (notification.sessionId === this.core.assistantManager?.get('telegram')?.id) return;
@@ -1463,6 +1519,10 @@ export class TelegramAdapter extends MessagingAdapter {
     );
   }
 
+  /**
+   * Create a new Telegram forum topic for a session and return its thread ID as a string.
+   * Called by the core when a session is created via the API or CLI (not from the Telegram UI).
+   */
   async createSessionThread(sessionId: string, name: string): Promise<string> {
     this.getTracer(sessionId)?.log("telegram", { action: "thread:create", sessionId, name });
     log.info({ sessionId, name }, "Session topic created");
@@ -1471,6 +1531,10 @@ export class TelegramAdapter extends MessagingAdapter {
     );
   }
 
+  /**
+   * Rename the forum topic for a session and update the session record's display name.
+   * No-ops silently if the session doesn't have a threadId yet (e.g. still initializing).
+   */
   async renameSessionThread(sessionId: string, newName: string): Promise<void> {
     this.getTracer(sessionId)?.log("telegram", { action: "thread:rename", sessionId, newName });
     const session = this.core.sessionManager.getSession(sessionId);
@@ -1489,6 +1553,7 @@ export class TelegramAdapter extends MessagingAdapter {
     await this.core.sessionManager.patchRecord(sessionId, { name: newName });
   }
 
+  /** Delete the forum topic associated with a session. */
   async deleteSessionThread(sessionId: string): Promise<void> {
     const record = this.core.sessionManager.getSessionRecord(sessionId);
     const platform = record?.platform as
@@ -1507,6 +1572,11 @@ export class TelegramAdapter extends MessagingAdapter {
     }
   }
 
+  /**
+   * Display or update the pinned skill commands message for a session.
+   * If the session's threadId is not yet set (e.g. session created from API),
+   * the commands are queued and flushed once the thread becomes available.
+   */
   async sendSkillCommands(
     sessionId: string,
     commands: AgentCommand[],
@@ -1635,11 +1705,25 @@ export class TelegramAdapter extends MessagingAdapter {
       .catch((err) => log.error({ err }, "handleMessage error"));
   }
 
+  /**
+   * Remove skill slash commands from the Telegram bot command list for a session.
+   *
+   * Clears any queued pending commands that hadn't been sent yet, then delegates
+   * to `SkillCommandManager` to delete the commands from the Telegram API. Called
+   * when a session with registered skill commands ends.
+   */
   async cleanupSkillCommands(sessionId: string): Promise<void> {
     this._pendingSkillCommands.delete(sessionId);
     await this.skillManager.cleanup(sessionId);
   }
 
+  /**
+   * Clean up all adapter state associated with a session.
+   *
+   * Finalizes and discards any in-flight draft, destroys the activity tracker
+   * (stopping ThinkingIndicator timers and finalizing any open ToolCard), and
+   * clears pending skill commands. Called when a session ends or is reset.
+   */
   async cleanupSessionState(sessionId: string): Promise<void> {
     this._pendingSkillCommands.delete(sessionId);
     // Finalize and clean up draft state
@@ -1654,10 +1738,23 @@ export class TelegramAdapter extends MessagingAdapter {
     }
   }
 
+  /**
+   * Remove `[TTS]...[/TTS]` blocks from the active or finalized draft for a session.
+   *
+   * The agent embeds these blocks so the speech plugin can extract the TTS text, but
+   * they should never appear in the chat message. Called after TTS audio has been sent.
+   */
   async stripTTSBlock(sessionId: string): Promise<void> {
     await this.draftManager.stripPattern(sessionId, /\[TTS\][\s\S]*?\[\/TTS\]/g);
   }
 
+  /**
+   * Archive a session by deleting its forum topic.
+   *
+   * Sets `session.archiving = true` to suppress any outgoing messages while the
+   * topic is being torn down, finalizes pending drafts, cleans up all trackers,
+   * then deletes the Telegram topic (which removes all messages).
+   */
   async archiveSessionTopic(sessionId: string): Promise<void> {
     this.getTracer(sessionId)?.log("telegram", { action: "thread:archive", sessionId });
     const core = this.core as OpenACPCore;

--- a/src/plugins/telegram/assistant.ts
+++ b/src/plugins/telegram/assistant.ts
@@ -1,3 +1,4 @@
+/** Data needed to render the startup welcome message in the Assistant topic. */
 export interface WelcomeContext {
   activeCount: number;
   errorCount: number;
@@ -7,6 +8,10 @@ export interface WelcomeContext {
   workspace: string;
 }
 
+/**
+ * Build the welcome message sent to the Assistant topic on startup.
+ * The message variant adapts based on whether there are active sessions or errors.
+ */
 export function buildWelcomeMessage(ctx: WelcomeContext): string {
   const { activeCount, errorCount, totalCount, agents, defaultAgent, workspace } = ctx;
 
@@ -43,6 +48,11 @@ export function buildWelcomeMessage(ctx: WelcomeContext): string {
   );
 }
 
+/**
+ * Build a redirect message pointing to the Assistant topic.
+ * Sent when a user sends a plain message in the General topic (threadId = 0),
+ * which is not a session topic and cannot receive session messages.
+ */
 export function redirectToAssistant(
   chatId: number,
   assistantTopicId: number,

--- a/src/plugins/telegram/commands/admin.ts
+++ b/src/plugins/telegram/commands/admin.ts
@@ -8,6 +8,10 @@ import { escapeHtml } from "../formatting.js";
 import { createChildLogger } from "../../../core/utils/log.js";
 const log = createChildLogger({ module: "telegram-cmd-admin" });
 
+/**
+ * Return true if the session currently has bypass permissions enabled.
+ * Checks both the ACP-level mode config and the client-side override flag.
+ */
 export function isBypassActive(session: Session): boolean {
   const modeOpt = session.getConfigByCategory("mode");
   return (modeOpt?.type === "select" && isPermissionBypass(String(modeOpt.currentValue)))
@@ -24,6 +28,13 @@ export function buildDangerousModeKeyboard(
   );
 }
 
+/**
+ * Register the `d:` callback handler for bypass permissions toggle buttons.
+ *
+ * When the session is live in memory, the toggle is applied via the command registry
+ * (/bypass_permissions) so it propagates through ACP. When the session is no longer
+ * in memory (e.g. after restart), the toggle falls back to a direct store patch.
+ */
 export function setupDangerousModeCallbacks(bot: Bot, core: OpenACPCore): void {
   bot.callbackQuery(/^d:/, async (ctx) => {
     const sessionId = ctx.callbackQuery.data.slice(2);
@@ -229,6 +240,11 @@ export function setupTTSCallbacks(bot: Bot, core: OpenACPCore): void {
   });
 }
 
+/**
+ * Handle `/text_to_speech [on|off]` — toggle TTS for the current session.
+ * Must be used inside a session topic. Without an argument, enables TTS for the
+ * next message only. Checks that a TTS provider is installed before enabling.
+ */
 export async function handleTTS(
   ctx: Context,
   core: OpenACPCore,
@@ -297,6 +313,14 @@ const OUTPUT_MODE_LABELS: Record<string, string> = {
   high: "🔍 High",
 };
 
+/**
+ * Handle `/outputmode [low|medium|high]` — set the adapter-level or session-level
+ * output verbosity.
+ *
+ * - No args: show current mode and usage
+ * - `low|medium|high`: set adapter default (persisted to config)
+ * - `session low|medium|high|reset`: override for the current session only
+ */
 export async function handleOutputMode(
   ctx: Context,
   core: OpenACPCore,
@@ -391,6 +415,10 @@ export function setupVerbosityCallbacks(bot: Bot, core: OpenACPCore): void {
   });
 }
 
+/**
+ * Handle `/update` — check npm for a newer version of `@openacp/cli`, install it,
+ * and trigger a process restart. Edits the status message in-place as each step completes.
+ */
 export async function handleUpdate(
   ctx: Context,
   core: OpenACPCore,
@@ -461,6 +489,10 @@ export async function handleUpdate(
   await core.requestRestart();
 }
 
+/**
+ * Handle `/restart` — confirm and trigger a process restart via `core.requestRestart()`.
+ * A short delay is added so Telegram can deliver the confirmation message before shutdown.
+ */
 export async function handleRestart(
   ctx: Context,
   core: OpenACPCore,

--- a/src/plugins/telegram/commands/agents.ts
+++ b/src/plugins/telegram/commands/agents.ts
@@ -6,6 +6,11 @@ import { escapeHtml } from "../formatting.js";
 
 const AGENTS_PER_PAGE = 6;
 
+/**
+ * Handle `/agents` — show installed and available agents with install buttons.
+ * Available agents are paginated (6 per page). Agents with unmet dependencies
+ * are shown with a warning rather than an install button.
+ */
 export async function handleAgents(ctx: Context, core: OpenACPCore, page = 0): Promise<void> {
   const catalog = core.agentCatalog;
   const items = catalog.getAvailable();
@@ -87,6 +92,11 @@ export async function handleAgents(ctx: Context, core: OpenACPCore, page = 0): P
   }
 }
 
+/**
+ * Handle `/install <agent>` — install an agent by name or ID with live progress updates.
+ * After installation, auto-installs handoff integration if the agent supports it,
+ * and shows required setup steps as copyable commands.
+ */
 export async function handleInstall(ctx: Context, core: OpenACPCore): Promise<void> {
   const text = (ctx.message?.text ?? "").trim();
   const parts = text.split(/\s+/);

--- a/src/plugins/telegram/commands/doctor.ts
+++ b/src/plugins/telegram/commands/doctor.ts
@@ -40,6 +40,13 @@ function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/**
+ * Handle `/doctor` — run all system diagnostic checks and display the report.
+ *
+ * Sends an initial "running…" message, runs `DoctorEngine.runAll()`, then
+ * edits the message with the report. Pending fixes are stored per-message so
+ * the `m:doctor:fix:<index>` callbacks know which fixes to apply.
+ */
 export async function handleDoctor(ctx: Context): Promise<void> {
   const statusMsg = await ctx.reply("🩺 Running diagnostics...", { parse_mode: "HTML" });
 

--- a/src/plugins/telegram/commands/index.ts
+++ b/src/plugins/telegram/commands/index.ts
@@ -22,6 +22,13 @@ import { TELEGRAM_OVERRIDES } from './telegram-overrides.js'
 import { createChildLogger } from '../../../core/utils/log.js'
 const log = createChildLogger({ module: 'telegram-menu-callbacks' })
 
+/**
+ * Register all callback query handlers for the Telegram bot.
+ *
+ * Handler registration order is significant in grammY: more specific prefix
+ * handlers (ns:, ar:, ag:) must be registered before the broad `m:` dispatcher,
+ * otherwise the broad handler would consume callbacks intended for specific flows.
+ */
 export function setupAllCallbacks(
   bot: Bot,
   core: OpenACPCore,

--- a/src/plugins/telegram/commands/integrate.ts
+++ b/src/plugins/telegram/commands/integrate.ts
@@ -3,6 +3,10 @@ import { InlineKeyboard } from "grammy";
 import type { OpenACPCore } from "../../../core/index.js";
 import { escapeHtml } from "../formatting.js";
 
+/**
+ * Handle `/integrate` — show a list of agents with available integrations.
+ * Tapping an agent opens the integration items (install/uninstall hooks).
+ */
 export async function handleIntegrate(ctx: Context, _core: OpenACPCore): Promise<void> {
   const { listIntegrations } = await import("../../../cli/integrate.js");
   const agents = listIntegrations();

--- a/src/plugins/telegram/commands/menu.ts
+++ b/src/plugins/telegram/commands/menu.ts
@@ -3,6 +3,11 @@ import { InlineKeyboard } from "grammy";
 import type { AgentCommand } from "../../../core/index.js";
 import type { MenuRegistry } from "../../../core/menu-registry.js";
 
+/**
+ * Build the main OpenACP menu keyboard from the MenuRegistry.
+ * Falls back to a hardcoded keyboard when the registry is not available.
+ * Items are grouped by their `group` property, with a row break between groups.
+ */
 export function buildMenuKeyboard(menuRegistry?: MenuRegistry): InlineKeyboard {
   if (!menuRegistry) {
     return new InlineKeyboard()

--- a/src/plugins/telegram/commands/new-session.ts
+++ b/src/plugins/telegram/commands/new-session.ts
@@ -14,6 +14,14 @@ function botFromCtx(ctx: Context): Bot {
   return { api: ctx.api } as unknown as Bot;
 }
 
+/**
+ * Handle `/new [agent] [workspace]` — create a new session.
+ *
+ * - With both args: creates the session directly via `createSessionDirect`.
+ * - From the assistant topic without full args: delegates to the AI assistant
+ *   to guide the user through selecting an agent and workspace.
+ * - Otherwise: shows a usage hint.
+ */
 export async function handleNew(
   ctx: Context,
   core: OpenACPCore,
@@ -54,6 +62,16 @@ export async function handleNew(
   );
 }
 
+/**
+ * Create a session topic and start the agent immediately.
+ *
+ * Creates the forum topic first (before the session events fire) to ensure the
+ * thread ID is available when `session_thread_ready` fires. Sends a control
+ * message with session status and bypass/TTS buttons. Cleans up the orphaned
+ * topic if session creation fails.
+ *
+ * Returns the Telegram thread ID, or null on failure.
+ */
 export async function createSessionDirect(
   ctx: Context,
   core: OpenACPCore,
@@ -105,6 +123,11 @@ export async function createSessionDirect(
   }
 }
 
+/**
+ * Handle `/newchat` — start a fresh chat in a new topic, reusing the current
+ * session's agent and workspace. Resolves agent/workspace from the in-memory session
+ * first, falling back to the stored record for sessions not currently loaded.
+ */
 export async function handleNewChat(
   ctx: Context,
   core: OpenACPCore,
@@ -297,6 +320,10 @@ function shortenPath(ws: string): string {
   return home && ws.startsWith(home) ? '~' + ws.slice(home.length) : ws
 }
 
+/**
+ * Show the agent selection step of the multi-step new session wizard.
+ * If only one agent is installed, skip directly to workspace selection.
+ */
 export async function showAgentPicker(ctx: Context, core: OpenACPCore, chatId: number): Promise<void> {
   const catalog = core.agentCatalog
   const installed = catalog.getAvailable().filter((i) => i.installed)
@@ -366,6 +393,18 @@ async function showWorkspacePicker(ctx: Context, core: OpenACPCore, chatId: numb
   }
 }
 
+/**
+ * Register all callback handlers for the multi-step new session wizard.
+ *
+ * Wizard flow:
+ * 1. `ns:start` → agent picker
+ * 2. `ns:agent:<key>` → workspace picker
+ * 3. `ns:ws:<id>` → create session
+ * 4. `ns:custom:<key>` → force-reply prompt for custom path input
+ *
+ * Custom path replies are intercepted from the `message:text` middleware by
+ * checking against the `_forceReplyMap` before passing to the next handler.
+ */
 export function setupNewSessionCallbacks(
   bot: Bot,
   core: OpenACPCore,
@@ -462,6 +501,13 @@ export function setupNewSessionCallbacks(
   })
 }
 
+/**
+ * Create a new session programmatically (used by the API server and assistant).
+ *
+ * Creates the forum topic and sends the initial "Setting up..." message before
+ * calling `core.handleNewSession()`, so the threadId is ready when session events
+ * fire. Cleans up the orphaned topic on failure.
+ */
 export async function executeNewSession(
   bot: Bot,
   core: OpenACPCore,

--- a/src/plugins/telegram/commands/resume.ts
+++ b/src/plugins/telegram/commands/resume.ts
@@ -17,6 +17,15 @@ function botFromCtx(ctx: Context): Bot {
 
 // --- Arg parsing ---
 
+/**
+ * Parse `/resume` arguments into a ContextQuery.
+ *
+ * Supported forms:
+ * - No args → latest 5 sessions
+ * - `pr <number>`, `branch <name>`, `commit <hash>`
+ * - Checkpoint ID (12-char hex) or session ID (auto-detected)
+ * - GitHub/Entire.io URLs (PR, commit, branch, compare, checkpoint)
+ */
 export function parseResumeArgs(matchStr: string): { query: Omit<ContextQuery, "repoPath"> } | null {
   const args = matchStr.split(" ").filter(Boolean);
   if (args.length === 0) return { query: { type: "latest", value: "5" } };
@@ -179,6 +188,14 @@ async function executeResume(
 
 // --- Main handler ---
 
+/**
+ * Handle `/resume [args]` — create a new session with Entire.io conversation context.
+ *
+ * Parses the args into a ContextQuery, resolves the default workspace, checks that
+ * the Entire provider is enabled, then creates the session with historical context
+ * loaded. Creates the forum topic before calling `createSessionWithContext` to
+ * avoid a race where session events fire before the thread is ready.
+ */
 export async function handleResume(
   ctx: Context,
   core: OpenACPCore,

--- a/src/plugins/telegram/commands/session.ts
+++ b/src/plugins/telegram/commands/session.ts
@@ -7,6 +7,13 @@ import { createChildLogger } from "../../../core/utils/log.js";
 import type { CommandsAssistantContext } from "../types.js";
 const log = createChildLogger({ module: "telegram-cmd-session" });
 
+/**
+ * Handle `/cancel` — abort the current prompt in the active session.
+ *
+ * In the assistant topic, delegates to the AI to confirm which session to cancel.
+ * In a session topic with an active prompt, calls `session.abortPrompt()`.
+ * If there is no active prompt (session paused/waiting), informs the user.
+ */
 export async function handleCancel(
   ctx: Context,
   core: OpenACPCore,
@@ -46,6 +53,11 @@ export async function handleCancel(
   }
 }
 
+/**
+ * Handle `/status` — show session info for the current topic, or overall system
+ * stats when used outside a topic. Falls back to stored record when the session
+ * is not currently loaded in memory.
+ */
 export async function handleStatus(ctx: Context, core: OpenACPCore): Promise<void> {
   const threadId = ctx.message?.message_thread_id;
   if (threadId) {
@@ -93,6 +105,10 @@ export async function handleStatus(ctx: Context, core: OpenACPCore): Promise<voi
   }
 }
 
+/**
+ * Handle `/sessions` — list all sessions with a status overview and cleanup buttons.
+ * Headless sessions (no Telegram topic) are filtered from the display but counted.
+ */
 export async function handleTopics(ctx: Context, core: OpenACPCore): Promise<void> {
   try {
     const allRecords = core.sessionManager.listRecords();
@@ -307,6 +323,11 @@ export async function handleCleanupEverythingConfirmed(
   );
 }
 
+/**
+ * Programmatically abort the most recently active Telegram session.
+ * Used by the assistant when told to cancel a session via chat.
+ * `excludeSessionId` prevents cancelling the assistant's own session.
+ */
 export async function executeCancelSession(
   core: OpenACPCore,
   excludeSessionId?: string,
@@ -361,6 +382,11 @@ export function setupSessionCallbacks(
   })
 }
 
+/**
+ * Handle `/archive` — show a confirmation prompt before deleting the current
+ * session's topic. The archive destroys the Telegram topic (all messages lost)
+ * and permanently removes the session record.
+ */
 export async function handleArchive(
   ctx: Context,
   core: OpenACPCore,

--- a/src/plugins/telegram/commands/settings.ts
+++ b/src/plugins/telegram/commands/settings.ts
@@ -48,6 +48,10 @@ function formatFieldLabel(field: ConfigFieldDef, value: unknown): string {
   return `${icon} ${field.displayName}: ${displayValue}`;
 }
 
+/**
+ * Handle `/settings` — display an inline keyboard of all safe config fields.
+ * Each button triggers a toggle, select, or delegated-to-assistant input flow.
+ */
 export async function handleSettings(ctx: Context, core: OpenACPCore): Promise<void> {
   const kb = await buildSettingsKeyboard(core);
   await ctx.reply(`<b>⚙️ Settings</b>\nTap to change:`, {
@@ -56,6 +60,17 @@ export async function handleSettings(ctx: Context, core: OpenACPCore): Promise<v
   });
 }
 
+/**
+ * Register all `s:` settings callback handlers.
+ *
+ * For string/number fields that need free-form input (`s:input:`), the
+ * handler delegates to the assistant session so the user can type a value
+ * conversationally rather than using a keyboard.
+ *
+ * STT provider selection (`s:pick:speech.stt.provider`) checks whether an
+ * API key is already configured; if not, it redirects to the assistant to
+ * collect the key before applying the change.
+ */
 export function setupSettingsCallbacks(
   bot: Bot,
   core: OpenACPCore,

--- a/src/plugins/telegram/commands/switch.ts
+++ b/src/plugins/telegram/commands/switch.ts
@@ -6,6 +6,14 @@ import { createChildLogger } from "../../../core/utils/log.js";
 
 const log = createChildLogger({ module: "telegram-cmd-switch" });
 
+/**
+ * Handle `/switch [agent]` — switch the agent for the current session.
+ *
+ * - No args: show inline keyboard of available agents.
+ * - With agent name: switch directly; if a prompt is in-flight, show a confirmation
+ *   prompt before interrupting it.
+ * - `/switch label on|off`: toggle whether the agent name is prefixed in session history.
+ */
 export async function handleSwitch(
   ctx: Context,
   core: OpenACPCore,
@@ -75,6 +83,10 @@ export async function handleSwitch(
   await executeSwitchAgent(ctx, core, session.id, raw);
 }
 
+/**
+ * Execute an agent switch for a session. Called by both the `/switch` command
+ * handler and the `swc:` confirmation callback (when a prompt was in-flight).
+ */
 export async function executeSwitchAgent(
   ctx: Context,
   core: OpenACPCore,

--- a/src/plugins/telegram/commands/tunnel.ts
+++ b/src/plugins/telegram/commands/tunnel.ts
@@ -6,6 +6,12 @@ import { createChildLogger } from "../../../core/utils/log.js";
 
 const log = createChildLogger({ module: "telegram-cmd-tunnel" });
 
+/**
+ * Handle `/tunnel [port] [label]` or `/tunnel stop <port>`.
+ *
+ * Associates the tunnel with the current session (if in a session topic) so it
+ * appears in `/tunnels` session-scoped view.
+ */
 export async function handleTunnel(
   ctx: Context,
   core: OpenACPCore,
@@ -76,6 +82,11 @@ export async function handleTunnel(
   );
 }
 
+/**
+ * Handle `/tunnels` — list active tunnels with stop buttons.
+ * In a session topic, shows only tunnels owned by that session.
+ * In other topics (assistant, general), shows all tunnels.
+ */
 export async function handleTunnels(
   ctx: Context,
   core: OpenACPCore,

--- a/src/plugins/telegram/draft-manager.ts
+++ b/src/plugins/telegram/draft-manager.ts
@@ -3,11 +3,21 @@ import { MessageDraft } from "./streaming.js";
 import type { SendQueue } from "../../core/adapter-primitives/primitives/send-queue.js";
 import type { DebugTracer } from "../../core/utils/debug-tracer.js";
 
+// Retains a finalized draft so tts_strip can edit the message after finalization.
+// The draft's stripPattern() still holds the message ID and can make a single edit.
 interface FinalizedDraft {
   messageId: number;
   draft: MessageDraft;
 }
 
+/**
+ * Per-session draft lifecycle manager.
+ *
+ * Owns the active `MessageDraft` for each session (the streaming message being
+ * assembled from text_delta events) and keeps a short-lived reference after
+ * finalization so post-send edits (e.g. TTS block removal) can still update
+ * the message in-place.
+ */
 export class DraftManager {
   private drafts: Map<string, MessageDraft> = new Map();
   private textBuffers: Map<string, string> = new Map();
@@ -19,6 +29,10 @@ export class DraftManager {
     private sendQueue: SendQueue,
   ) {}
 
+  /**
+   * Return the active draft for a session, creating one if it doesn't exist yet.
+   * Only one draft per session exists at a time.
+   */
   getOrCreate(sessionId: string, threadId: number, tracer: DebugTracer | null = null): MessageDraft {
     let draft = this.drafts.get(sessionId);
     if (!draft) {
@@ -51,7 +65,12 @@ export class DraftManager {
   }
 
   /**
-   * Finalize the current draft and return the message ID.
+   * Finalize the active draft for a session and retain a short-lived reference for post-send edits.
+   *
+   * Removes the draft from the active map before awaiting to prevent concurrent calls from
+   * double-finalizing the same draft. If the draft produces a message ID, stores it as a
+   * `FinalizedDraft` so `stripPattern` (e.g. TTS block removal) can still edit the message
+   * after it has been sent.
    */
   async finalize(
     sessionId: string,
@@ -91,6 +110,12 @@ export class DraftManager {
     // [TTS] block will remain visible. This is a rare edge case — log for debugging.
   }
 
+  /**
+   * Discard all draft state for a session without sending anything.
+   *
+   * Removes the active draft, text buffer, and finalized draft reference. Called when a
+   * session ends or is reset and any unsent content should be silently dropped.
+   */
   cleanup(sessionId: string): void {
     this.drafts.delete(sessionId);
     this.textBuffers.delete(sessionId);

--- a/src/plugins/telegram/formatting.ts
+++ b/src/plugins/telegram/formatting.ts
@@ -25,6 +25,10 @@ import {
 } from "../../core/adapter-primitives/message-formatter.js";
 import type { DisplayVerbosity } from "../../core/adapter-primitives/format-types.js";
 
+/**
+ * Escape characters that have special meaning in Telegram HTML parse mode.
+ * Must be applied to all user/agent-provided strings before embedding in HTML messages.
+ */
 export function escapeHtml(text: string | undefined | null): string {
   if (!text) return "";
   return text
@@ -33,6 +37,17 @@ export function escapeHtml(text: string | undefined | null): string {
     .replace(/>/g, "&gt;");
 }
 
+/**
+ * Convert Markdown to Telegram HTML parse mode.
+ *
+ * Telegram supports HTML rather than MarkdownV2 because MarkdownV2 requires
+ * escaping almost every punctuation character, which breaks real-world agent
+ * output (file paths, diffs, JSON, etc.). HTML mode only requires escaping
+ * `&`, `<`, and `>`, making it far more reliable for agent-generated content.
+ *
+ * Strategy: code blocks/inline code are extracted into placeholders first so
+ * that subsequent HTML escaping and markdown transformations don't corrupt them.
+ */
 export function markdownToTelegramHtml(md: string): string {
   // Step 1: Extract code blocks and inline code into placeholders
   const codeBlocks: string[] = [];
@@ -85,6 +100,10 @@ export function markdownToTelegramHtml(md: string): string {
   return text;
 }
 
+/**
+ * Render a tool call event as Telegram HTML.
+ * Higher verbosity levels show more input/output detail.
+ */
 export function formatToolCall(
   tool: ToolCallMeta,
   verbosity: DisplayVerbosity = "medium",
@@ -161,6 +180,10 @@ export function formatPlan(plan: {
   return `<b>Plan:</b>\n${lines.join("\n")}`;
 }
 
+/**
+ * Render token usage as a visual bar + percentage.
+ * Shows a warning emoji when context is ≥85% full to alert users before hitting limits.
+ */
 export function formatUsage(
   usage: { tokensUsed?: number; contextSize?: number; cost?: number },
   _verbosity: DisplayVerbosity = "medium",

--- a/src/plugins/telegram/index.ts
+++ b/src/plugins/telegram/index.ts
@@ -2,6 +2,17 @@ import type { OpenACPPlugin, InstallContext } from '../../core/plugin/types.js'
 import type { OpenACPCore } from '../../core/core.js'
 import type { TelegramChannelConfig } from './types.js'
 
+/**
+ * Factory for the Telegram plugin.
+ *
+ * The plugin is `essential: true` — OpenACP won't start without it. Its `setup()`
+ * hook constructs a `TelegramAdapter` and registers it as `adapter:telegram` in
+ * the service registry so other plugins can reference it.
+ *
+ * On first run, topic IDs are null. `TelegramAdapter.start()` creates the system
+ * topics and persists their IDs back to plugin settings via the `saveTopicIds` callback.
+ * On subsequent runs, the persisted IDs are read from plugin settings in `setup()`.
+ */
 function createTelegramPlugin(): OpenACPPlugin {
   let adapter: { stop(): Promise<void> } | null = null
 
@@ -247,6 +258,11 @@ function createTelegramPlugin(): OpenACPPlugin {
   }
 }
 
+/**
+ * Poll `getUpdates` until a group message is received, then return its chat ID.
+ * Used during `install` when the user chooses auto-detect instead of manual entry.
+ * Times out after ~4 minutes (120 attempts × 2s) and falls back to manual input.
+ */
 async function detectChatIdViaPolling(
   token: string,
   terminal: InstallContext['terminal'],

--- a/src/plugins/telegram/permissions.ts
+++ b/src/plugins/telegram/permissions.ts
@@ -7,13 +7,22 @@ import { buildDeepLink } from './topics.js'
 import { createChildLogger } from '../../core/utils/log.js'
 const log = createChildLogger({ module: 'telegram-permissions' })
 
-// Stored pending permission callbacks: callbackKey → { sessionId, requestId, options }
+// In-memory map from short callback key → pending permission data.
+// Keys are 8-character nanoid strings to stay within Telegram's 64-byte callback_data limit.
 interface PendingPermission {
   sessionId: string
   requestId: string
   options: { id: string; isAllow: boolean }[]
 }
 
+/**
+ * Renders PermissionRequest objects as Telegram inline keyboard buttons and
+ * routes the user's approval/denial back to the PermissionGate.
+ *
+ * Each request is assigned a short callback key (`p:<key>:<optionId>`) to avoid
+ * Telegram's 64-byte limit on callback_data. The resolved option is passed to
+ * `session.permissionGate.resolve()` to unblock the waiting agent prompt.
+ */
 export class PermissionHandler {
   private pending: Map<string, PendingPermission> = new Map()
 
@@ -24,10 +33,18 @@ export class PermissionHandler {
     private sendNotification: (notification: NotificationMessage) => Promise<void>,
   ) {}
 
+  /**
+   * Send a permission request to the session's topic as an inline keyboard message,
+   * and fire a notification to the Notifications topic so the user is alerted.
+   *
+   * Each button encodes `p:<callbackKey>:<optionId>`. The callbackKey is a short
+   * nanoid that maps to the full pending state stored in-memory, avoiding the
+   * 64-byte Telegram callback_data limit.
+   */
   async sendPermissionRequest(session: Session, request: PermissionRequest): Promise<void> {
     const threadId = Number(session.threadId)
 
-    // Short callback key (Telegram 64-byte limit on callback_data)
+    // nanoid(8) = 8-char key; well within the 64-byte callback_data budget
     const callbackKey = nanoid(8)
     this.pending.set(callbackKey, {
       sessionId: session.id,
@@ -67,9 +84,16 @@ export class PermissionHandler {
     })
   }
 
+  /**
+   * Register the `p:` callback handler in the bot's middleware chain.
+   *
+   * Must be called during setup so grammY processes permission responses
+   * before other generic callback handlers.
+   */
   setupCallbackHandler(): void {
     this.bot.on('callback_query:data', async (ctx, next) => {
       const data = ctx.callbackQuery.data
+      // Only handle permission callbacks; pass everything else to the next handler
       if (!data.startsWith('p:')) return next()
 
       const parts = data.split(':')

--- a/src/plugins/telegram/renderer.ts
+++ b/src/plugins/telegram/renderer.ts
@@ -14,6 +14,13 @@ import {
   formatUsage,
 } from "./formatting.js";
 
+/**
+ * Telegram-specific renderer for structured `OutgoingMessage` types.
+ *
+ * Produces HTML strings (Telegram parse_mode: 'HTML') for each message kind.
+ * Plain text rendering is not used because HTML mode handles agent output
+ * (code fences, diffs, etc.) more reliably than MarkdownV2.
+ */
 export class TelegramRenderer extends BaseRenderer {
   renderToolCall(
     content: OutgoingMessage,

--- a/src/plugins/telegram/skill-command-manager.ts
+++ b/src/plugins/telegram/skill-command-manager.ts
@@ -8,8 +8,17 @@ import { createChildLogger } from "../../core/utils/log.js";
 
 const log = createChildLogger({ module: "skill-commands" });
 
+/**
+ * Manages the pinned "Available Skills" message in each session topic.
+ *
+ * When an agent registers skill commands, they are displayed as a pinned HTML
+ * message with tap-to-copy slash commands. The message is edited in-place on
+ * each update and unpinned when the session ends. Message IDs are persisted to
+ * platform data so the correct message is found after a restart.
+ */
 export class SkillCommandManager {
-  private messages: Map<string, number> = new Map(); // sessionId → pinned msgId
+  // sessionId → Telegram message ID of the pinned skills message
+  private messages: Map<string, number> = new Map();
 
   constructor(
     private bot: Bot,
@@ -18,6 +27,11 @@ export class SkillCommandManager {
     private sessionManager: SessionManager,
   ) {}
 
+  /**
+   * Send or update the pinned skill commands message for a session.
+   * Creates a new pinned message if none exists; edits the existing one otherwise.
+   * Passing an empty `commands` array removes the pinned message.
+   */
   async send(
     sessionId: string,
     threadId: number,

--- a/src/plugins/telegram/streaming.ts
+++ b/src/plugins/telegram/streaming.ts
@@ -3,8 +3,22 @@ import { markdownToTelegramHtml, splitMessage } from './formatting.js'
 import type { SendQueue } from '../../core/adapter-primitives/primitives/send-queue.js'
 import type { DebugTracer } from '../../core/utils/debug-tracer.js'
 
+// Throttle interval for streaming edits: emit at most one edit every 5 seconds while
+// text chunks are arriving. This avoids hitting Telegram's per-message rate limit
+// (~1 edit/s) while still showing live progress for long-running agents.
 const FLUSH_INTERVAL = 5000
 
+/**
+ * In-flight streaming message for a single agent response.
+ *
+ * Text chunks arrive via `append()`. A debounced timer fires `flush()` every
+ * FLUSH_INTERVAL ms, sending the buffered content as either a new message (first
+ * flush) or an edit of the existing message. `finalize()` is called on
+ * `text_done` to push the complete, untruncated content.
+ *
+ * The edit-in-place approach keeps each agent turn as a single Telegram message
+ * rather than flooding the topic with many small messages.
+ */
 export class MessageDraft {
   private buffer: string = ''
   private messageId?: number
@@ -27,6 +41,7 @@ export class MessageDraft {
     this.tracer = tracer
   }
 
+  /** Append a text chunk to the buffer and schedule a throttled flush. */
   append(text: string): void {
     if (!text) return
     this.buffer += text
@@ -34,6 +49,7 @@ export class MessageDraft {
   }
 
   private scheduleFlush(): void {
+    // One timer at a time — let the current interval elapse before re-arming
     if (this.flushTimer) return
     this.flushTimer = setTimeout(() => {
       this.flushTimer = undefined
@@ -124,6 +140,16 @@ export class MessageDraft {
     }
   }
 
+  /**
+   * Flush the complete buffer as the final message for this turn.
+   *
+   * Cancels any pending debounce timer, waits for in-flight flushes to settle,
+   * then sends the full content. If the HTML exceeds 4096 bytes, the content is
+   * split at markdown boundaries to avoid breaking HTML tags mid-tag.
+   *
+   * Returns the Telegram message ID of the sent/edited message, or undefined
+   * if nothing was sent (empty buffer or all network calls failed).
+   */
   async finalize(): Promise<number | undefined> {
     this.tracer?.log("telegram", { action: "draft:finalize", sessionId: this.sessionId, bufferLen: this.buffer.length, msgId: this.messageId })
     if (this.flushTimer) {
@@ -228,10 +254,15 @@ export class MessageDraft {
     return this.messageId
   }
 
+  /** Returns the Telegram message ID for this draft, or undefined if not yet sent. */
   getMessageId(): number | undefined {
     return this.messageId
   }
 
+  /**
+   * Strip occurrences of `pattern` from the buffer and edit the message in-place.
+   * Used by the TTS plugin to remove [TTS]...[/TTS] blocks after audio is sent.
+   */
   async stripPattern(pattern: RegExp): Promise<void> {
     if (!this.messageId || !this.buffer) return
 

--- a/src/plugins/telegram/topic-manager.ts
+++ b/src/plugins/telegram/topic-manager.ts
@@ -5,6 +5,7 @@ import { createChildLogger } from '../../core/utils/log.js'
 
 const log = createChildLogger({ module: 'topic-manager' })
 
+/** Flat view of a session record, enriched with its Telegram topic ID. */
 export interface TopicInfo {
   sessionId: string
   topicId: number | null
@@ -14,24 +15,35 @@ export interface TopicInfo {
   lastActiveAt: string
 }
 
+/** Result of a single-topic deletion operation. */
 export interface DeleteTopicResult {
   ok: boolean
+  /** True when deletion requires explicit confirmation (session is still active). */
   needsConfirmation?: boolean
   topicId?: number | null
   session?: { id: string; name: string | null; status: string }
   error?: string
 }
 
+/** Aggregate result for a bulk cleanup operation. */
 export interface CleanupResult {
   deleted: string[]
   failed: { sessionId: string; error: string }[]
 }
 
+// IDs for the two system-managed topics that must never be deleted by user-facing commands.
 interface SystemTopicIds {
   notificationTopicId: number | null
   assistantTopicId: number | null
 }
 
+/**
+ * High-level topic management for the Telegram adapter.
+ *
+ * Sits above the raw Telegram API (`topics.ts`) and adds session-level concerns:
+ * guarding system topics, requiring confirmation for active sessions, and
+ * coordinating with the SessionManager to remove session records after deletion.
+ */
 export class TopicManager {
   constructor(
     private sessionManager: SessionManager,
@@ -39,6 +51,10 @@ export class TopicManager {
     private systemTopicIds: SystemTopicIds,
   ) {}
 
+  /**
+   * List user-facing session topics, excluding system topics.
+   * Optionally filtered to specific status values.
+   */
   listTopics(filter?: { statuses?: string[] }): TopicInfo[] {
     const records = this.sessionManager.listRecords(filter)
     return records
@@ -54,6 +70,12 @@ export class TopicManager {
       }))
   }
 
+  /**
+   * Delete a session topic and its session record.
+   *
+   * Returns `needsConfirmation: true` when the session is still active and
+   * `options.confirmed` was not set — callers must ask the user before proceeding.
+   */
   async deleteTopic(sessionId: string, options?: { confirmed?: boolean }): Promise<DeleteTopicResult> {
     const records = this.sessionManager.listRecords()
     const record = records.find(r => r.sessionId === sessionId)
@@ -87,6 +109,10 @@ export class TopicManager {
     return { ok: true, topicId }
   }
 
+  /**
+   * Bulk-delete topics by status (default: finished, error, cancelled).
+   * Active/initializing sessions are cancelled before deletion to prevent orphaned processes.
+   */
   async cleanup(statuses?: string[]): Promise<CleanupResult> {
     const targetStatuses = statuses?.length ? statuses : ['finished', 'error', 'cancelled']
     const records = this.sessionManager.listRecords({ statuses: targetStatuses })

--- a/src/plugins/telegram/topics.ts
+++ b/src/plugins/telegram/topics.ts
@@ -1,7 +1,10 @@
 import type { Bot } from 'grammy'
 
-// Ensure notification and assistant topics exist, create if needed
-// Returns updated topic IDs
+/**
+ * Ensure the two system topics (Notifications and Assistant) exist in the group.
+ * Creates any missing topic and persists the resulting IDs via `saveConfig`.
+ * Called once on startup; idempotent if both IDs are already present in config.
+ */
 export async function ensureTopics(
   bot: Bot,
   chatId: number,
@@ -26,7 +29,11 @@ export async function ensureTopics(
   return { notificationTopicId, assistantTopicId }
 }
 
-// Create a new forum topic for a session
+/**
+ * Create a new forum topic for a session and return its thread ID.
+ * Each session gets exactly one dedicated topic; the thread ID is used
+ * to route all subsequent messages for that session.
+ */
 export async function createSessionTopic(
   bot: Bot,
   chatId: number,
@@ -36,7 +43,7 @@ export async function createSessionTopic(
   return topic.message_thread_id
 }
 
-// Rename an existing forum topic
+/** Rename an existing forum topic. Failures are silently ignored (topic may be closed/deleted). */
 export async function renameSessionTopic(
   bot: Bot,
   chatId: number,
@@ -50,7 +57,7 @@ export async function renameSessionTopic(
   }
 }
 
-// Delete a forum topic and all its messages
+/** Delete a forum topic and all its messages permanently. */
 export async function deleteSessionTopic(
   bot: Bot,
   chatId: number,
@@ -59,9 +66,14 @@ export async function deleteSessionTopic(
   await bot.api.deleteForumTopic(chatId, threadId);
 }
 
-// Build a Telegram deep link to a specific message in a forum topic
+/**
+ * Build a Telegram deep link that navigates directly to a forum topic or message.
+ *
+ * When `messageId` is provided (and differs from `threadId`), the link points to
+ * that specific message; otherwise it links to the topic root.
+ */
 export function buildDeepLink(chatId: number, threadId: number, messageId?: number): string {
-  // chatId for groups starts with -100, need to strip it for the link
+  // Group chatId is prefixed with -100; strip it to form a valid t.me link
   const cleanId = String(chatId).replace('-100', '')
   // For forum groups: c/{chatId}/{threadId}/{messageId} links to a specific message
   // Without messageId: c/{chatId}/{threadId} links to the topic itself

--- a/src/plugins/telegram/types.ts
+++ b/src/plugins/telegram/types.ts
@@ -1,13 +1,28 @@
 import type { Session } from "../../core/sessions/session.js";
 import type { ChannelConfig } from "../../core/channel.js";
 
+/**
+ * Runtime configuration for the Telegram adapter.
+ *
+ * `notificationTopicId` and `assistantTopicId` start as `null` on first run and are
+ * populated by `ensureTopics()` when the system topics are created in the group.
+ * Both IDs are persisted to plugin settings so they survive restarts.
+ */
 export interface TelegramChannelConfig extends ChannelConfig {
   botToken: string
   chatId: number
+  /** Forum topic used for all cross-session notifications (completions, permissions). Null until first run. */
   notificationTopicId: number | null
+  /** Forum topic where users chat with the assistant. Null until first run. */
   assistantTopicId: number | null
 }
 
+/**
+ * Context passed to command handlers that need to interact with the assistant session.
+ *
+ * Allows commands (e.g. /new, /cancel, /resume) to delegate to the AI assistant
+ * when run inside the assistant topic, instead of showing a plain usage error.
+ */
 export interface CommandsAssistantContext {
   topicId: number;
   getSession: () => Session | null;

--- a/src/plugins/telegram/validators.ts
+++ b/src/plugins/telegram/validators.ts
@@ -1,6 +1,10 @@
 import { createChildLogger } from '../../core/utils/log.js'
 const log = createChildLogger({ module: 'telegram-validators' })
 
+/**
+ * Validate a bot token by calling the Telegram `getMe` API.
+ * Returns the bot name and username on success, or an error description on failure.
+ */
 export async function validateBotToken(
   token: string,
 ): Promise<
@@ -27,6 +31,10 @@ export async function validateBotToken(
   }
 }
 
+/**
+ * Validate that a chat ID refers to a supergroup (required for forum topics).
+ * Returns whether the group has Topics enabled (`isForum`).
+ */
 export async function validateChatId(
   token: string,
   chatId: number,
@@ -63,6 +71,10 @@ export async function validateChatId(
   }
 }
 
+/**
+ * Check that the bot is an admin in the group and has the `can_manage_topics` permission.
+ * Group creators are always treated as having all permissions.
+ */
 export async function validateBotAdmin(
   token: string,
   chatId: number,
@@ -119,6 +131,15 @@ export async function validateBotAdmin(
   }
 }
 
+/**
+ * Run all prerequisite checks for the topic-per-session model:
+ * 1. Topics are enabled on the group (`is_forum: true`)
+ * 2. Bot is an admin
+ * 3. Bot has `can_manage_topics` permission
+ *
+ * Returns all failing issues so the user can fix them all at once.
+ * Called on adapter startup; if checks fail, a background watcher retries periodically.
+ */
 export async function checkTopicsPrerequisites(
   token: string,
   chatId: number,

--- a/src/plugins/tunnel/index.ts
+++ b/src/plugins/tunnel/index.ts
@@ -5,6 +5,17 @@ import type { ApiServerService } from '../api-server/service.js'
 import { MAX_RETRIES } from './tunnel-registry.js'
 import { createViewerRoutes } from './viewer-routes.js'
 
+/**
+ * Tunnel plugin — exposes the local API server to the internet via a tunnel provider.
+ *
+ * Setup starts the system tunnel when the API server emits `api-server:started`,
+ * then registers viewer routes so agents can share file/diff/output content via
+ * public URLs. Also registers `/tunnel` and `/tunnels` chat commands for managing
+ * additional user-created tunnels.
+ *
+ * The `cloudflare` provider is auto-migrated to `openacp` on startup for users
+ * who configured it before the managed tunnel was introduced.
+ */
 function createTunnelPlugin(): OpenACPPlugin {
   let service: { stop(): Promise<void> } | null = null
 

--- a/src/plugins/tunnel/keepalive.ts
+++ b/src/plugins/tunnel/keepalive.ts
@@ -1,3 +1,13 @@
+/**
+ * Periodically pings the tunnel URL to detect silent failures.
+ *
+ * Some tunnel providers (notably Cloudflare quick tunnels) can silently drop
+ * without triggering a process exit event. This keepalive polls the OpenACP
+ * health endpoint every 30 seconds and calls `onDead()` after 3 consecutive
+ * failures, which causes TunnelRegistry to kill and restart the tunnel process.
+ *
+ * Only used for the system tunnel — user tunnels are managed independently.
+ */
 export class TunnelKeepAlive {
   private interval: NodeJS.Timeout | null = null
   private consecutiveFails = 0
@@ -6,6 +16,10 @@ export class TunnelKeepAlive {
   static readonly FAIL_THRESHOLD = 3
   static readonly PING_TIMEOUT = 5_000
 
+  /**
+   * Start polling. Replaces any existing interval.
+   * `onDead` is called once when the failure threshold is reached.
+   */
   start(tunnelUrl: string, onDead: () => void): void {
     this.stop()
 
@@ -30,6 +44,10 @@ export class TunnelKeepAlive {
     }, TunnelKeepAlive.PING_INTERVAL)
   }
 
+  /**
+   * Stop the keepalive interval and reset the failure counter.
+   * Resetting ensures a clean slate if the keepalive is restarted after stopping.
+   */
   stop(): void {
     if (this.interval) {
       clearInterval(this.interval)

--- a/src/plugins/tunnel/provider.ts
+++ b/src/plugins/tunnel/provider.ts
@@ -1,5 +1,14 @@
+/**
+ * Abstract interface for tunnel provider implementations.
+ *
+ * Each provider wraps a specific tunneling tool (Cloudflare, ngrok, bore, etc.).
+ * `start()` spawns the subprocess and resolves once the public URL is known.
+ * After establishment, unexpected exits are signalled via `onExit()` so the
+ * TunnelRegistry can schedule retries.
+ */
 export interface TunnelProvider {
-  start(localPort: number): Promise<string>  // returns public URL
+  /** Spawn the tunnel subprocess and return the public URL once established. */
+  start(localPort: number): Promise<string>
   /** Stop the tunnel. When force=true, skip graceful shutdown and SIGKILL immediately.
    *  When preserveState=true, keep tunnel alive on remote (don't delete from worker/storage) for reconnect on restart. */
   stop(force?: boolean, preserveState?: boolean): Promise<void>

--- a/src/plugins/tunnel/providers/bore.ts
+++ b/src/plugins/tunnel/providers/bore.ts
@@ -6,6 +6,15 @@ const log = createChildLogger({ module: 'bore-tunnel' })
 
 const SIGKILL_TIMEOUT_MS = 5_000
 
+/**
+ * Tunnel provider that uses the bore CLI (https://github.com/ekzhang/bore).
+ *
+ * bore must be installed separately (not auto-installed). Connects to `bore.pub`
+ * by default, or a custom server via `options.server`. Optionally accepts
+ * `options.port` (fixed remote port) and `options.secret` for server auth.
+ *
+ * URL is extracted from stdout: "listening at <host>:<port>".
+ */
 export class BoreTunnelProvider implements TunnelProvider {
   private child: ChildProcess | null = null
   private publicUrl = ''
@@ -49,6 +58,7 @@ export class BoreTunnelProvider implements TunnelProvider {
         return
       }
 
+      // Parse bore's "listening at <host>:<port>" line to extract the public URL
       const urlPattern = /listening at ([^\s]+):(\d+)/
 
       const onData = (data: Buffer) => {

--- a/src/plugins/tunnel/providers/cloudflare.ts
+++ b/src/plugins/tunnel/providers/cloudflare.ts
@@ -9,6 +9,17 @@ const log = createChildLogger({ module: 'cloudflare-tunnel' })
 
 const SIGKILL_TIMEOUT_MS = 5_000
 
+/**
+ * Tunnel provider using Cloudflare quick tunnels (no account required).
+ *
+ * Runs `cloudflared tunnel --url http://localhost:<port>` and extracts the
+ * randomly assigned `*.trycloudflare.com` URL from stderr. The binary is
+ * located from PATH first, then from `binDir` (installed by post-upgrade step),
+ * and finally auto-downloaded as a last resort.
+ *
+ * Quick tunnels are rate-limited and assign a new random URL on each start.
+ * Prefer OpenACPTunnelProvider for a stable URL.
+ */
 export class CloudflareTunnelProvider implements TunnelProvider {
   private child: ChildProcess | null = null
   private publicUrl = ''

--- a/src/plugins/tunnel/providers/install-cloudflared.ts
+++ b/src/plugins/tunnel/providers/install-cloudflared.ts
@@ -1,5 +1,9 @@
 import { ensureBinary, type BinarySpec } from '../../../core/utils/install-binary.js'
 
+// cloudflared is not available on all systems via a package manager, and
+// users of the OpenACP managed tunnel provider don't need to install it themselves.
+// We download the official prebuilt binary from GitHub Releases on first use
+// and cache it in the plugin's bin directory.
 export const CLOUDFLARED_SPEC: BinarySpec = {
   name: 'cloudflared',
   githubBaseUrl: 'https://github.com/cloudflare/cloudflared/releases/latest/download',
@@ -19,6 +23,10 @@ export const CLOUDFLARED_SPEC: BinarySpec = {
   isArchive: (url) => url.endsWith('.tgz'),
 }
 
+/**
+ * Ensure the cloudflared binary is available, downloading it if needed.
+ * Returns the path to the binary.
+ */
 export async function ensureCloudflared(): Promise<string> {
   return ensureBinary(CLOUDFLARED_SPEC)
 }

--- a/src/plugins/tunnel/providers/ngrok.ts
+++ b/src/plugins/tunnel/providers/ngrok.ts
@@ -6,6 +6,14 @@ const log = createChildLogger({ module: 'ngrok-tunnel' })
 
 const SIGKILL_TIMEOUT_MS = 5_000
 
+/**
+ * Tunnel provider using ngrok (https://ngrok.com).
+ *
+ * Requires ngrok to be installed and an auth token configured via `options.authtoken`.
+ * Auth token is passed via the `NGROK_AUTHTOKEN` environment variable (not CLI args)
+ * to avoid leaking it in `ps aux` output. Supports v2 (*.ngrok.io) and v3
+ * (*.ngrok-free.app, *.ngrok.app) URL formats.
+ */
 export class NgrokTunnelProvider implements TunnelProvider {
   private child: ChildProcess | null = null
   private publicUrl = ''

--- a/src/plugins/tunnel/providers/openacp.ts
+++ b/src/plugins/tunnel/providers/openacp.ts
@@ -11,12 +11,15 @@ const log = createChildLogger({ module: 'openacp-tunnel' })
 export const DEFAULT_WORKER_URL = 'https://tunnel-worker.openacp.ai'
 export const DEFAULT_API_KEY = 'saG87sc26gZKbA24tQm0tqsJ0jo3z'
 
+// Periodically ping the worker to keep the tunnel registration alive.
+// Workers may expire idle tunnels, so we heartbeat every 10 minutes.
 const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000
 // 15s instead of the spec's suggested 10s: cloudflared can take a few seconds to
 // connect on slower machines or cold starts. If it hasn't crashed by 15s we assume
 // the tunnel is up — the public URL is already known from the worker response anyway.
 const STARTUP_TIMEOUT_MS = 15_000
 const SIGKILL_TIMEOUT_MS = 5_000
+// Plugin storage key for persisted tunnel state (tunnelId + token + publicUrl)
 const STORAGE_KEY = 'openacp-tunnels'
 
 interface TunnelState {
@@ -27,6 +30,19 @@ interface TunnelState {
 
 type TunnelStateMap = Record<string, TunnelState>
 
+/**
+ * OpenACP managed tunnel provider.
+ *
+ * Flow:
+ * 1. Request a tunnel from the OpenACP worker (POST /tunnel/create) — gets back a
+ *    Cloudflare tunnel token and a stable public URL.
+ * 2. Spawn cloudflared with that token to connect the tunnel.
+ * 3. Run a heartbeat to keep the tunnel registration alive on the worker.
+ * 4. On stop, DELETE the tunnel from the worker (unless preserveState=true for restart).
+ *
+ * Tunnel state (id + token + URL) is persisted in plugin storage so restarts can
+ * reuse existing tunnels instead of creating new ones (stable URL survives restarts).
+ */
 export class OpenACPTunnelProvider implements TunnelProvider {
   private child: ChildProcess | null = null
   private publicUrl = ''
@@ -53,10 +69,9 @@ export class OpenACPTunnelProvider implements TunnelProvider {
 
   start(localPort: number): Promise<string> {
     const promise = this._startAsync(localPort)
-    // Attach a no-op catch so Node.js does not flag this as an unhandled
-    // rejection if the process exits during fake-timer advancement in tests
-    // (before the caller's await/catch is reached). The original `promise`
-    // reference still rejects normally for the caller.
+    // Attach a no-op catch so Node.js does not flag this as an unhandled rejection
+    // if the process exits during fake-timer advancement in tests before the
+    // caller's await/catch is reached. The original `promise` still rejects normally.
     promise.catch(() => {})
     return promise
   }
@@ -117,6 +132,8 @@ export class OpenACPTunnelProvider implements TunnelProvider {
     return this.publicUrl
   }
 
+  // Try to reuse a persisted tunnel (stable URL across restarts).
+  // If the saved tunnel is no longer alive on the worker, create a fresh one.
   private async resolveCredentials(
     saved: TunnelState | undefined,
     all: TunnelStateMap,

--- a/src/plugins/tunnel/providers/tailscale.ts
+++ b/src/plugins/tunnel/providers/tailscale.ts
@@ -6,6 +6,15 @@ const log = createChildLogger({ module: 'tailscale-tunnel' })
 
 const SIGKILL_TIMEOUT_MS = 5_000
 
+/**
+ * Tunnel provider using Tailscale Funnel (https://tailscale.com/kb/1223/funnel).
+ *
+ * Requires tailscale to be installed and authenticated. Funnel exposes a local port
+ * via the device's Tailscale HTTPS URL (*.ts.net). The hostname is pre-resolved via
+ * `tailscale status --json` because the `funnel` command may exit immediately after
+ * configuring the route (rather than staying alive), in which case we construct the
+ * URL ourselves from the resolved hostname.
+ */
 export class TailscaleTunnelProvider implements TunnelProvider {
   private child: ChildProcess | null = null
   private publicUrl = ''
@@ -21,6 +30,8 @@ export class TailscaleTunnelProvider implements TunnelProvider {
   }
 
   async start(localPort: number): Promise<string> {
+    // Resolve hostname upfront so we can construct the URL if `funnel` exits
+    // immediately after configuring the route (before printing the URL).
     let hostname = ''
     try {
       const statusJson = execSync('tailscale status --json', { encoding: 'utf-8', timeout: 10_000 })

--- a/src/plugins/tunnel/templates/diff-viewer.ts
+++ b/src/plugins/tunnel/templates/diff-viewer.ts
@@ -23,6 +23,13 @@ function getMonacoLang(lang?: string): string {
   return MONACO_LANGUAGE[lang] || 'plaintext'
 }
 
+/**
+ * Render a Monaco diff editor HTML page for the given diff entry.
+ *
+ * Uses the `diff` library to count add/delete lines for the stats badge.
+ * Old and new content are JSON-serialised with `</script>` escaped before injection.
+ * Supports side-by-side and inline diff views, plus light/dark theme toggle.
+ */
 export function renderDiffViewer(entry: ViewerEntry): string {
   const fileName = entry.filePath || 'untitled'
   const lang = getMonacoLang(entry.language)
@@ -34,7 +41,7 @@ export function renderDiffViewer(entry: ViewerEntry): string {
   const adds = (patch.match(/^\+[^+]/gm) || []).length
   const dels = (patch.match(/^-[^-]/gm) || []).length
 
-  // Escape </script> in content
+  // Escape </script> in content to prevent premature tag closure
   const safeOld = JSON.stringify(oldContent).replace(/<\//g, '<\\/')
   const safeNew = JSON.stringify(newContent).replace(/<\//g, '<\\/')
 

--- a/src/plugins/tunnel/templates/file-viewer.ts
+++ b/src/plugins/tunnel/templates/file-viewer.ts
@@ -23,6 +23,14 @@ function getMonacoLang(lang?: string): string {
   return MONACO_LANGUAGE[lang] || 'plaintext'
 }
 
+/**
+ * Render a Monaco-based file viewer HTML page for the given entry.
+ *
+ * Content is JSON-serialised and injected as a JS variable. `</script>` sequences
+ * inside the content are escaped to prevent premature tag closure. The page
+ * supports light/dark themes, word wrap, minimap, and markdown preview.
+ * URL hash fragments (#L42 or #L42-L55) scroll the editor to the referenced line(s).
+ */
 export function renderFileViewer(entry: ViewerEntry): string {
   const fileName = entry.filePath || 'untitled'
   const lang = getMonacoLang(entry.language)

--- a/src/plugins/tunnel/templates/output-viewer.ts
+++ b/src/plugins/tunnel/templates/output-viewer.ts
@@ -1,5 +1,12 @@
 import type { ViewerEntry } from '../viewer-store.js'
 
+/**
+ * Render a simple line-numbered output viewer HTML page.
+ *
+ * Intentionally minimal (no Monaco) since command output is plain text and
+ * doesn't benefit from a full code editor. Line numbers are rendered server-side
+ * to avoid any JS dependency, making the page fast to load even for long outputs.
+ */
 export function renderOutputViewer(entry: ViewerEntry): string {
   const label = entry.filePath ?? 'Output'
   const lines = entry.content.split('\n')

--- a/src/plugins/tunnel/tunnel-registry.ts
+++ b/src/plugins/tunnel/tunnel-registry.ts
@@ -13,8 +13,14 @@ import { OpenACPTunnelProvider } from './providers/openacp.js'
 const log = createChildLogger({ module: 'tunnel-registry' })
 
 export const MAX_RETRIES = 5
+// Exponential backoff base: 2s, 4s, 8s, 16s, 32s
 const BASE_RETRY_DELAY_MS = 2_000
 
+/**
+ * Represents a single running (or recently failed) tunnel.
+ * `type: "system"` is the main OpenACP tunnel; `type: "user"` are agent-created tunnels.
+ * `status` transitions: starting → active | failed. Failed entries may auto-retry.
+ */
 export interface TunnelEntry {
   port: number
   type: 'system' | 'user'
@@ -43,6 +49,19 @@ interface LiveEntry {
   retryTimer: ReturnType<typeof setTimeout> | null
 }
 
+/**
+ * Manages the lifecycle of all active tunnel processes.
+ *
+ * Responsibilities:
+ * - Spawn/stop tunnel provider subprocesses via the TunnelProvider interface
+ * - Exponential backoff retry (up to MAX_RETRIES) on crash or start failure
+ * - Keepalive polling for the system tunnel to detect silent drops
+ * - Persist user tunnel state to `tunnels.json` so they survive restarts
+ * - Enforce the per-user tunnel limit
+ *
+ * System tunnels (one per instance, pointing to the API server) are managed
+ * separately from user tunnels (agent-created, per-session).
+ */
 export class TunnelRegistry {
   private entries: Map<number, LiveEntry> = new Map()
   private saveTimeout: ReturnType<typeof setTimeout> | null = null
@@ -63,6 +82,13 @@ export class TunnelRegistry {
     this.storage = opts.storage ?? null
   }
 
+  /**
+   * Spawn a new tunnel process for the given port and register it.
+   *
+   * Persists the entry to `tunnels.json` once the tunnel reaches `active` status.
+   * Throws if the port is already in use by an active or starting tunnel, or if the
+   * user tunnel limit is reached.
+   */
   async add(port: number, opts: {
     type: 'system' | 'user'
     provider: string
@@ -218,6 +244,12 @@ export class TunnelRegistry {
     }
   }
 
+  /**
+   * Stop a user tunnel by port and remove it from the registry.
+   *
+   * Cancels any pending retry timer and waits for an in-progress spawn to settle
+   * before terminating the process. Throws if the port is a system tunnel.
+   */
   async stop(port: number): Promise<void> {
     const live = this.entries.get(port)
     if (!live) return
@@ -255,6 +287,7 @@ export class TunnelRegistry {
     return stopped
   }
 
+  /** Stop all user tunnels. Errors from individual stops are silently ignored. */
   async stopAllUser(): Promise<void> {
     const userEntries = this.list(false)
     for (const entry of userEntries) {
@@ -288,6 +321,12 @@ export class TunnelRegistry {
     this.entries.clear()
   }
 
+  /**
+   * Return all current tunnel entries.
+   *
+   * Pass `includeSystem = true` to include the system tunnel in the result;
+   * by default only user tunnels are returned.
+   */
   list(includeSystem = false): TunnelEntry[] {
     const entries = Array.from(this.entries.values()).map(l => l.entry)
     if (includeSystem) return entries
@@ -302,6 +341,10 @@ export class TunnelRegistry {
     return this.list(false).filter(e => e.sessionId === sessionId)
   }
 
+  /**
+   * Return the system tunnel entry, or null if it hasn't been registered yet
+   * (e.g. `TunnelService.start()` hasn't been called, or the tunnel failed to start).
+   */
   getSystemEntry(): TunnelEntry | null {
     for (const live of this.entries.values()) {
       if (live.entry.type === 'system') return live.entry
@@ -309,6 +352,13 @@ export class TunnelRegistry {
     return null
   }
 
+  /**
+   * Re-launch tunnels persisted from a previous run.
+   *
+   * Only user tunnels are restored — the system tunnel is registered separately by
+   * `TunnelService.start()`. `sessionId` is intentionally dropped: sessions do not
+   * survive a restart, so restored tunnels are session-less until an agent claims them.
+   */
   async restore(): Promise<void> {
     if (!fs.existsSync(this.registryPath)) return
 
@@ -316,7 +366,8 @@ export class TunnelRegistry {
       const raw = JSON.parse(fs.readFileSync(this.registryPath, 'utf-8')) as PersistedEntry[]
       log.info({ count: raw.length }, 'Restoring tunnels')
 
-      // Only restore user tunnels — system tunnel is registered separately by TunnelService.start()
+      // Only restore user tunnels — system tunnel is registered separately by TunnelService.start().
+      // sessionId is intentionally omitted on restore: sessions don't survive a restart.
       const userEntries = raw.filter(e => e.type === 'user')
       const results = await Promise.allSettled(
         userEntries.map(persisted =>
@@ -324,7 +375,6 @@ export class TunnelRegistry {
             type: persisted.type,
             provider: persisted.provider,
             label: persisted.label,
-            // sessionId intentionally omitted — sessions don't survive restart
           })
         )
       )
@@ -366,6 +416,8 @@ export class TunnelRegistry {
     }
   }
 
+  // Debounce disk writes — multiple tunnel state changes may occur in rapid succession
+  // (e.g. status update + URL assignment). Coalesce them into a single write after 2s.
   private scheduleSave(): void {
     if (this.saveTimeout) clearTimeout(this.saveTimeout)
     this.saveTimeout = setTimeout(() => this.save(), 2000)

--- a/src/plugins/tunnel/tunnel-service.ts
+++ b/src/plugins/tunnel/tunnel-service.ts
@@ -1,4 +1,10 @@
 // TunnelConfig was removed from config.ts (migrated to plugin settings)
+
+/**
+ * Tunnel plugin settings shape.
+ * `port` is deprecated — the tunnel now always points to the API server port.
+ * `auth` is deprecated — viewer routes are public; authentication was removed.
+ */
 export interface TunnelConfig {
   enabled: boolean
   port: number
@@ -15,6 +21,14 @@ import type { PluginStorage } from '../../core/plugin/types.js'
 
 const log = createChildLogger({ module: 'tunnel' })
 
+/**
+ * High-level facade over TunnelRegistry and ViewerStore.
+ *
+ * Owns the system tunnel (started in `start()` once the API server port is known),
+ * user tunnel management (add/stop/list), and viewer URL generation.
+ * Registered as the `"tunnel"` service so other plugins can call `fileUrl()`,
+ * `diffUrl()`, etc. to share content via the public tunnel URL.
+ */
 export class TunnelService {
   private registry: TunnelRegistry
   private store: ViewerStore

--- a/src/plugins/tunnel/viewer-routes.ts
+++ b/src/plugins/tunnel/viewer-routes.ts
@@ -11,6 +11,16 @@ const NOT_FOUND_HTML = `<!DOCTYPE html>
 .box{text-align:center;padding:40px}.code{font-size:72px;font-weight:bold;color:#484f58}p{margin-top:16px;color:#8b949e}</style>
 </head><body><div class="box"><div class="code">404</div><p>This viewer link has expired or does not exist.</p></div></body></html>`
 
+/**
+ * Register viewer routes on the API server (Fastify plugin).
+ *
+ * These routes serve Monaco-based HTML viewer pages for files, diffs, and command output.
+ * Agents produce a short entry id via ViewerStore, then pass the public URL to the user
+ * so they can view the content in a browser without needing local access.
+ *
+ * Routes are registered without auth (viewer links are public but ephemeral — they
+ * expire after the configured TTL and the id is unguessable).
+ */
 export function createViewerRoutes(store: ViewerStore): FastifyPluginAsync {
   return async (app) => {
     app.get<{ Params: { id: string } }>('/view/:id', async (request, reply) => {

--- a/src/plugins/tunnel/viewer-store.ts
+++ b/src/plugins/tunnel/viewer-store.ts
@@ -5,6 +5,7 @@ import { createChildLogger } from '../../core/utils/log.js'
 
 const log = createChildLogger({ module: 'viewer-store' })
 
+// Hard limit per entry to avoid serving multi-MB payloads over the tunnel.
 const MAX_CONTENT_SIZE = 1_000_000  // 1MB
 
 const EXTENSION_LANGUAGE: Record<string, string> = {
@@ -18,6 +19,12 @@ const EXTENSION_LANGUAGE: Record<string, string> = {
   '.tf': 'hcl', '.vue': 'xml', '.svelte': 'xml',
 }
 
+/**
+ * Metadata for a single viewer entry.
+ * For `type: "diff"`, `content` holds the new text and `oldContent` holds the original.
+ * For `type: "output"`, `filePath` is used as the display label (not a real file path).
+ * Entries expire after the configured TTL and are cleaned up lazily on read and periodically.
+ */
 export interface ViewerEntry {
   id: string
   type: 'file' | 'diff' | 'output'
@@ -31,6 +38,13 @@ export interface ViewerEntry {
   expiresAt: number
 }
 
+/**
+ * In-memory store for content shared via tunnel viewer routes.
+ *
+ * Agents call `storeFile()` / `storeDiff()` / `storeOutput()` to get a short URL id,
+ * then pass that URL to the user. The viewer routes serve HTML pages using the stored content.
+ * Content is scoped to the session's working directory to avoid leaking files outside the workspace.
+ */
 export class ViewerStore {
   private entries = new Map<string, ViewerEntry>()
   private cleanupTimer: ReturnType<typeof setInterval>
@@ -38,6 +52,7 @@ export class ViewerStore {
 
   constructor(ttlMinutes: number = 60) {
     this.ttlMs = ttlMinutes * 60 * 1000
+    // Periodic cleanup prevents unbounded memory growth for long-running instances
     this.cleanupTimer = setInterval(() => this.cleanup(), 5 * 60 * 1000)
   }
 
@@ -143,6 +158,9 @@ export class ViewerStore {
     }
   }
 
+  // Guard against agents trying to serve files outside the session workspace
+  // (e.g. /etc/passwd or ~/ paths). Uses realpath to handle symlinks and canonicalize
+  // case on macOS/Windows where the filesystem is case-insensitive.
   private isPathAllowed(filePath: string, workingDirectory: string): boolean {
     const caseInsensitive = process.platform === 'darwin' || process.platform === 'win32'
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,2 +1,26 @@
-// Testing utilities for OpenACP plugin and adapter authors
+// Testing utilities for OpenACP plugin and adapter authors.
+//
+// These helpers exist so plugin authors can validate their adapters against
+// the IChannelAdapter contract without wiring up a real messaging platform.
+// Import from `@openacp/cli/testing` in your plugin test files.
+
+/**
+ * Runs the standard IChannelAdapter conformance test suite against a given adapter factory.
+ *
+ * Verifies that the adapter correctly implements all required interface methods
+ * (name, capabilities, sendMessage, etc.) and behaves within the expected contract.
+ * Use this in your adapter's test file to catch regressions and ensure compatibility
+ * with the OpenACP core routing layer.
+ *
+ * @param createAdapter - Factory function that returns a fresh adapter instance for each test.
+ * @param cleanup - Optional teardown callback run after each test (e.g., stop the adapter).
+ *
+ * @example
+ * ```ts
+ * import { runAdapterConformanceTests } from '@openacp/cli/testing'
+ * import { MyAdapter } from './my-adapter.js'
+ *
+ * runAdapterConformanceTests(() => new MyAdapter(mockConfig))
+ * ```
+ */
 export { runAdapterConformanceTests } from './core/adapter-primitives/__tests__/adapter-conformance.js'


### PR DESCRIPTION
## Summary

- Add JSDoc comments to all public functions, classes, and types across the entire codebase
- Add inline comments explaining non-obvious logic, business rules, and complex flows
- Covers core modules (config, agents, sessions, plugin, adapter-primitives, utils), all plugins (telegram, api-server, tunnel, context, security, etc.), CLI, and entry points

## Scope

Follows the comment conventions defined in CLAUDE.md:
- JSDoc for all public APIs
- Inline comments for non-obvious logic only (no narration of self-evident code)
- Block comments for complex flows

## Test plan

- [ ] `pnpm build` passes — no type errors introduced
- [ ] Comments do not change runtime behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)