### PR TITLE
fix(session): handle late cancel when agent completes before abort

### DIFF
--- a/src/core/sessions/__tests__/session-lifecycle.test.ts
+++ b/src/core/sessions/__tests__/session-lifecycle.test.ts
@@ -145,14 +145,15 @@ describe('Session - Lifecycle & Prompt Processing', () => {
   })
 
   describe('abortPrompt()', () => {
-    it('clears queue and cancels agent', async () => {
+    it('is a no-op when no turn is in-flight', async () => {
       const agent = mockAgentInstance()
       const session = createTestSession(agent)
       session.activate()
 
       await session.abortPrompt()
 
-      expect(agent.cancel).toHaveBeenCalled()
+      // No active turn context → agent.cancel should NOT be called
+      expect(agent.cancel).not.toHaveBeenCalled()
     })
   })
 

--- a/src/core/sessions/session.ts
+++ b/src/core/sessions/session.ts
@@ -119,6 +119,8 @@ export class Session extends TypedEmitter<SessionEvents> {
   private pendingContext: string | null = null;
   /** Per-turn abort tracking — avoids race when next turn resets before current turn reads */
   private _abortedTurnIds = new Set<string>();
+  /** Last completed turnId — used by abortPrompt() to retroactively mark a just-finished turn as interrupted */
+  private _lastCompletedTurnId: string | null = null;
 
   constructor(opts: {
     id?: string;
@@ -436,6 +438,8 @@ export class Session extends TypedEmitter<SessionEvents> {
         }, async (p) => p).catch(() => {});
       }
 
+      // Track the completed turnId so late abortPrompt() calls can retroactively mark it
+      this._lastCompletedTurnId = finalTurnId || null;
       // Always clear turn context so routing state is never stale after a failed turn
       this.activeTurnContext = null;
     }
@@ -714,17 +718,35 @@ export class Session extends TypedEmitter<SessionEvents> {
       if (!result) return; // blocked by middleware
     }
     const turnId = this.activeTurnContext?.turnId;
-    if (turnId) this._abortedTurnIds.add(turnId);
 
-    // Cancel agent FIRST so the orphaned processPrompt resolves before
-    // drainNext starts the next item. Timeout prevents hanging if agent
-    // is unresponsive — queue abort proceeds regardless after 5 seconds.
-    await Promise.race([
-      this.agentInstance.cancel().catch(() => {}),
-      new Promise<void>((r) => setTimeout(r, 5000)),
-    ]);
+    if (turnId) {
+      // Turn is still in-flight — mark for interrupted stopReason in the finally block
+      this._abortedTurnIds.add(turnId);
 
-    this.queue.abortCurrent();
+      // Cancel agent FIRST so the orphaned processPrompt resolves before
+      // drainNext starts the next item. Timeout prevents hanging if agent
+      // is unresponsive — queue abort proceeds regardless after 5 seconds.
+      await Promise.race([
+        this.agentInstance.cancel().catch(() => {}),
+        new Promise<void>((r) => setTimeout(r, 5000)),
+      ]);
+
+      this.queue.abortCurrent();
+    } else if (this._lastCompletedTurnId && !this.queue.isProcessing) {
+      // Turn already completed before cancel arrived — retroactively update
+      // the history record so the client sees stopReason: "interrupted" on reload.
+      const retroTurnId = this._lastCompletedTurnId;
+      this._lastCompletedTurnId = null;
+      if (this.middlewareChain) {
+        await this.middlewareChain.execute(Hook.TURN_END, {
+          sessionId: this.id,
+          stopReason: 'interrupted' as import('../types.js').StopReason,
+          durationMs: 0,
+          turnId: retroTurnId,
+        }, async (p) => p).catch(() => {});
+      }
+    }
+
     this.log.info("Prompt aborted (queue preserved, %d pending)", this.queue.pending);
   }
 

--- a/src/plugins/context/history/history-recorder.ts
+++ b/src/plugins/context/history/history-recorder.ts
@@ -294,10 +294,22 @@ export class HistoryRecorder {
 
   async onTurnEnd(sessionId: string, stopReason: string): Promise<void> {
     const state = this.states.get(sessionId);
-    if (!state || !state.currentAssistantTurn) return;
+    if (!state) return;
     this.cancelDebounce(sessionId);
-    state.currentAssistantTurn.stopReason = stopReason;
-    state.currentAssistantTurn = null;
+    if (state.currentAssistantTurn) {
+      // Turn still in-progress — finalize it
+      state.currentAssistantTurn.stopReason = stopReason;
+      state.currentAssistantTurn = null;
+    } else if (stopReason === 'interrupted' && state.history.turns.length > 0) {
+      // Retroactive interrupt: turn already completed but cancel arrived late.
+      // Update the last assistant turn's stopReason so clients see "interrupted" on reload.
+      const lastTurn = state.history.turns[state.history.turns.length - 1];
+      if (lastTurn.role === 'assistant') {
+        lastTurn.stopReason = 'interrupted';
+      }
+    } else {
+      return; // nothing to update
+    }
     await this.store.write(state.history);
   }
 


### PR DESCRIPTION
## Summary
- Track `_lastCompletedTurnId` so `abortPrompt()` can retroactively mark a just-finished turn as `interrupted` when the cancel arrives after the agent has already completed
- Only call `agent.cancel()` when a turn is actually in-flight (skip no-op cancels)
- Update `history-recorder.onTurnEnd` to handle retroactive interrupt: updates last assistant turn's `stopReason` when no active turn exists

## Context
When the agent responds faster than the cancel request arrives, `activeTurnContext` is already null by the time `abortPrompt()` runs. Previously this meant the turn was recorded as `end_turn` instead of `interrupted`, causing the client to show the full message without the interrupted indicator on session reload.

## Test plan
- [ ] Interrupt a fast-responding agent → verify history shows `stopReason: "interrupted"`
- [ ] Call `abortPrompt()` with no active turn → verify no-op (no agent.cancel called)
- [ ] Run existing session lifecycle and history recorder tests