### PR TITLE
feat: interrupt system — abortCurrent() + per-turn stopReason tracking

### DIFF
--- a/src/core/sessions/prompt-queue.ts
+++ b/src/core/sessions/prompt-queue.ts
@@ -72,14 +72,22 @@ export class PromptQueue {
   }
 
   /**
+   * Abort only the in-flight prompt, keeping queued prompts intact.
+   * The queue will automatically drain to the next item via `drainNext()`
+   * in the `process()` finally block.
+   */
+  abortCurrent(): void {
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+  }
+
+  /**
    * Abort the in-flight prompt and discard all queued prompts.
    * Pending promises are resolved (not rejected) so callers don't see unhandled rejections.
    */
   clear(): void {
-    // Abort the currently running prompt so the queue can drain
-    if (this.abortController) {
-      this.abortController.abort()
-    }
+    this.abortCurrent()
     // Resolve pending promises so callers don't hang
     for (const item of this.queue) {
       item.resolve()

--- a/src/core/sessions/session.ts
+++ b/src/core/sessions/session.ts
@@ -115,6 +115,8 @@ export class Session extends TypedEmitter<SessionEvents> {
   private readonly queue: PromptQueue;
   private speechService?: SpeechService;
   private pendingContext: string | null = null;
+  /** Set by abortPrompt(), read by processPrompt() to override stopReason */
+  private _promptAborted = false;
 
   constructor(opts: {
     id?: string;
@@ -381,6 +383,7 @@ export class Session extends TypedEmitter<SessionEvents> {
       }, async (p) => p).catch(() => {});
     }
 
+    this._promptAborted = false;
     let stopReason: string = 'end_turn';
     let promptError: unknown;
     try {
@@ -409,10 +412,11 @@ export class Session extends TypedEmitter<SessionEvents> {
       this.off(SessionEv.AGENT_EVENT, turnTextListener);
 
       const finalTurnId = this.activeTurnContext?.turnId ?? turnId ?? '';
+      const finalStopReason = this._promptAborted ? 'interrupted' : stopReason;
 
       // Hook: turn:end — always fires, even on error
       if (this.middlewareChain) {
-        this.middlewareChain.execute(Hook.TURN_END, { sessionId: this.id, stopReason: stopReason as import('../types.js').StopReason, durationMs: Date.now() - promptStart, turnId: finalTurnId, meta }, async (p) => p).catch(() => {});
+        this.middlewareChain.execute(Hook.TURN_END, { sessionId: this.id, stopReason: finalStopReason as import('../types.js').StopReason, durationMs: Date.now() - promptStart, turnId: finalTurnId, meta }, async (p) => p).catch(() => {});
       }
 
       // Hook: agent:afterTurn — full assembled text, read-only, fire-and-forget
@@ -421,7 +425,7 @@ export class Session extends TypedEmitter<SessionEvents> {
           sessionId: this.id,
           turnId: finalTurnId,
           fullText: turnTextBuffer.join(''),
-          stopReason: stopReason as import('../types.js').StopReason,
+          stopReason: finalStopReason as import('../types.js').StopReason,
           meta,
         }, async (p) => p).catch(() => {});
       }
@@ -695,15 +699,16 @@ export class Session extends TypedEmitter<SessionEvents> {
     return this.agentCapabilities?.sessionCapabilities?.[cap] === true;
   }
 
-  /** Cancel the current prompt and clear the queue. Stays in active state. */
+  /** Cancel the current prompt. Queued prompts continue processing. Stays in active state. */
   async abortPrompt(): Promise<void> {
     // Hook: agent:beforeCancel — modifiable, can block
     if (this.middlewareChain) {
       const result = await this.middlewareChain.execute(Hook.AGENT_BEFORE_CANCEL, { sessionId: this.id }, async (p) => p);
       if (!result) return; // blocked by middleware
     }
-    this.queue.clear();
-    this.log.info("Prompt aborted");
+    this._promptAborted = true;
+    this.queue.abortCurrent();
+    this.log.info("Prompt aborted (queue preserved, %d pending)", this.queue.pending);
     await this.agentInstance.cancel();
   }
 

--- a/src/core/sessions/session.ts
+++ b/src/core/sessions/session.ts
@@ -115,8 +115,8 @@ export class Session extends TypedEmitter<SessionEvents> {
   private readonly queue: PromptQueue;
   private speechService?: SpeechService;
   private pendingContext: string | null = null;
-  /** Set by abortPrompt(), read by processPrompt() to override stopReason */
-  private _promptAborted = false;
+  /** Per-turn abort tracking — avoids race when next turn resets before current turn reads */
+  private _abortedTurnIds = new Set<string>();
 
   constructor(opts: {
     id?: string;
@@ -383,7 +383,6 @@ export class Session extends TypedEmitter<SessionEvents> {
       }, async (p) => p).catch(() => {});
     }
 
-    this._promptAborted = false;
     let stopReason: string = 'end_turn';
     let promptError: unknown;
     try {
@@ -412,7 +411,9 @@ export class Session extends TypedEmitter<SessionEvents> {
       this.off(SessionEv.AGENT_EVENT, turnTextListener);
 
       const finalTurnId = this.activeTurnContext?.turnId ?? turnId ?? '';
-      const finalStopReason = this._promptAborted ? 'interrupted' : stopReason;
+      const wasAborted = this._abortedTurnIds.has(finalTurnId);
+      if (wasAborted) this._abortedTurnIds.delete(finalTurnId);
+      const finalStopReason = wasAborted ? 'interrupted' : stopReason;
 
       // Hook: turn:end — always fires, even on error
       if (this.middlewareChain) {
@@ -706,7 +707,8 @@ export class Session extends TypedEmitter<SessionEvents> {
       const result = await this.middlewareChain.execute(Hook.AGENT_BEFORE_CANCEL, { sessionId: this.id }, async (p) => p);
       if (!result) return; // blocked by middleware
     }
-    this._promptAborted = true;
+    const turnId = this.activeTurnContext?.turnId;
+    if (turnId) this._abortedTurnIds.add(turnId);
     this.queue.abortCurrent();
     this.log.info("Prompt aborted (queue preserved, %d pending)", this.queue.pending);
     await this.agentInstance.cancel();


### PR DESCRIPTION
## Summary

- **PromptQueue.abortCurrent()**: Aborts only the active prompt, keeps queued items intact. Queue drains to next item automatically via `drainNext()` in the `process()` finally block.
- **Session.abortPrompt()**: Uses `abortCurrent()` instead of `clear()` — interrupted turn stops, queued messages continue processing.
- **Per-turn abort tracking**: `_abortedTurnIds` Set replaces `_promptAborted` boolean — avoids race condition when queue drains next item before current turn's finally block reads the flag.
- **stopReason: "interrupted"**: Aborted turns are recorded in history with `stopReason: "interrupted"`, enabling app-side persistence of interrupted state across session switches.

## Test plan

- [ ] Send multiple messages → interrupt current → queued messages still process
- [ ] Interrupt mid-stream → server history records `stopReason: "interrupted"` on the turn
- [ ] Rapid abort + queue drain → no race condition, correct stopReason per turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)