### PR TITLE
fix(permissions): implement Always Allow approval persistence per session

### DIFF
--- a/src/core/agents/agent-instance.ts
+++ b/src/core/agents/agent-instance.ts
@@ -780,6 +780,7 @@ export class AgentInstance extends TypedEmitter<AgentInstanceEvents> {
             id: opt.optionId,
             label: opt.name,
             isAllow: opt.kind === "allow_once" || opt.kind === "allow_always",
+            kind: opt.kind as 'allow_once' | 'allow_always' | 'deny',
           })),
         };
 

--- a/src/core/sessions/session-bridge.ts
+++ b/src/core/sessions/session-bridge.ts
@@ -468,6 +468,17 @@ export class SessionBridge {
     // Wait for user response — adapter resolves this promise
     const optionId = await promise;
 
+    // If user chose "Always Allow", remember it for future requests in this session
+    const chosenOption = permReq.options.find((o) => o.id === optionId);
+    if (chosenOption?.kind === 'allow_always') {
+      const approvalKey = permReq.toolName ?? permReq.description;
+      this.session.approvedAlways.add(approvalKey);
+      log.info(
+        { sessionId: this.session.id, approvalKey, optionId },
+        "Stored always-allow approval for future requests",
+      );
+    }
+
     // Broadcast permission:resolved so other adapters can dismiss their UI
     this.deps.eventBus?.emit(BusEvent.PERMISSION_RESOLVED, {
       sessionId: this.session.id,
@@ -481,7 +492,7 @@ export class SessionBridge {
     return optionId;
   }
 
-  /** Check if a permission request should be auto-approved (bypass mode only) */
+  /** Check if a permission request should be auto-approved (bypass mode or "always allow") */
   private checkAutoApprove(request: PermissionRequest): string | null {
     // Bypass mode: auto-approve all permissions (agent-side or client-side)
     const modeOption = this.session.getConfigByCategory("mode");
@@ -495,6 +506,19 @@ export class SessionBridge {
         log.info(
           { sessionId: this.session.id, requestId: request.id, optionId: allowOption.id, agentBypass: !!isAgentBypass, clientBypass: !!isClientBypass },
           "Bypass mode: auto-approving permission",
+        );
+        return allowOption.id;
+      }
+    }
+
+    // "Always Allow" — user previously approved this permission description with allow_always
+    const approvalKey = request.toolName ?? request.description;
+    if (this.session.approvedAlways.has(approvalKey)) {
+      const allowOption = request.options.find((o) => o.kind === 'allow_always') ?? request.options.find((o) => o.isAllow);
+      if (allowOption) {
+        log.info(
+          { sessionId: this.session.id, requestId: request.id, optionId: allowOption.id },
+          "Always-allow: auto-approving previously approved permission",
         );
         return allowOption.id;
       }

--- a/src/core/sessions/session.ts
+++ b/src/core/sessions/session.ts
@@ -112,6 +112,11 @@ export class Session extends TypedEmitter<SessionEvents> {
   activeTurnContext: TurnContext | null = null;
 
   readonly permissionGate = new PermissionGate();
+  /**
+   * Tool names/IDs that the user has approved with "Always Allow" during this session.
+   * Checked in SessionBridge.checkAutoApprove() to skip re-prompting.
+   */
+  readonly approvedAlways = new Set<string>();
   private readonly queue: PromptQueue;
   private speechService?: SpeechService;
   private pendingContext: string | null = null;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -95,6 +95,8 @@ export interface PermissionRequest {
   id: string;
   description: string;
   options: PermissionOption[];
+  /** The tool name this permission is for (used for "always allow" matching across invocations). */
+  toolName?: string;
 }
 
 /** A single choice within a permission request (e.g., "Allow once", "Deny"). */
@@ -103,6 +105,8 @@ export interface PermissionOption {
   label: string;
   /** Whether this option grants the requested permission. */
   isAllow: boolean;
+  /** The kind of approval: "allow_once", "allow_always", or "deny". */
+  kind?: 'allow_once' | 'allow_always' | 'deny';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix "Always Allow" option not being remembered — users were re-prompted for every tool invocation
- Preserve `kind` field (allow_once/allow_always/deny) from agent SDK through the full permission pipeline
- Cache "always allow" decisions per session in `Session.approvedAlways` Set
- Auto-approve cached permissions in `SessionBridge.checkAutoApprove()` before prompting user

## Root cause
`AgentInstance.requestPermission()` discarded the `kind` field when converting SDK options to `PermissionRequest`. No approval cache existed anywhere in the pipeline, so every permission request was treated as new.

## Changes
- `src/core/types.ts` — add `kind` to `PermissionOption`, `toolName` to `PermissionRequest`
- `src/core/agents/agent-instance.ts` — preserve `kind` field from SDK
- `src/core/sessions/session.ts` — add `approvedAlways` Set
- `src/core/sessions/session-bridge.ts` — check cache before prompting, store on allow_always

## Test plan
- [ ] Create session, trigger permission (e.g. edit file), select "Always Allow"
- [ ] Trigger same operation again — should auto-approve without prompting
- [ ] Create new session — should prompt again (cache is per-session)
- [ ] "Allow Once" still prompts on next invocation
- [ ] Bypass mode still works as before