### PR TITLE
feat(api): add client compatibility requirements to health endpoint

### DIFF
--- a/src/plugins/api-server/compatibility.ts
+++ b/src/plugins/api-server/compatibility.ts
@@ -1,0 +1,38 @@
+/**
+ * Client compatibility requirements.
+ *
+ * The server declares the minimum and recommended versions of the OpenACP App
+ * (desktop client) that are compatible with this server release. The values are
+ * returned in the public health endpoint so the App can enforce version checks
+ * on connect — similar to Docker's API version negotiation and Kubernetes'
+ * version skew policy.
+ *
+ * - `minVersion`         — Hard block. The App MUST be at least this version to
+ *                          use the server. Bump this when you ship a breaking API
+ *                          change (removed endpoint, changed response shape, etc.).
+ *
+ * - `recommendedVersion` — Soft warning. The App SHOULD be at least this version
+ *                          for the best experience. Bump this when you ship an
+ *                          important new feature that the App needs to surface.
+ *
+ * Both follow the project's date-based version format: YYYY.MDD.N
+ */
+
+export interface ClientCompatibility {
+  /** Minimum App version required (hard block below this). */
+  minVersion: string
+  /** Recommended App version (soft warning below this). */
+  recommendedVersion: string
+}
+
+/**
+ * Current client compatibility requirements for this server version.
+ *
+ * Update these values when shipping changes that affect the App:
+ * - Breaking API changes → bump `minVersion`
+ * - New features the App should adopt → bump `recommendedVersion`
+ */
+export const CLIENT_COMPATIBILITY: ClientCompatibility = {
+  minVersion: '0.0.0',
+  recommendedVersion: '0.0.0',
+}

--- a/src/plugins/api-server/index.ts
+++ b/src/plugins/api-server/index.ts
@@ -10,6 +10,7 @@ import type { CommandRegistry } from '../../core/command-registry.js'
 import type { ContextManager } from '../context/context-manager.js'
 import type { ApiServerInstance } from './server.js'
 import type { RouteDeps } from './routes/types.js'
+import { CLIENT_COMPATIBILITY } from './compatibility.js'
 import { createChildLogger } from '../../core/utils/log.js'
 
 const log = createChildLogger({ module: 'api-server' })
@@ -278,6 +279,7 @@ function createApiServerPlugin(): OpenACPPlugin {
         authPreHandler: routeAuthPreHandler,
         contextManager,
         lifecycleManager: core.lifecycleManager,
+        getClientCompatibility: () => CLIENT_COMPATIBILITY,
       }
 
       // Register all route plugins under /api/v1/

--- a/src/plugins/api-server/routes/health.ts
+++ b/src/plugins/api-server/routes/health.ts
@@ -20,12 +20,14 @@ export async function systemRoutes(
   // or session counts would aid reconnaissance.
   // instanceId is included so callers (e.g. `instances list`) can verify this response
   // belongs to the expected instance and not an unrelated process on the same port.
+  // clientCompatibility is included so the App can enforce version checks on connect.
   app.get('/health', async () => {
     return {
       status: 'ok',
       instanceId: deps.instanceId,
       uptime: Date.now() - deps.startedAt,
       version: deps.getVersion(),
+      clientCompatibility: deps.getClientCompatibility(),
     };
   });
 

--- a/src/plugins/api-server/routes/types.ts
+++ b/src/plugins/api-server/routes/types.ts
@@ -4,6 +4,7 @@ import type { TopicManager } from '../../telegram/topic-manager.js';
 import type { CommandRegistry } from '../../../core/command-registry.js';
 import type { ContextManager } from '../../context/context-manager.js';
 import type { LifecycleManager } from '../../../core/plugin/lifecycle-manager.js';
+import type { ClientCompatibility } from '../compatibility.js';
 
 /**
  * Dependencies injected into Fastify route plugins.
@@ -23,4 +24,6 @@ export interface RouteDeps {
   contextManager?: ContextManager;
   /** LifecycleManager for plugin state queries and hot-load operations. */
   lifecycleManager?: LifecycleManager;
+  /** Returns client compatibility requirements for the health endpoint. */
+  getClientCompatibility: () => ClientCompatibility;
 }


### PR DESCRIPTION
## Summary
- Add `clientCompatibility` field to the public `GET /system/health` endpoint
- Server declares `minVersion` (hard block) and `recommendedVersion` (soft warning) for the desktop App
- New `compatibility.ts` module with constants — bump values when shipping breaking API changes
- Pattern follows Docker API version negotiation + Kubernetes version skew policy

## Changes
- **New:** `src/plugins/api-server/compatibility.ts` — `ClientCompatibility` interface + constants
- **Modified:** `routes/health.ts` — health response includes `clientCompatibility`
- **Modified:** `routes/types.ts` — `RouteDeps` gains `getClientCompatibility()`
- **Modified:** `index.ts` — wires compatibility constants into route deps

## Health response
```json
{
  "status": "ok",
  "instanceId": "main",
  "uptime": 12345,
  "version": "2026.411.1",
  "clientCompatibility": {
    "minVersion": "0.0.0",
    "recommendedVersion": "0.0.0"
  }
}
```

## Test plan
- [ ] `npm run build` passes
- [ ] Start server, `curl /api/v1/health` returns `clientCompatibility` field
- [ ] Old App clients ignore the new field (backward compatible)