### PR TITLE
feat: support session rename via PATCH endpoint

### DIFF
--- a/src/core/sessions/session-bridge.ts
+++ b/src/core/sessions/session-bridge.ts
@@ -181,10 +181,8 @@ export class SessionBridge {
       }
     });
 
-    // Wire lifecycle: persist and relay name changes — only rename thread once per session.
+    // Wire lifecycle: persist and relay name changes to all adapters.
     this.listen(this.session, SessionEv.NAMED, async (name: string) => {
-      const record = this.deps.sessionManager.getSessionRecord(this.session.id);
-      const alreadyNamed = !!record?.name;
       await this.deps.sessionManager.patchRecord(this.session.id, { name });
       if (!this.session.isAssistant) {
         this.deps.eventBus?.emit(BusEvent.SESSION_UPDATED, {
@@ -192,9 +190,7 @@ export class SessionBridge {
           name,
         });
       }
-      if (!alreadyNamed) {
-        await this.adapter.renameSessionThread(this.session.id, name);
-      }
+      await this.adapter.renameSessionThread(this.session.id, name);
     });
 
     // Wire lifecycle: persist prompt count after each prompt for resume decisions

--- a/src/plugins/api-server/routes/sessions.ts
+++ b/src/plugins/api-server/routes/sessions.ts
@@ -360,6 +360,11 @@ export async function sessionRoutes(
       const body = UpdateSessionBodySchema.parse(request.body);
       const changes: Record<string, unknown> = {};
 
+      if (body.name !== undefined) {
+        session.setName(body.name);
+        changes.name = body.name;
+      }
+
       if (body.agentName !== undefined) {
         if (session.promptRunning) {
           await session.abortPrompt();

--- a/src/plugins/api-server/schemas/sessions.ts
+++ b/src/plugins/api-server/schemas/sessions.ts
@@ -68,6 +68,7 @@ export const DangerousModeBodySchema = z.object({
 });
 
 export const UpdateSessionBodySchema = z.object({
+  name: z.string().min(1).max(200).optional(),
   agentName: z.string().min(1).max(200).optional(),
   voiceMode: z.enum(['off', 'next', 'on']).optional(),
   dangerousMode: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Add `name` field to `UpdateSessionBodySchema` so PATCH `/sessions/:id` accepts `{ name }`
- PATCH handler calls `session.setName()` which emits `SessionEv.NAMED`
- SessionBridge catches NAMED → persists via `patchRecord` + broadcasts `BusEvent.SESSION_UPDATED` + calls `adapter.renameSessionThread()`
- Remove `!alreadyNamed` guard so user-initiated renames always propagate to all adapters (Telegram topic rename, Discord thread rename, SSE broadcast)

## Test plan
- [ ] PATCH `/api/v1/sessions/:id` with `{ name: "new name" }` → verify session record updated
- [ ] Verify `session:updated` SSE event emitted with new name
- [ ] Verify Telegram/Discord adapters receive `renameSessionThread` call
- [ ] Verify auto-naming from first response still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)